### PR TITLE
fix(framework): GDR autotuned-grid corruption + 4 training fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ define build_wheel
 	cp pyproject.toml pyproject.toml.bak && \
 	trap 'mv -f pyproject.toml.bak pyproject.toml' EXIT INT TERM; \
 	uv run --no-project --with tomlkit python3 .github/scripts/set_cuda_version_tag.py $(1) && \
-	CMAKE_ARGS="$(CCACHE_FLAGS) --parallel $(PARALLEL_JOBS)" uv build --wheel --out-dir dist && \
+	CMAKE_ARGS="$(CCACHE_FLAGS)" CMAKE_BUILD_PARALLEL_LEVEL=$(PARALLEL_JOBS) uv build --wheel --out-dir dist && \
 	uv run --no-project --with auditwheel --with patchelf auditwheel repair dist/*.whl \
 		-w dist/repaired/ \
 		--exclude libcuda.so.1 \

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -702,6 +702,7 @@ if (BUILD_TESTS OR BUILD_TESTS_INTEGRATION)
     add_executable(integration-tests
         src/testing/utilities/test_main.cpp
         src/testing/distributed/test-nccl.cpp
+        src/testing/tokenizer/test-chat-template.cpp
     )
     target_link_libraries(integration-tests PRIVATE
         surogate-common Catch2::Catch2 CLI11::CLI11 fmt::fmt-header-only

--- a/csrc/src/kernels/fill.cu
+++ b/csrc/src/kernels/fill.cu
@@ -11,10 +11,15 @@
  */
 
 #include <cassert>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include "utilities/tensor.h"
 #include "utilities/utils.h"
 #include "utilities/vec.cuh"
 
@@ -149,4 +154,57 @@ void zero_device_segments(const std::uint64_t* ptrs, const std::uint64_t* sizes,
     // One block per segment; segments are large enough that per-block looping is fine.
     zero_segments_kernel<<<n, 256, 0, stream>>>(ptrs, sizes, n);
     CUDA_CHECK(cudaGetLastError());
+}
+
+namespace {
+
+template <typename T>
+__global__ void zero_matrix_columns_kernel(T* data, long rows, long cols, long col_start, long col_end) {
+    const long width = col_end - col_start;
+    const long total = rows * width;
+    for (long id = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x; id < total;
+         id += static_cast<long>(blockDim.x) * gridDim.x) {
+        const long row = id / width;
+        const long col = col_start + (id - row * width);
+        data[row * cols + col] = T{};
+    }
+}
+
+template <typename T>
+void zero_matrix_columns_impl(T* data, long rows, long cols, long col_start, long col_end, cudaStream_t stream) {
+    const long width = col_end - col_start;
+    if (rows <= 0 || width <= 0) return;
+    constexpr int block = 256;
+    const long total = rows * width;
+    const int grid = static_cast<int>(
+        std::min<long>(div_ceil(static_cast<std::size_t>(total), static_cast<std::size_t>(block)), 65535));
+    zero_matrix_columns_kernel<<<grid, block, 0, stream>>>(data, rows, cols, col_start, col_end);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+}  // namespace
+
+void zero_matrix_columns(Tensor& dest, long col_start, long col_end, cudaStream_t stream) {
+    if (!dest.Data) return;
+    if (dest.Rank != 2) {
+        throw std::invalid_argument("zero_matrix_columns: expected rank-2 tensor");
+    }
+    const long rows = dest.Sizes[0];
+    const long cols = dest.Sizes[1];
+    if (col_start < 0 || col_end < col_start || col_end > cols) {
+        throw std::invalid_argument("zero_matrix_columns: invalid column range");
+    }
+    if (col_start == col_end || rows <= 0) {
+        return;
+    }
+
+    if (dest.DType == ETensorDType::FP32) {
+        zero_matrix_columns_impl(dest.get<float>(), rows, cols, col_start, col_end, stream);
+    } else if (dest.DType == ETensorDType::BF16) {
+        zero_matrix_columns_impl(dest.get<nv_bfloat16>(), rows, cols, col_start, col_end, stream);
+    } else if (dest.DType == ETensorDType::FP16) {
+        zero_matrix_columns_impl(dest.get<half>(), rows, cols, col_start, col_end, stream);
+    } else {
+        throw std::invalid_argument("zero_matrix_columns: unsupported tensor dtype");
+    }
 }

--- a/csrc/src/kernels/kernels.h
+++ b/csrc/src/kernels/kernels.h
@@ -2110,6 +2110,7 @@ void fill_dense_cu_seqlens(int32_t* cu_seqlens, int num_docs, int max_doc_seqlen
 // Efficiently zero multiple non-contiguous device buffers in a single kernel launch.
 // `ptrs[i]` is a device pointer (encoded as uint64_t) and `sizes[i]` is the size in bytes.
 void zero_device_segments(const std::uint64_t* ptrs, const std::uint64_t* sizes, int n, cudaStream_t stream);
+void zero_matrix_columns(Tensor& dest, long col_start, long col_end, cudaStream_t stream);
 
 void convert_dtype(float* target, const nv_bfloat16* source, std::size_t size);
 void convert_dtype(nv_bfloat16* target, const float* source, std::size_t size);

--- a/csrc/src/runtime/jit/gated_delta_rule_kernels.h
+++ b/csrc/src/runtime/jit/gated_delta_rule_kernels.h
@@ -99,6 +99,36 @@ public:
     /// Backward through WY representation. Grid: (NT, B*H).
     void bwd_wy(dim3 grid, void** args, int num_args, cudaStream_t stream) const;
 
+    // ======================================================================
+    // Autotuned tile sizes (from the loaded manifests' compile-time constants).
+    //
+    // Grid math MUST use these instead of re-deriving tile sizes: the autotuner
+    // legally picks different tilings per (H,K,V) — e.g. fwd_o chose BV=64 at
+    // H=16 but BV=32 at H=32 — and a mismatched hardcoded grid under-launches,
+    // silently leaving part of the output buffer uninitialized (garbage model).
+    // The fallback is only used for legacy manifests without "constants".
+    // ======================================================================
+
+    /// fwd_h V-tile: grid_x = cdiv(V, fwd_h_bv(fallback)).
+    [[nodiscard]] int fwd_h_bv(int fallback) const {
+        return fwd_h_ ? fwd_h_->meta().const_int("BV", fallback) : fallback;
+    }
+
+    /// fwd_o V-tile: grid_x = cdiv(V, fwd_o_bv(fallback)).
+    [[nodiscard]] int fwd_o_bv(int fallback) const {
+        return fwd_o_ ? fwd_o_->meta().const_int("BV", fallback) : fallback;
+    }
+
+    /// bwd_dhu V-tile: grid_x = cdiv(V, bwd_dhu_bv(fallback)).
+    [[nodiscard]] int bwd_dhu_bv(int fallback) const {
+        return bwd_dhu_ ? bwd_dhu_->meta().const_int("BV", fallback) : fallback;
+    }
+
+    /// bwd_dqkwg K-tile: NK = cdiv(K, bwd_dqkwg_bk(fallback)) (also sizes dg_nk).
+    [[nodiscard]] int bwd_dqkwg_bk(int fallback) const {
+        return bwd_dqkwg_ ? bwd_dqkwg_->meta().const_int("BK", fallback) : fallback;
+    }
+
 private:
     /// Load a single kernel from manifests, if present.
     void load_kernel(const std::unordered_map<std::string, std::string>& manifests,

--- a/csrc/src/runtime/jit/jit_kernel.cpp
+++ b/csrc/src/runtime/jit/jit_kernel.cpp
@@ -152,6 +152,16 @@ JitKernel JitKernel::load_manifest(const std::string& manifest_path) {
     meta.shared_mem_bytes = j.value("shared_mem", 0);
     meta.extra_null_params = j.value("extra_null_params", 0);
 
+    // Integer compile-time constants (autotuned tile sizes etc.). Launch sites use
+    // these for grid math; non-integer entries (e.g. DOT_PRECISION, EPS) are skipped.
+    if (auto it = j.find("constants"); it != j.end() && it->is_object()) {
+        for (const auto& [key, val] : it->items()) {
+            if (val.is_number_integer()) {
+                meta.constants[key] = val.get<int>();
+            }
+        }
+    }
+
     // Resolve cubin/ptx path relative to the manifest directory
     auto dir = std::filesystem::path(manifest_path).parent_path();
 

--- a/csrc/src/runtime/jit/jit_kernel.h
+++ b/csrc/src/runtime/jit/jit_kernel.h
@@ -9,6 +9,7 @@
 #define SUROGATE_SRC_RUNTIME_JIT_JIT_KERNEL_H
 
 #include <string>
+#include <unordered_map>
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -22,6 +23,19 @@ struct JitKernelMeta {
     /// Number of extra null-pointer parameters the compiler appends after user params.
     /// Triton 3.x adds 2 (global_scratch, profile_scratch); plain CUDA kernels use 0.
     int extra_null_params = 0;
+
+    /// Integer compile-time constants baked into the cubin (parsed from the manifest's
+    /// "constants" object, e.g. autotuned tile sizes BV/BK). Launch-site grid math MUST
+    /// use these — the autotuner may legally pick a different tiling per dims (e.g.
+    /// H=32 picks fwd_o BV=32 where H=16 picked BV=64), and a hardcoded grid then
+    /// under-launches, silently leaving part of the output uninitialized.
+    std::unordered_map<std::string, int> constants;
+
+    /// Constant lookup with fallback for manifests that predate constants parsing.
+    [[nodiscard]] int const_int(const std::string& key, int fallback) const {
+        auto it = constants.find(key);
+        return it == constants.end() ? fallback : it->second;
+    }
 };
 
 /// RAII wrapper around a CUDA module + function loaded from an external cubin/PTX.

--- a/csrc/src/runtime/ops/gated_delta_rule.cpp
+++ b/csrc/src/runtime/ops/gated_delta_rule.cpp
@@ -149,11 +149,7 @@ void CompiledExecutor::dispatch_gated_delta_rule_common(const CompiledOp& op, co
         }
     }
     if (!out_is_ref) {
-        out_val = make_persistent_tensor(mRunState,
-                                         mSavedCache,
-                                         op.op_id + ".out_fallback",
-                                         v.DType,
-                                         {B, T, H, V});
+        out_val = make_persistent_tensor(mRunState, mSavedCache, op.op_id + ".out_fallback", v.DType, {B, T, H, V});
     }
 
     Tensor state_val;
@@ -182,10 +178,13 @@ void CompiledExecutor::dispatch_gated_delta_rule_common(const CompiledOp& op, co
 
     const int BT = 64;
     const int NT = cdiv(static_cast<int>(T), BT);
-    const int BK_kkt = std::min(std::max(next_power_of_2(static_cast<int>(K)), 16), 64);
-    const int BV_h = (K > 64) ? 32 : std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64);
-    const int BK_o = std::min(std::max(next_power_of_2(static_cast<int>(K)), 16), 64);
-    const int BV_o = std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64);
+    // V-tile sizes for grid math come from the loaded manifests: the autotuner picks
+    // them per (H,K,V) (e.g. fwd_o BV=64 at H=16 but BV=32 at H=32), so re-deriving
+    // them here under-launches and leaves output columns uninitialized. The second
+    // argument is only a fallback for legacy manifests without recorded constants.
+    const int BV_h =
+        mGdrKernels.fwd_h_bv((K > 64) ? 32 : std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64));
+    const int BV_o = mGdrKernels.fwd_o_bv(std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64));
     const int BH = static_cast<int>(B * H);
     cudaStream_t stream = mRunState.MainStream;
 
@@ -448,9 +447,12 @@ void CompiledExecutor::dispatch_chunk_gated_delta_rule_backward(const CompiledOp
 
     const int BT = 64;
     const int NT = cdiv(static_cast<int>(T), BT);
-    const int BV_h = (K > 64) ? 32 : std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64);
-    const int BK_bwd = std::min(std::max(next_power_of_2(static_cast<int>(K)), 16), 64);
-    const int BV_bwd = std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64);
+    // Tile sizes for grid math come from the loaded manifests (autotuned per H,K,V);
+    // the formulas are only fallbacks for legacy manifests. See the forward dispatch.
+    const int bv_default = std::min(std::max(next_power_of_2(static_cast<int>(V)), 16), 64);
+    const int BV_h = mGdrKernels.fwd_h_bv((K > 64) ? 32 : bv_default);
+    const int BV_dhu = mGdrKernels.bwd_dhu_bv((K > 64) ? 32 : bv_default);
+    const int BK_bwd = mGdrKernels.bwd_dqkwg_bk(std::min(std::max(next_power_of_2(static_cast<int>(K)), 16), 64));
     const int NK = cdiv(static_cast<int>(K), BK_bwd);
     const int BH = static_cast<int>(B * H);
     cudaStream_t stream = mRunState.MainStream;
@@ -638,7 +640,7 @@ void CompiledExecutor::dispatch_chunk_gated_delta_rule_backward(const CompiledOp
         float sv = scale;
         int32_t Tv = static_cast<int32_t>(T);
         void* args[] = {&q_eff, &k_eff, &wp, &gp, &dhtp, &dh0p, &dop, &dhp, &dvp, &dv2p, &sv, &Tv};
-        mGdrKernels.bwd_dhu({static_cast<unsigned>(cdiv(static_cast<int>(V), BV_h)), static_cast<unsigned>(BH), 1},
+        mGdrKernels.bwd_dhu({static_cast<unsigned>(cdiv(static_cast<int>(V), BV_dhu)), static_cast<unsigned>(BH), 1},
                             args,
                             12,
                             stream);
@@ -887,7 +889,9 @@ long cgr_backward_stack_bound(const CompiledOp& op, const BufferPlan& plan) {
     bytes += align_stack_bytes(B * T * H * K * BF16);       // dw
     bytes += align_stack_bytes(B * T * H * FP32);           // dg_wy
     bytes += align_stack_bytes(B * T * H * FP32);           // dg_out
-    const long NK = std::max(1L, K / chunk_size);
+    // NK depends on the autotuned bwd_dqkwg BK (not known at planning time);
+    // bound with the smallest tile the autotuner may pick (BK=32 -> NK=cdiv(K,32)).
+    const long NK = std::max(1L, (K + 31) / 32);
     bytes += align_stack_bytes(NK * B * T * H * FP32);  // dg_nk
     return bytes;
 }

--- a/csrc/src/runtime/optimizers/adamw_8bit_optimizer.cpp
+++ b/csrc/src/runtime/optimizers/adamw_8bit_optimizer.cpp
@@ -27,6 +27,7 @@
 #include "runtime/executor/graph_executor_utils.h"
 #include "runtime/optimizers/cpu_adamw.h"
 #include "runtime/optimizers/flash_adamw_8bit.h"
+#include "runtime/optimizers/gradient_mask.h"
 #include "utilities/comm.h"
 #include "utilities/tensor.h"
 #include "utilities/tensor_container.h"
@@ -221,6 +222,9 @@ void AdamW8BitOptimizer::step(dsl::DslModel& model,
 
     // CPU-RAM centric streaming path
     if (model.mGrads->is_streaming_grads()) {
+        if (gradient_mask::enabled()) {
+            throw std::runtime_error("AdamW8BitOptimizer::step: gradient masks are not supported with streaming grads");
+        }
         step_cpu_streaming(model,
                            comm,
                            config.learning_rate,
@@ -255,6 +259,48 @@ void AdamW8BitOptimizer::step(dsl::DslModel& model,
             model.mGrads->clear_reduce_pending();
         } else {
             model.mGrads->reduce_all(comm, stream);
+        }
+    }
+
+    const bool grad_mask_enabled = gradient_mask::enabled();
+    std::unordered_map<void*, bool> trainable_grad_ptrs;
+    if (grad_mask_enabled) {
+        for (const auto& name : model.mGrads->param_names()) {
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+            auto [it, inserted] =
+                trainable_grad_ptrs.emplace(static_cast<void*>(grad->Data), gradient_mask::whole_param_trainable(name));
+            if (!inserted) {
+                it->second = it->second || gradient_mask::whole_param_trainable(name);
+            }
+        }
+
+        std::unordered_set<void*> seen_mask_ptrs;
+        for (const auto& name : model.mGrads->param_names()) {
+            Tensor& val = use_weight_manager ? model.mWeightManager->get_master(name) : model.mParams->get(name);
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+
+            const bool param_sharded = param_is_sharded(name);
+            Tensor grad_view =
+                param_sharded ? static_cast<Tensor>(shard_view(*grad, model.mShardIdx, model.mNumShards)) : *grad;
+            if (param_sharded && grad_view.nelem() != val.nelem()) {
+                throw std::runtime_error("AdamW8BitOptimizer::step: sharded grad size mismatch for " + name);
+            }
+
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            const bool trainable = (it != trainable_grad_ptrs.end()) && it->second;
+            if (!trainable) {
+                if (seen_mask_ptrs.insert(static_cast<void*>(grad->Data)).second) {
+                    fill_zero(grad_view, stream);
+                }
+                continue;
+            }
+            gradient_mask::apply_partial_mask(name, grad_view, stream);
         }
     }
 
@@ -297,13 +343,20 @@ void AdamW8BitOptimizer::step(dsl::DslModel& model,
             throw std::runtime_error("AdamW8BitOptimizer::step: sharded grad size mismatch for " + name);
         }
 
-        float wd = config.weight_decay;
+        float wd = gradient_mask::weight_decay_for(name, config.weight_decay);
 
         state_offset = (state_offset + GROUP_SIZE - 1) / GROUP_SIZE * GROUP_SIZE;
         const size_t n = val.nelem();
         if (!val.Data || !grad_view.Data) {
             state_offset += n;
             continue;
+        }
+        if (grad_mask_enabled) {
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            if (it != trainable_grad_ptrs.end() && !it->second) {
+                state_offset += n;
+                continue;
+            }
         }
         const size_t group_offset = state_offset / GROUP_SIZE;
 
@@ -428,6 +481,48 @@ void AdamW8BitOptimizer::step_graph(dsl::DslModel& model,
         }
     }
 
+    const bool grad_mask_enabled = gradient_mask::enabled();
+    std::unordered_map<void*, bool> trainable_grad_ptrs;
+    if (grad_mask_enabled) {
+        for (const auto& name : model.mGrads->param_names()) {
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+            auto [it, inserted] =
+                trainable_grad_ptrs.emplace(static_cast<void*>(grad->Data), gradient_mask::whole_param_trainable(name));
+            if (!inserted) {
+                it->second = it->second || gradient_mask::whole_param_trainable(name);
+            }
+        }
+
+        std::unordered_set<void*> seen_mask_ptrs;
+        for (const auto& name : model.mGrads->param_names()) {
+            Tensor& val = use_weight_manager ? model.mWeightManager->get_master(name) : model.mParams->get(name);
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+
+            const bool param_sharded = param_is_sharded(name);
+            Tensor grad_view =
+                param_sharded ? static_cast<Tensor>(shard_view(*grad, model.mShardIdx, model.mNumShards)) : *grad;
+            if (param_sharded && grad_view.nelem() != val.nelem()) {
+                throw std::runtime_error("AdamW8BitOptimizer::step_graph: sharded grad size mismatch for " + name);
+            }
+
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            const bool trainable = (it != trainable_grad_ptrs.end()) && it->second;
+            if (!trainable) {
+                if (seen_mask_ptrs.insert(static_cast<void*>(grad->Data)).second) {
+                    fill_zero(grad_view, stream);
+                }
+                continue;
+            }
+            gradient_mask::apply_partial_mask(name, grad_view, stream);
+        }
+    }
+
     model.calculate_gradient_norm(comm, config.grad_clip, stream, grads_reduced || dispatch_local);
     const float* grad_scale = rs.scratch().norm_buffer.template get<float>() + 1;
 
@@ -464,13 +559,20 @@ void AdamW8BitOptimizer::step_graph(dsl::DslModel& model,
             throw std::runtime_error("AdamW8BitOptimizer::step_graph: sharded grad size mismatch for " + name);
         }
 
-        const float wd_scale = 1.f;
+        const float wd_scale = gradient_mask::weight_decay_for(name, 1.f);
 
         state_offset = (state_offset + GROUP_SIZE - 1) / GROUP_SIZE * GROUP_SIZE;
         const size_t n = val.nelem();
         if (!val.Data || !grad_view.Data) {
             state_offset += n;
             continue;
+        }
+        if (grad_mask_enabled) {
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            if (it != trainable_grad_ptrs.end() && !it->second) {
+                state_offset += n;
+                continue;
+            }
         }
         const size_t group_offset = state_offset / GROUP_SIZE;
 

--- a/csrc/src/runtime/optimizers/adamw_optimizer.cpp
+++ b/csrc/src/runtime/optimizers/adamw_optimizer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <cuda_bf16.h>
@@ -22,6 +23,7 @@
 #include "runtime/executor/graph_executor_utils.h"
 #include "runtime/optimizers/adamw.h"
 #include "runtime/optimizers/adamw_8bit.h"
+#include "runtime/optimizers/gradient_mask.h"
 #include "utilities/comm.h"
 #include "utilities/tensor.h"
 
@@ -150,6 +152,48 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
         }
     }
 
+    const bool grad_mask_enabled = gradient_mask::enabled();
+    std::unordered_map<void*, bool> trainable_grad_ptrs;
+    if (grad_mask_enabled) {
+        for (const auto& name : model.mGrads->param_names()) {
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+            auto [it, inserted] =
+                trainable_grad_ptrs.emplace(static_cast<void*>(grad->Data), gradient_mask::whole_param_trainable(name));
+            if (!inserted) {
+                it->second = it->second || gradient_mask::whole_param_trainable(name);
+            }
+        }
+
+        std::unordered_set<void*> seen_mask_ptrs;
+        for (const auto& name : model.mGrads->param_names()) {
+            Tensor& val = use_weight_manager ? model.mWeightManager->get_master(name) : model.mParams->get(name);
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+
+            const bool param_sharded = param_is_sharded(name);
+            Tensor grad_view =
+                param_sharded ? static_cast<Tensor>(shard_view(*grad, model.mShardIdx, model.mNumShards)) : *grad;
+            if (param_sharded && grad_view.nelem() != val.nelem()) {
+                throw std::runtime_error("AdamWOptimizer::step: sharded grad size mismatch for " + name);
+            }
+
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            const bool trainable = (it != trainable_grad_ptrs.end()) && it->second;
+            if (!trainable) {
+                if (seen_mask_ptrs.insert(static_cast<void*>(grad->Data)).second) {
+                    fill_zero(grad_view, stream);
+                }
+                continue;
+            }
+            gradient_mask::apply_partial_mask(name, grad_view, stream);
+        }
+    }
+
     model.calculate_gradient_norm(comm, config.grad_clip, stream, grads_reduced || dispatch_local);
     const float* grad_scale = rs.scratch().norm_buffer.template get<float>() + 1;
 
@@ -195,9 +239,17 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
             state_offset += n;
             continue;
         }
+        if (grad_mask_enabled) {
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            if (it != trainable_grad_ptrs.end() && !it->second) {
+                state_offset += n;
+                continue;
+            }
+        }
 
         float* m = state.state1.template get<float>() + state_offset;
         float* v = state.state2.template get<float>() + state_offset;
+        const float wd = gradient_mask::weight_decay_for(name, config.weight_decay);
 
         if (val.DType == ETensorDType::FP32) {
             if (grad_view.DType == ETensorDType::FP32) {
@@ -211,7 +263,7 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
                              config.adamw_beta2,
                              step_idx,
                              config.adamw_epsilon,
-                             config.weight_decay,
+                             wd,
                              grad_scale,
                              nullptr,
                              nullptr,
@@ -227,7 +279,7 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
                              config.adamw_beta2,
                              step_idx,
                              config.adamw_epsilon,
-                             config.weight_decay,
+                             wd,
                              grad_scale,
                              nullptr,
                              nullptr,
@@ -247,7 +299,7 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
                              config.adamw_beta2,
                              step_idx,
                              config.adamw_epsilon,
-                             config.weight_decay,
+                             wd,
                              grad_scale,
                              nullptr,
                              nullptr,
@@ -263,7 +315,7 @@ void AdamWOptimizer::step(dsl::DslModel& model, NCCLCommunicator& comm, const Op
                              config.adamw_beta2,
                              step_idx,
                              config.adamw_epsilon,
-                             config.weight_decay,
+                             wd,
                              grad_scale,
                              nullptr,
                              nullptr,
@@ -334,6 +386,48 @@ void AdamWOptimizer::step_graph(dsl::DslModel& model,
         }
     }
 
+    const bool grad_mask_enabled = gradient_mask::enabled();
+    std::unordered_map<void*, bool> trainable_grad_ptrs;
+    if (grad_mask_enabled) {
+        for (const auto& name : model.mGrads->param_names()) {
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+            auto [it, inserted] =
+                trainable_grad_ptrs.emplace(static_cast<void*>(grad->Data), gradient_mask::whole_param_trainable(name));
+            if (!inserted) {
+                it->second = it->second || gradient_mask::whole_param_trainable(name);
+            }
+        }
+
+        std::unordered_set<void*> seen_mask_ptrs;
+        for (const auto& name : model.mGrads->param_names()) {
+            Tensor& val = use_weight_manager ? model.mWeightManager->get_master(name) : model.mParams->get(name);
+            bool accumulate = false;
+            Tensor* grad = model.mGrads->get_param_grad(name, accumulate);
+            (void)accumulate;
+            if (!grad || !grad->Data) continue;
+
+            const bool param_sharded = param_is_sharded(name);
+            Tensor grad_view =
+                param_sharded ? static_cast<Tensor>(shard_view(*grad, model.mShardIdx, model.mNumShards)) : *grad;
+            if (param_sharded && grad_view.nelem() != val.nelem()) {
+                throw std::runtime_error("AdamWOptimizer::step_graph: sharded grad size mismatch for " + name);
+            }
+
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            const bool trainable = (it != trainable_grad_ptrs.end()) && it->second;
+            if (!trainable) {
+                if (seen_mask_ptrs.insert(static_cast<void*>(grad->Data)).second) {
+                    fill_zero(grad_view, stream);
+                }
+                continue;
+            }
+            gradient_mask::apply_partial_mask(name, grad_view, stream);
+        }
+    }
+
     model.calculate_gradient_norm(comm, config.grad_clip, stream, grads_reduced || dispatch_local);
     const float* grad_scale = rs.scratch().norm_buffer.template get<float>() + 1;
 
@@ -379,11 +473,18 @@ void AdamWOptimizer::step_graph(dsl::DslModel& model,
             state_offset += n;
             continue;
         }
+        if (grad_mask_enabled) {
+            auto it = trainable_grad_ptrs.find(static_cast<void*>(grad->Data));
+            if (it != trainable_grad_ptrs.end() && !it->second) {
+                state_offset += n;
+                continue;
+            }
+        }
 
         float* m = state.state1.template get<float>() + state_offset;
         float* v = state.state2.template get<float>() + state_offset;
 
-        const float wd_scale = 1.f;
+        const float wd_scale = gradient_mask::weight_decay_for(name, 1.f);
 
         if (val.DType == ETensorDType::FP32) {
             if (grad_view.DType == ETensorDType::FP32) {

--- a/csrc/src/runtime/optimizers/gradient_mask.h
+++ b/csrc/src/runtime/optimizers/gradient_mask.h
@@ -102,6 +102,10 @@ inline bool is_growth_mlp_up_or_gate(std::string_view name) {
             contains_ci(name, "mlp_up_weight") || contains_ci(name, "gate_weight") || contains_ci(name, "up_weight"));
 }
 
+inline bool is_fused_mlp_up_gate(std::string_view name) {
+    return contains_ci(name, "mlp_up_weight");
+}
+
 inline bool is_growth_mlp_down(std::string_view name) {
     return (contains_ci(name, "mlp") || contains_ci(name, "mixer")) &&
            (contains_ci(name, "down_proj") || contains_ci(name, "mlp_down_weight") || contains_ci(name, "down_weight"));
@@ -147,6 +151,18 @@ inline void apply_partial_mask(std::string_view name, Tensor& grad, cudaStream_t
         throw std::runtime_error("mlp_growth_new_half mask got empty gradient for " + std::string(name));
     }
     if (is_growth_mlp_up_or_gate(name)) {
+        if (is_fused_mlp_up_gate(name)) {
+            if ((rows % 4) != 0) {
+                throw std::runtime_error("mlp_growth_new_half expected fused 2M row count for " + std::string(name));
+            }
+            const long quarter_rows = rows / 4;
+            const long half_rows = rows / 2;
+            const std::size_t row_bytes = static_cast<std::size_t>(cols) * get_dtype_size(grad.DType);
+            CUDA_CHECK(cudaMemsetAsync(grad.Data, 0, static_cast<std::size_t>(quarter_rows) * row_bytes, stream));
+            char* second_old = reinterpret_cast<char*>(grad.Data) + static_cast<std::size_t>(half_rows) * row_bytes;
+            CUDA_CHECK(cudaMemsetAsync(second_old, 0, static_cast<std::size_t>(quarter_rows) * row_bytes, stream));
+            return;
+        }
         if ((rows % 2) != 0) {
             throw std::runtime_error("mlp_growth_new_half expected even row count for " + std::string(name));
         }

--- a/csrc/src/runtime/optimizers/gradient_mask.h
+++ b/csrc/src/runtime/optimizers/gradient_mask.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+//
+// Optional runtime gradient masks for deliberate non-LoRA partial-update runs.
+// Unset environment variables leave optimizer behavior unchanged.
+
+#ifndef SUROGATE_SRC_RUNTIME_OPTIMIZERS_GRADIENT_MASK_H
+#define SUROGATE_SRC_RUNTIME_OPTIMIZERS_GRADIENT_MASK_H
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "kernels/kernels.h"
+#include "utilities/tensor.h"
+
+namespace optimizers::gradient_mask {
+
+struct Spec {
+    bool enabled = false;
+    bool mlp_growth_new_half = false;
+    std::vector<std::string> trainable_substrings;
+};
+
+inline std::string lower(std::string_view value) {
+    std::string out(value);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return out;
+}
+
+inline bool contains_ci(std::string_view haystack, std::string_view needle) {
+    const std::string h = lower(haystack);
+    const std::string n = lower(needle);
+    return h.find(n) != std::string::npos;
+}
+
+inline std::vector<std::string> split_csv(const char* raw) {
+    std::vector<std::string> out;
+    if (!raw || raw[0] == '\0') {
+        return out;
+    }
+    std::stringstream ss(raw);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        item.erase(item.begin(),
+                   std::find_if(item.begin(), item.end(), [](unsigned char c) { return !std::isspace(c); }));
+        item.erase(std::find_if(item.rbegin(), item.rend(), [](unsigned char c) { return !std::isspace(c); }).base(),
+                   item.end());
+        if (!item.empty()) {
+            out.push_back(lower(item));
+        }
+    }
+    return out;
+}
+
+inline const Spec& spec() {
+    static const Spec parsed = [] {
+        Spec s;
+        if (const char* allow = std::getenv("SUROGATE_TRAINABLE_PARAM_SUBSTRINGS")) {
+            s.trainable_substrings = split_csv(allow);
+            s.enabled = !s.trainable_substrings.empty();
+        }
+
+        const char* raw_mode = std::getenv("SUROGATE_GRADIENT_MASK_MODE");
+        const std::string mode = raw_mode ? lower(raw_mode) : "";
+        if (mode.empty() || mode == "none" || mode == "off" || mode == "0") {
+            return s;
+        }
+        s.enabled = true;
+        if (mode == "allow_substrings") {
+            if (s.trainable_substrings.empty()) {
+                throw std::runtime_error("SUROGATE_GRADIENT_MASK_MODE=allow_substrings requires "
+                                         "SUROGATE_TRAINABLE_PARAM_SUBSTRINGS");
+            }
+            return s;
+        }
+        if (mode == "mlp_growth_new_half") {
+            s.mlp_growth_new_half = true;
+            return s;
+        }
+        throw std::runtime_error("Unknown SUROGATE_GRADIENT_MASK_MODE: " + mode);
+    }();
+    return parsed;
+}
+
+inline bool enabled() {
+    return spec().enabled;
+}
+
+inline bool is_growth_mlp_up_or_gate(std::string_view name) {
+    return (contains_ci(name, "mlp") || contains_ci(name, "mixer")) &&
+           (contains_ci(name, "gate_proj") || contains_ci(name, "up_proj") || contains_ci(name, "mlp_gate_weight") ||
+            contains_ci(name, "mlp_up_weight") || contains_ci(name, "gate_weight") || contains_ci(name, "up_weight"));
+}
+
+inline bool is_growth_mlp_down(std::string_view name) {
+    return (contains_ci(name, "mlp") || contains_ci(name, "mixer")) &&
+           (contains_ci(name, "down_proj") || contains_ci(name, "mlp_down_weight") || contains_ci(name, "down_weight"));
+}
+
+inline bool is_growth_mlp_param(std::string_view name) {
+    return is_growth_mlp_up_or_gate(name) || is_growth_mlp_down(name);
+}
+
+inline bool whole_param_trainable(std::string_view name) {
+    const Spec& s = spec();
+    if (!s.enabled) {
+        return true;
+    }
+
+    if (!s.trainable_substrings.empty()) {
+        for (const std::string& needle : s.trainable_substrings) {
+            if (contains_ci(name, needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (s.mlp_growth_new_half) {
+        return is_growth_mlp_param(name);
+    }
+
+    return true;
+}
+
+inline void apply_partial_mask(std::string_view name, Tensor& grad, cudaStream_t stream) {
+    const Spec& s = spec();
+    if (!s.mlp_growth_new_half || !is_growth_mlp_param(name)) {
+        return;
+    }
+    if (grad.Rank != 2) {
+        throw std::runtime_error("mlp_growth_new_half mask expected rank-2 gradient for " + std::string(name));
+    }
+    const long rows = grad.Sizes[0];
+    const long cols = grad.Sizes[1];
+    if (rows <= 0 || cols <= 0) {
+        throw std::runtime_error("mlp_growth_new_half mask got empty gradient for " + std::string(name));
+    }
+    if (is_growth_mlp_up_or_gate(name)) {
+        if ((rows % 2) != 0) {
+            throw std::runtime_error("mlp_growth_new_half expected even row count for " + std::string(name));
+        }
+        const std::size_t bytes =
+            static_cast<std::size_t>(rows / 2) * static_cast<std::size_t>(cols) * get_dtype_size(grad.DType);
+        CUDA_CHECK(cudaMemsetAsync(grad.Data, 0, bytes, stream));
+        return;
+    }
+    if (is_growth_mlp_down(name)) {
+        if ((cols % 2) != 0) {
+            throw std::runtime_error("mlp_growth_new_half expected even column count for " + std::string(name));
+        }
+        zero_matrix_columns(grad, 0, cols / 2, stream);
+    }
+}
+
+inline float weight_decay_for(std::string_view name, float configured_weight_decay) {
+    const Spec& s = spec();
+    if (s.mlp_growth_new_half && is_growth_mlp_param(name)) {
+        // Weight decay would modify the frozen inherited half of a partially
+        // masked tensor. Disable it for the whole tensor in this mode.
+        return 0.0f;
+    }
+    return configured_weight_decay;
+}
+
+}  // namespace optimizers::gradient_mask
+
+#endif  // SUROGATE_SRC_RUNTIME_OPTIMIZERS_GRADIENT_MASK_H

--- a/csrc/src/testing/tokenizer/test-chat-template.cpp
+++ b/csrc/src/testing/tokenizer/test-chat-template.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+//
+// Regression tests for encode_for_training() thinking / no-think mode handling.
+//
+// Bug (fixed): render_chat_template() never set `enable_thinking`, so the
+// generation-prompt render always emitted the no-think empty "<think>\n\n</think>\n\n"
+// block. For a THINKING assistant turn this misaligned the byte-diff that defines
+// the trainable span, producing a doubled </think>, corrupted reasoning, and a
+// target that taught the model to reason AFTER an already-closed think block
+// (i.e. to "think" in no-think mode). encode_for_training() now derives
+// enable_thinking from the assistant content (a "</think>" block => thinking turn)
+// and passes it to both renders consistently.
+//
+// Requires a real tokenizer dir with a Qwen3-style chat template; set
+// SUROGATE_TEST_MODEL=<dir>. Skips cleanly when unset.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "tokenizer/tokenizer.h"
+
+using tokenizer::ChatMessage;
+using tokenizer::LossStrategy;
+using tokenizer::Tokenizer;
+using tokenizer::TrainingEncoded;
+
+namespace {
+
+size_t count_substr(const std::string& s, const std::string& sub) {
+    size_t n = 0, pos = 0;
+    while ((pos = s.find(sub, pos)) != std::string::npos) {
+        ++n;
+        pos += sub.size();
+    }
+    return n;
+}
+
+std::string decode_full(const Tokenizer& tok, const TrainingEncoded& enc) {
+    return tok.decode(enc.input_ids);
+}
+
+std::string decode_trained(const Tokenizer& tok, const TrainingEncoded& enc) {
+    std::vector<int32_t> ids;
+    for (size_t i = 0; i < enc.input_ids.size(); ++i) {
+        if (enc.labels[i] != -100) ids.push_back(enc.input_ids[i]);
+    }
+    return tok.decode(ids);
+}
+
+}  // namespace
+
+TEST_CASE("encode_for_training separates thinking and no-think modes", "[tokenizer][chat-template]") {
+    const char* model_dir = std::getenv("SUROGATE_TEST_MODEL");
+    if (!model_dir) {
+        SUCCEED("SUROGATE_TEST_MODEL not set; skipping chat-template regression test");
+        return;
+    }
+    Tokenizer tok = Tokenizer::from_pretrained(model_dir);
+
+    SECTION("thinking turn: reasoning kept, single think block, trained after open <think>") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "<think>\nAdun doi si doi.\n</think>\n\nPatru."},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::DEFAULT);
+        std::string full = decode_full(tok, enc);
+        std::string trained = decode_trained(tok, enc);
+
+        // Exactly one think block — the bug produced an empty block + a second </think>.
+        REQUIRE(count_substr(full, "<think>") == 1);
+        REQUIRE(count_substr(full, "</think>") == 1);
+        // No empty (no-think) block should appear for a thinking turn.
+        REQUIRE(full.find("<think>\n\n</think>") == std::string::npos);
+        // Reasoning must be intact and trained (the bug sliced its first tokens off).
+        REQUIRE(full.find("Adun doi si doi.") != std::string::npos);
+        REQUIRE(trained.find("Adun doi si doi.") != std::string::npos);
+        REQUIRE(trained.find("Patru.") != std::string::npos);
+    }
+
+    SECTION("no-think turn: empty block, only the answer is trained") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "Patru."},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::DEFAULT);
+        std::string full = decode_full(tok, enc);
+        std::string trained = decode_trained(tok, enc);
+
+        REQUIRE(count_substr(full, "<think>") == 1);
+        REQUIRE(count_substr(full, "</think>") == 1);
+        // The empty no-think block must be present...
+        REQUIRE(full.find("<think>\n\n</think>") != std::string::npos);
+        // ...and the model must NOT be trained to emit any reasoning/think tokens.
+        REQUIRE(trained.find("<think>") == std::string::npos);
+        REQUIRE(trained.find("</think>") == std::string::npos);
+        REQUIRE(trained.find("Patru.") != std::string::npos);
+    }
+}
+
+TEST_CASE("apply_chat_template honors enable_thinking generation prompt", "[tokenizer][chat-template]") {
+    const char* model_dir = std::getenv("SUROGATE_TEST_MODEL");
+    if (!model_dir) {
+        SUCCEED("SUROGATE_TEST_MODEL not set; skipping chat-template regression test");
+        return;
+    }
+    Tokenizer tok = Tokenizer::from_pretrained(model_dir);
+    std::vector<ChatMessage> msgs = {{"user", "Salut"}};
+
+    // enable_thinking=true => open "<think>\n" prompt (no close); =false => empty block.
+    std::string thinking = tok.apply_chat_template(msgs, /*add_generation_prompt=*/true, /*enable_thinking=*/true);
+    std::string no_think = tok.apply_chat_template(msgs, /*add_generation_prompt=*/true, /*enable_thinking=*/false);
+
+    REQUIRE(count_substr(thinking, "</think>") == 0);
+    REQUIRE(count_substr(no_think, "</think>") == 1);
+}

--- a/csrc/src/tokenizer/tokenizer.cpp
+++ b/csrc/src/tokenizer/tokenizer.cpp
@@ -153,14 +153,23 @@ struct Tokenizer::Impl {
     }
 
     // Render the chat template with the given messages and options.
-    std::string render_chat_template(const nlohmann::ordered_json& messages, bool add_generation_prompt) const {
+    std::string render_chat_template(const nlohmann::ordered_json& messages,
+                                     bool add_generation_prompt,
+                                     std::optional<bool> enable_thinking = std::nullopt) const {
         if (!chat_tmpl_root) {
             throw std::runtime_error("No chat template loaded.");
         }
-        auto context = minja::Context::make(json({
+        auto ctx_json = json({
             {"messages", messages},
             {"add_generation_prompt", add_generation_prompt},
-        }));
+        });
+        // Only define enable_thinking when explicitly requested. The template
+        // gates on `enable_thinking is defined`, so leaving it unset preserves
+        // the template's own default behavior for non-training callers.
+        if (enable_thinking.has_value()) {
+            ctx_json["enable_thinking"] = *enable_thinking;
+        }
+        auto context = minja::Context::make(ctx_json);
         context->set("bos_token", bos_token_str);
         context->set("eos_token", eos_token_str);
 
@@ -771,14 +780,16 @@ std::string Tokenizer::special_token(const std::string& name) const {
     return "";
 }
 
-std::string Tokenizer::apply_chat_template(const std::vector<ChatMessage>& messages, bool add_generation_prompt) const {
+std::string Tokenizer::apply_chat_template(const std::vector<ChatMessage>& messages,
+                                           bool add_generation_prompt,
+                                           std::optional<bool> enable_thinking) const {
     // Convert ChatMessage to nlohmann::ordered_json array
     nlohmann::ordered_json json_messages = nlohmann::ordered_json::array();
     for (const auto& msg : messages) {
         json_messages.push_back({{"role", msg.role}, {"content", msg.content}});
     }
 
-    return impl_->render_chat_template(json_messages, add_generation_prompt);
+    return impl_->render_chat_template(json_messages, add_generation_prompt, enable_thinking);
 }
 
 std::vector<int32_t> Tokenizer::apply_chat_template_and_encode(const std::vector<ChatMessage>& messages,
@@ -832,9 +843,17 @@ TrainingEncoded Tokenizer::encode_for_training(const std::vector<ChatMessage>& m
         round_idx++;
         bool is_last_round = (round_idx == num_pairs);
 
+        // Pick the generation-prompt mode from the assistant content: a "</think>"
+        // block means this is a THINKING turn (open "<think>\n" prompt); otherwise a
+        // no-think turn (empty "<think>\n\n</think>\n\n" block). Both renders below
+        // MUST use the same mode, or the byte-diff that defines the trainable span
+        // misaligns — which previously trained the model to emit reasoning after an
+        // already-closed think block (i.e. to "think" in no-think mode).
+        std::optional<bool> enable_thinking = (messages[i + 1].content.find("</think>") != std::string::npos);
+
         // 1. Render up to user_i with gen_prompt=true → prefix/chrome segment
         std::vector<ChatMessage> up_to_user(messages.begin(), messages.begin() + i + 1);
-        std::string render_with_user = apply_chat_template(up_to_user, /*add_generation_prompt=*/true);
+        std::string render_with_user = apply_chat_template(up_to_user, /*add_generation_prompt=*/true, enable_thinking);
 
         if (render_with_user.size() > prev_render.size()) {
             std::string chrome = render_with_user.substr(prev_render.size());
@@ -844,7 +863,8 @@ TrainingEncoded Tokenizer::encode_for_training(const std::vector<ChatMessage>& m
 
         // 2. Render up to asst_i with gen_prompt=false → response segment
         std::vector<ChatMessage> up_to_asst(messages.begin(), messages.begin() + i + 2);
-        std::string render_with_asst = apply_chat_template(up_to_asst, /*add_generation_prompt=*/false);
+        std::string render_with_asst =
+            apply_chat_template(up_to_asst, /*add_generation_prompt=*/false, enable_thinking);
 
         if (render_with_asst.size() > render_with_user.size()) {
             std::string response = render_with_asst.substr(render_with_user.size());

--- a/csrc/src/tokenizer/tokenizer.h
+++ b/csrc/src/tokenizer/tokenizer.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -79,7 +80,13 @@ public:
     // Returns the formatted string ready for encode().
     // If add_generation_prompt is true, appends the assistant header so the
     // model can continue generating.
-    std::string apply_chat_template(const std::vector<ChatMessage>& messages, bool add_generation_prompt = false) const;
+    // enable_thinking, when set, is passed to the template (e.g. Qwen3 emits an
+    // open "<think>\n" generation prompt when true vs. an empty
+    // "<think>\n\n</think>\n\n" block when false); std::nullopt leaves it unset
+    // so the template falls back to its own default.
+    std::string apply_chat_template(const std::vector<ChatMessage>& messages,
+                                    bool add_generation_prompt = false,
+                                    std::optional<bool> enable_thinking = std::nullopt) const;
 
     // Convenience: apply_chat_template + encode_with_special_tokens in one call.
     std::vector<int32_t> apply_chat_template_and_encode(const std::vector<ChatMessage>& messages,

--- a/tests/test_onboarding_qwen3_5.py
+++ b/tests/test_onboarding_qwen3_5.py
@@ -521,6 +521,11 @@ def run_surogate_step(
         use_zero_copy=False,
     )
     opts.dsl_ir_json = build_dsl_ir_for_model(str(model_dir))
+    from surogate.kernels.jit_compile import compile_jit_kernels
+
+    _manifests = compile_jit_kernels(opts.dsl_ir_json)
+    if _manifests:
+        opts.jit_kernel_manifests = _manifests
 
     trainer = _surogate.SurogateTrainer(
         ngpu=1,
@@ -588,6 +593,11 @@ def run_surogate_forward(model_dir: Path, inputs: np.ndarray, targets: np.ndarra
         use_zero_copy=False,
     )
     opts.dsl_ir_json = build_dsl_ir_for_model(str(model_dir))
+    from surogate.kernels.jit_compile import compile_jit_kernels
+
+    _manifests = compile_jit_kernels(opts.dsl_ir_json)
+    if _manifests:
+        opts.jit_kernel_manifests = _manifests
 
     trainer = _surogate.SurogateTrainer(
         ngpu=1,


### PR DESCRIPTION
Framework fixes discovered while training Qwen3.5-4B (hybrid linear+full attention). Five commits, cherry-picked from the `ro` work branch onto current `main`. Compile-checked locally (`make build` links `_surogate.abi3.so`; the only failure is the venv-copy step in an isolated worktree, not a build error).

## Headline: GDR launch grid must come from autotuned manifest constants (`fc60b3bc`)
`gated_delta_rule.cpp` hardcoded the launch-grid tile sizes (fwd_o `BV=64`, fwd_h/bwd_dhu `BV=32`, bwd_dqkwg `BK=64`) while the AOT Triton autotuner bakes **whichever tiling won benchmarking** into the cubin. At `H=32` (Qwen3.5-4B, ratio-2 GQA linear attention) fwd_o autotunes to `BV=32`, so the kernel needs `cdiv(V,32)=4` grid-x blocks but was launched with `cdiv(V,64)=2` — **columns 64..127 of every linear-attn mixer output were never written** (uninitialized memory).

Effect: every ratio-2 hybrid model had a silently-garbage forward. Loss looked sane, LoRA learned to compensate the broken mixer, and merged checkpoints degraded/collapsed. `H=16` models (0.8B/2B) were unaffected only because autotune happened to pick `BV=64` there.

Fix: parse the manifest `constants` into `JitKernelMeta`; derive all grid-sensitive tiles (`fwd_h_bv`/`fwd_o_bv`/`bwd_dhu_bv`/`bwd_dqkwg_bk`) from the loaded kernels, with the old formulas as fallback for legacy manifests. `dg_nk` stack bound now assumes the smallest tile conservatively.

Repro/guard: `tests/test_onboarding_qwen3_5.py` now compiles JIT manifests itself and can run against the 4B via `QWEN3_5_MODEL_PATH` — forward parity vs HF failed (rms ~0.35–0.51/layer) before, all 5 tests pass after. 0.8B unchanged.

## Also included
- `cfd60620` fix: thinking-mode tokenization (only define `enable_thinking` in the chat-template context when explicitly requested; adds `test-chat-template.cpp`)
- `81c71faf` fix(build): pass `--parallel` to the wheel target's cmake configure
- `7502e2f1` runtime gradient-mask guard (adamw / adamw_8bit)
- `8c11722e` fused mlp growth-mask fix

Not included: `fix(qwen3.5-moe)` + `crash-handler debuginfod` are already on `main` (via #57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)