### PR TITLE
Optimize NCCL throttling and document deadlock prevention mechanism

### DIFF
--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -1,14 +1,61 @@
 # Multi-GPU Training
 
-Surogate provides robust support for multi-GPU training, enabling efficient utilization of multiple GPUs to accelerate model training and handle larger models and datasets. The framework leverages data parallelism and model parallelism techniques to distribute the workload across available GPUs.
+Surogate provides robust support for multi-GPU training, enabling efficient utilization of multiple GPUs to accelerate model training and handle larger models and datasets. The framework leverages data parallelism techniques with optimized communication patterns to distribute the workload across available GPUs.
 
-## Data Parallelism
+## Multi-Threading vs Multiprocessing
 
-In data parallelism, Surogate replicates the model on each GPU and splits the input data across the GPUs. Each GPU processes its portion of the data independently, computes gradients, and then synchronizes the gradients across all GPUs to update the model parameters. This approach is particularly effective for large datasets where the same model can be applied to different data samples in parallel.
+Within a single node, there are two main approaches for handling multi-GPU support:
 
-## Model Parallelism
+1. **One process per GPU (multiprocessing)**: This approach can help avoid Python's Global Interpreter Lock (GIL) and scales beyond a single node, making it suitable for distributed training across multiple machines.
 
-For very large models that cannot fit into a single GPU's memory, Surogate supports model parallelism. In this approach, different parts of the model are distributed across multiple GPUs. During training, data flows through the model segments on different GPUs, allowing the training of models that exceed the memory capacity of a single GPU.
+2. **Multiple threads in a single process (multi-threading)**: This is Surogate's primary focus. Multi-threading exploits the shared address space, allowing direct GPU-to-GPU memory copies without resorting to IPC handles, which provides better performance for single-node multi-GPU training.
+
+While Surogate supports both options, the framework is optimized for the multi-threaded setup and its direct communication capabilities.
+
+## Data Parallelism with ZeRO-1
+
+When running on multiple GPUs, Surogate always shards optimizer states (ZeRO-1) by default. This approach is strictly better than traditional Distributed Data Parallel (DDP) with replicated optimizer states, as it leads to reduced memory consumption without increasing the amount of communication.
+
+In this setup, the model is replicated on each GPU and input data is split across the GPUs. Each GPU processes its portion of the data independently, computes gradients, and then synchronizes the gradients across all GPUs to update the model parameters.
+
+## Kernel Fusion and Communication Optimization
+
+To minimize memory bandwidth and improve performance, Surogate employs aggressive kernel fusion strategies:
+
+### Fused Operations
+
+To avoid unnecessary round trips to device memory, Surogate fuses all successive operations that are not either a global reduction or involve a matrix multiplication. Key fusion strategies include:
+
+- **Non-linearity operators**: All non-linearity operators have an additional output parameter that returns the abs-max of their result, enabling efficient FP8 quantization without extra memory reads.
+- **RMS-norm and residual addition**: These operations are handled in a joint kernel, which also returns the abs-max of the RMS-norm output.
+- **Transpose and quantize**: Since FP8 GEMM on consumer GPUs only supports the TN (transpose:non-transpose) layout, Surogate uses a fused transpose+quantize kernel to handle the required transposes manually.
+- **Cross-entropy loss**: The forward and backward passes of the cross-entropy loss are fused into a single kernel, avoiding the need to materialize a large per-token loss tensor.
+
+These optimizations significantly reduce memory traffic and improve training throughput, especially when using FP8 precision.
+
+## LM-Head and Embeddings: Replication Strategy
+
+Due to the large vocabulary dimension in language models, both compute and communication costs for the LM-head (language modeling head) significantly exceed those of a regular transformer block. Surogate employs a specialized strategy to handle this imbalance:
+
+### Replication Instead of Sharding
+
+Rather than sharding the LM-head and token embeddings across workers, Surogate **replicates** them on each GPU. This design choice offers several advantages:
+
+- **Reduced synchronization frequency**: Gradients for the LM-head only need to be synchronized at the last gradient accumulation step, rather than at every step.
+- **Better communication overlap**: The LM-head is placed in a separate buffer from the double-buffered transformer blocks, enabling gradient communication to overlap with computation during the backward pass.
+
+### Communication Overlap Strategies
+
+During the last backward pass:
+
+1. **LM-head gradient communication** can be overlapped with computing the gradients for the last two transformer blocks, whose weights are still available locally from the preceding forward pass.
+2. **Backward matrix scheduling**: The two backward matrices of the LM-head gradient are scheduled such that the weight gradient calculation is handled first, allowing communication to overlap with the input gradient calculation.
+
+However, the effectiveness of this optimization diminishes with increased gradient accumulation chunking, as gradient communication can only commence in the last chunk.
+
+### Token Embeddings Limitation
+
+For token embeddings, the next required operation after the backward pass is the global norm reduction of the gradients. Unfortunately, there is no computation available to overlap with this communication, so this latency cannot be hidden.
 
 ## Configuration Parameters
 


### PR DESCRIPTION
- Skip launch queue throttling for transactions without NCCL collectives
  (Send/Recv point-to-point operations don't need synchronization barriers)
- Document the root cause of multi-threaded NCCL deadlocks: per-process
  CUDA launch queue exhaustion when fast GPUs race ahead of slow ones
- Explain the CPU-side barrier solution and why MPI mode doesn't need it