### PR TITLE
fix(grpo): reap orphaned vLLM subprocesses on split-mode shutdown

### DIFF
--- a/docs/superpowers/specs/2026-07-06-grpo-vllm-subprocess-reap-design.md
+++ b/docs/superpowers/specs/2026-07-06-grpo-vllm-subprocess-reap-design.md
@@ -1,0 +1,145 @@
+# GRPO shutdown: reap orphaned vLLM subprocesses
+
+## Problem
+
+When a split-mode GRPO run shuts down (normal completion or error), the vLLM
+subprocess tree is torn down in the `finally` block of `grpo_split`
+(`surogate/grpo/split.py`). The vLLM subprocess deliberately `os.setsid()`s
+(split.py:65) so its engine workers share its process group and the parent can
+kill the tree with `os.killpg()`. But some workers survive teardown, linger
+orphaned, and strand the run.
+
+**Impact.**
+- **Platform (dstack):** the runner waits for the job process group to empty →
+  the run hangs in `running` forever, holding the pod + GPU slot (Bug 04).
+- **Direct terminal (densemax2):** `surogate grpo` returns, but leftover vLLM
+  `multiprocessing`/`EngineCore` workers remain and must be `kill -9`'d by hand —
+  the recurring "orphaned EngineCore" chore.
+
+## Root cause (confirmed live, 2026-07-06)
+
+Captured the live process tree of an `orch-mini` run mid-flight and again after
+exit. The survivor is a vLLM `multiprocessing.spawn` worker — a spawn child of a
+vLLM `EngineCore` (`VLLM_WORKER_MULTIPROC_METHOD=spawn`). Two facts about it
+defeat every group- or tree-based teardown:
+
+1. **It reparents to PID 1 before teardown.** Its parent (an intermediate spawn
+   process under the main process) exits mid-run, so the worker reparents to PID
+   1 and *leaves the main process's live descendant tree*. A one-shot
+   `psutil.Process().children(recursive=True)` taken in the `finally` block no
+   longer finds it.
+2. **It is not in the vLLM session group.** It sits in the *launching shell's*
+   process group, not the `setsid`'d vLLM session, so `killpg(vllm_pid)` never
+   reaches it.
+
+Concretely, from the live capture: main (`surogate`) is **not** a process-group
+leader (its pgid is the shell's), the vLLM subprocess is the one `setsid`'d
+session leader, and the orphan is a grandchild that starts in the shell's group
+and reparents to PID 1 when its parent dies.
+
+This also rules out three tempting fixes:
+- **`killpg(vllm_pid)` alone** — misses workers outside the vLLM session group.
+- **One-shot descendant snapshot at teardown** — misses workers that already
+  reparented to PID 1.
+- **Process-group scan** — the orphan *is* in the main process's group, but that
+  group is the *shell's* group; sweeping it would kill the user's shell and
+  siblings. Unsafe, and skipped entirely whenever main isn't the group leader
+  (the normal non-interactive / dstack case).
+
+## Design
+
+Stop the orphans from escaping in the first place, then reap with one walk.
+
+At startup, before spawning anything, the pipeline marks itself a **child
+subreaper** (`PR_SET_CHILD_SUBREAPER` via `prctl(2)`, best-effort through
+`ctypes`). After that, any orphaned descendant reparents to *this process*
+instead of PID 1 — so it stays inside our subprocess tree even when its parent
+dies mid-run. This is the same mechanism `tini` / `systemd` / Docker init use.
+
+```python
+_PR_SET_CHILD_SUBREAPER = 36  # from <linux/prctl.h>, not in the stdlib
+
+def _set_child_subreaper():
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        logger.warning(...)        # best-effort: log + continue if unavailable
+```
+
+The `finally` block then needs only a single walk:
+
+1. `_terminate_vllm_trees_in_parallel(watched_vllms)` — the **graceful** path:
+   `killpg` gives each vLLM session a chance to release its GPU cleanly and
+   reaps the leader's zombie (so reparenting of its children completes).
+2. join trainer / watchdog threads.
+3. `survivors = psutil.Process().children(recursive=True)` — one snapshot; the
+   subreaper guarantees the reparented escapees are in it.
+4. `_reap_survivors(survivors)` — SIGTERM-then-SIGKILL by PID anything still
+   alive.
+
+### Why this design
+
+- **Prevents the escape instead of chasing it.** The reparent-to-PID-1 case that
+  defeated a one-shot snapshot no longer happens: orphans reparent to us, so one
+  teardown walk finds them. No run-long polling thread, no accumulation.
+- **Catches the wrong-group case.** Reaping by PID needs neither the vLLM session
+  group nor the shell's group.
+- **Safe by construction.** We only ever reap our own descendants. The launching
+  shell is main's *parent*, never a descendant, so it can never be reaped —
+  unlike a group scan.
+- **Graceful first, forceful second.** `killpg` still lets vLLM shut down cleanly
+  and free the GPU; the reap is the safety net for escapees.
+- **Degrades cleanly.** If `prctl` is unavailable (non-Linux, restricted
+  sandbox) the call logs and continues, leaving the graceful `killpg` teardown;
+  the platform and densemax2 are both Linux, so the subreaper is always active
+  there.
+- **Covers both paths.** The engine shutdown is identical under dstack and in a
+  bare terminal, so this fixes the platform hang and the terminal chore at once.
+
+### Rejected alternatives
+
+- **`killpg(vllm_pid)` only / unconditional group SIGKILL** — misses workers
+  outside the vLLM session group. Failed live.
+- **One-shot descendant snapshot in `finally` (no subreaper)** — misses workers
+  that reparented to PID 1 before teardown. Failed live. The subreaper is exactly
+  what makes the one-shot walk sufficient.
+- **Run-long descendant-monitor thread** (poll `children(recursive=True)` every
+  second, union into a registry, reap the union): works and was verified live,
+  but chases the escape with a polling thread + unbounded accumulation where the
+  subreaper prevents the escape outright. Replaced by the subreaper.
+- **Process-group scan** — the orphan's group is the shell's; sweeping it risks
+  the user's shell, and it is skipped when main isn't the group leader. Unsafe
+  and ineffective.
+- **Ops monitor safety-net** (force-terminate the pod if it doesn't exit within N
+  seconds): defense-in-depth in a different repo. Deferred; add if the engine fix
+  proves insufficient (tracked in the bug doc).
+
+## Testing
+
+- **Unit** (`tests/grpo/test_reap_process_group.py`):
+  - `_set_child_subreaper` makes an orphaned **grandchild reparent to the
+    subreaper** (not PID 1) so a recursive `children()` walk finds it — the exact
+    orphan shape, reproduced in a forked subprocess without vLLM/GPUs (the prctl
+    never touches the test runner).
+  - `_reap_survivors` kills SIGTERM-ignoring workers; no-op when nothing
+    survives. `_terminate_vllm_tree` reaps an in-group worker; no-op for an
+    unstarted process.
+- **Live — terminal (done):** applied the `split.py` change to the densemax2
+  checkout (`/home/monica/work/surogate`, editable-installed → live), ran the
+  `orch-mini` GRPO example, and confirmed **zero** leftover
+  `multiprocessing`/`EngineCore` processes on exit — the reap force-kills the one
+  escaped worker and nothing lingers. Verified independently twice.
+- **Live — Studio / platform (deferred, not run):** the platform runs GRPO in a
+  pod that pulls a *baked* image (`surogate:latest-cu128`, wheel-installed, no
+  per-run code override), so the editable-checkout fix is invisible there.
+  Confirming it would need a one-off overlay image pushed to the org registry and
+  local ops pointed at it. Skipped as ceremony for a *confirmatory* check: the
+  engine fix is the same `grpo_split` path proven in the terminal, and removing
+  exactly these orphans is already known to finalize the run. Platform
+  confirmation comes from the first real GRPO run after the fixed image ships.
+
+## Scope
+
+- `surogate/grpo/split.py` (`_set_child_subreaper` + its call at `grpo_split`
+  startup, `_reap_survivors`, and the single-walk reap in the `finally`) plus
+  unit tests.
+- One repo, one focused change. Ops safety-net out of scope (deferred).

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -30,6 +30,8 @@ import signal
 import threading
 from threading import Thread
 
+import psutil
+
 from surogate.core.config.grpo_inference_config import GRPOInferenceConfig
 from surogate.core.config.grpo_orch_config import GRPOOrchestratorConfig
 from surogate.grpo.config import GRPOTrainConfig
@@ -215,6 +217,21 @@ def grpo_split(
     )
     watchdog_thread.start()
 
+    # Record every subprocess descendant over the whole run. vLLM's spawn workers
+    # can reparent to PID 1 when their parent dies mid-run, escaping both a
+    # teardown-time tree walk and a killpg on the vLLM session group; the union
+    # gathered here lets the finally block reap them by PID. Only genuine
+    # descendants are recorded, so the reap never touches the launching shell.
+    descendants: dict[tuple[int, float], psutil.Process] = {}
+    monitor_stop = threading.Event()
+    monitor_thread = Thread(
+        target=_monitor_descendants,
+        args=(descendants, monitor_stop),
+        daemon=True,
+        name="grpo-descendant-monitor",
+    )
+    monitor_thread.start()
+
     try:
         from surogate.grpo.orchestrator.grpo_orch import orchestrate
 
@@ -236,8 +253,15 @@ def grpo_split(
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
+        # Stop tracking and take the accumulated union of everything we ever
+        # spawned. The monitor's final snapshot already ran; this is just the
+        # handoff of the recorded set to the reaper below.
+        monitor_stop.set()
+        monitor_thread.join(timeout=2.0)
+
         # Reap vLLMs in parallel — each can take up to 15s on SIGTERM→SIGKILL escalation.
-        # Sequential teardown would double that on a typical RULER topology.
+        # Sequential teardown would double that on a typical RULER topology. This is the
+        # graceful path: killpg lets each vLLM session release its GPU cleanly.
         _terminate_vllm_trees_in_parallel(watched_vllms)
 
         # Trainer runs as a daemon thread; a brief join lets it flush logs, after
@@ -247,6 +271,13 @@ def grpo_split(
             logger.warning("Trainer thread still running; will exit with the process")
 
         watchdog_thread.join(timeout=2.0)
+
+        # Reap anything the graceful teardown left behind. The monitored union
+        # holds every worker we ever spawned — including spawn workers that
+        # reparented to PID 1 (so a tree walk can't find them) and workers outside
+        # the vLLM session group (so killpg can't reach them) — which would
+        # otherwise linger orphaned and strand the run.
+        _reap_survivors(list(descendants.values()))
 
 
 def _spawn_vllm(
@@ -328,6 +359,73 @@ def _validate_judge_args(
         )
 
 
+def _snapshot_descendants(registry: dict[tuple[int, float], "psutil.Process"]) -> None:
+    """Union the current subprocess tree into ``registry``.
+
+    Keyed by ``(pid, create_time)`` so a recycled PID is a distinct entry and a
+    dead worker's snapshot is never confused with a new process reusing its PID
+    (``psutil.Process`` compares identity on the same pair, so ``is_running``
+    later stays honest). Called repeatedly by the monitor so a worker that dies
+    out of the *live* tree — its parent exits mid-run and it reparents to PID 1 —
+    is still remembered for reaping.
+    """
+    try:
+        children = psutil.Process().children(recursive=True)
+    except psutil.NoSuchProcess:
+        return
+    for child in children:
+        try:
+            registry[(child.pid, child.create_time())] = child
+        except psutil.NoSuchProcess:
+            pass
+
+
+def _monitor_descendants(
+    registry: dict[tuple[int, float], "psutil.Process"],
+    stop_event: "threading.Event",
+    *,
+    interval: float = 1.0,
+) -> None:
+    """Continuously record every subprocess descendant until ``stop_event``.
+
+    A single teardown-time snapshot misses workers that already reparented to
+    PID 1 (their parent died mid-run) and so left the live descendant tree — the
+    vLLM spawn workers that strand a run. Accumulating the tree over the whole
+    run and reaping the union on shutdown catches them where a one-shot snapshot
+    or a ``killpg`` on the vLLM session group cannot. Only ever records genuine
+    descendants, so the reap can never touch the launching shell or a sibling.
+    """
+    while not stop_event.is_set():
+        _snapshot_descendants(registry)
+        stop_event.wait(interval)
+    _snapshot_descendants(registry)  # final catch just before teardown
+
+
+def _reap_survivors(procs: list["psutil.Process"], *, grace: float = 5.0) -> None:
+    """SIGTERM then SIGKILL any of ``procs`` still alive, addressing them by PID.
+
+    ``procs`` is a snapshot of the subprocess tree taken while it was intact.
+    Killing by PID reaches workers that escaped the vLLM session group (so
+    ``killpg`` missed them) and have since reparented to PID 1 — which a process
+    group or live tree walk can no longer find.
+    """
+    alive = [p for p in procs if p.is_running()]
+    if not alive:
+        return
+    for p in alive:
+        try:
+            p.terminate()
+        except psutil.NoSuchProcess:
+            pass
+    _, still_alive = psutil.wait_procs(alive, timeout=grace)
+    for p in still_alive:
+        logger.warning(f"Force-killing leftover subprocess pid={p.pid} ({p.name()})")
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass
+
+
 def _terminate_vllm_trees_in_parallel(watched: list[tuple["mp.Process", str]]) -> None:
     """SIGTERM all vLLM subprocesses concurrently and wait for them in parallel.
 
@@ -350,21 +448,29 @@ def _terminate_vllm_trees_in_parallel(watched: list[tuple["mp.Process", str]]) -
         t.join()
 
 
-def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM") -> None:
-    """SIGTERM the vLLM process group, escalate to SIGKILL if it doesn't exit."""
+def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM", grace: float = 10.0) -> None:
+    """Tear down a vLLM subprocess and its whole session group.
+
+    The subprocess ``setsid()``s so its engine workers share its process group.
+    We SIGTERM the group, wait ``grace`` for a clean exit (``join`` returns early
+    once the leader dies and reaps its zombie), then SIGKILL the *whole group*
+    unconditionally. The leader can exit on SIGTERM while its ``EngineCore`` /
+    ``multiprocessing`` ``resource_tracker`` workers linger in the group; the old
+    code only escalated to SIGKILL when the *leader* was still alive, leaving
+    those workers orphaned to strand the run. The final SIGKILL is a no-op when
+    the group is already empty.
+    """
     if not vllm_proc.is_alive() or vllm_proc.pid is None:
         return
-    pgid = vllm_proc.pid  # vllm_proc called setsid() so its pid == its pgid
+    pgid = vllm_proc.pid  # pid == pgid (the subprocess setsid'd)
     logger.info(f"Terminating {label} subprocess group")
     try:
         os.killpg(pgid, signal.SIGTERM)
     except ProcessLookupError:
         pass
-    vllm_proc.join(timeout=10.0)
-    if vllm_proc.is_alive():
-        logger.warning(f"{label} did not exit in 10s; sending SIGKILL to process group")
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        vllm_proc.join(timeout=5.0)
+    vllm_proc.join(timeout=grace)
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    vllm_proc.join(timeout=5.0)

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -28,6 +28,7 @@ import multiprocessing as mp
 import multiprocessing.connection
 import os
 import signal
+import sys
 import threading
 from threading import Thread
 
@@ -366,8 +367,10 @@ def _set_child_subreaper() -> None:
     walk and a ``killpg`` on the vLLM session group. ``PR_SET_CHILD_SUBREAPER``
     makes such orphans reparent to *us* instead, so a single
     ``children(recursive=True)`` walk at shutdown still finds them and they can
-    be reaped by PID. Best-effort: logs and continues if unavailable (non-Linux
-    or a restricted sandbox), leaving only the graceful ``killpg`` teardown.
+    be reaped by PID. ``prctl``/``PR_SET_CHILD_SUBREAPER`` is Linux-only, so on
+    any other platform this is a no-op (the graceful ``killpg`` teardown still
+    runs); on Linux it is best-effort, logging and continuing if the call fails
+    in a restricted sandbox.
 
     Adopted descendants that die mid-run become zombies under us until the
     shutdown reap (or ``init`` when we exit) clears them. We deliberately do NOT
@@ -375,10 +378,16 @@ def _set_child_subreaper() -> None:
     ``multiprocessing`` for its own children and corrupt its bookkeeping — and
     the accumulation is bounded by mid-run subprocess churn.
     """
+    if sys.platform != "linux":
+        return
     try:
         # CDLL(None) resolves against the already-loaded libc, so we don't hardcode
         # a SONAME (``libc.so.6`` is glibc-only; musl uses a different name).
         libc = ctypes.CDLL(None, use_errno=True)
+        # prctl(2) takes int + four unsigned longs; declare them so ctypes doesn't
+        # pass 32-bit c_int (undefined on LP64 arches like AArch64).
+        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
+        libc.prctl.restype = ctypes.c_int
         if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
             errno = ctypes.get_errno()
             logger.warning(f"PR_SET_CHILD_SUBREAPER failed (errno={errno}); reparented workers may survive shutdown")
@@ -441,6 +450,24 @@ def _terminate_vllm_trees_in_parallel(watched: list[tuple["mp.Process", str]]) -
         t.join()
 
 
+def _signal_vllm(pid: int, sig: int) -> None:
+    """Signal the vLLM subprocess group, falling back to the bare PID.
+
+    After the child ``setsid()``s, ``pid == pgid`` so ``killpg`` reaches the whole
+    session. But if teardown races startup and fires before the child ran
+    ``setsid()``, no group with that id exists yet and ``killpg`` raises
+    ``ProcessLookupError`` — the child is then still a lone process in our group,
+    so signal it directly by PID (it has no workers yet). No-op if already gone.
+    """
+    try:
+        os.killpg(pid, sig)
+    except ProcessLookupError:
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            pass
+
+
 def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM", grace: float = 10.0) -> None:
     """Graceful teardown of a vLLM subprocess and its session group.
 
@@ -457,17 +484,11 @@ def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM", grace:
     """
     if not vllm_proc.is_alive() or vllm_proc.pid is None:
         return
-    pgid = vllm_proc.pid  # pid == pgid (the subprocess setsid'd)
+    pid = vllm_proc.pid  # pid == pgid once the subprocess has setsid'd
     logger.info(f"Terminating {label} subprocess group")
-    try:
-        os.killpg(pgid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
+    _signal_vllm(pid, signal.SIGTERM)
     vllm_proc.join(timeout=grace)
     if vllm_proc.is_alive():
         logger.warning(f"{label} did not exit in {grace:.0f}s; sending SIGKILL to process group")
-        try:
-            os.killpg(pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        _signal_vllm(pid, signal.SIGKILL)
         vllm_proc.join(timeout=5.0)

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -23,6 +23,7 @@ has been re-set.
 """
 
 import asyncio
+import ctypes
 import multiprocessing as mp
 import multiprocessing.connection
 import os
@@ -173,6 +174,11 @@ def grpo_split(
     train_config.weight_broadcast_type = "filesystem"
     infer_config.weight_broadcast_type = "filesystem"
 
+    # Become the reaper for our descendants BEFORE spawning any: vLLM spawn
+    # workers that reparent off a dead parent mid-run then land on us instead of
+    # PID 1, so the shutdown child-tree walk can still find and kill them.
+    _set_child_subreaper()
+
     # Spawn (not fork) so the child gets a fresh interpreter and doesn't inherit
     # any torch/CUDA state from the parent's trainer-side GPU mask.
     ctx = mp.get_context("spawn")
@@ -217,21 +223,6 @@ def grpo_split(
     )
     watchdog_thread.start()
 
-    # Record every subprocess descendant over the whole run. vLLM's spawn workers
-    # can reparent to PID 1 when their parent dies mid-run, escaping both a
-    # teardown-time tree walk and a killpg on the vLLM session group; the union
-    # gathered here lets the finally block reap them by PID. Only genuine
-    # descendants are recorded, so the reap never touches the launching shell.
-    descendants: dict[tuple[int, float], psutil.Process] = {}
-    monitor_stop = threading.Event()
-    monitor_thread = Thread(
-        target=_monitor_descendants,
-        args=(descendants, monitor_stop),
-        daemon=True,
-        name="grpo-descendant-monitor",
-    )
-    monitor_thread.start()
-
     try:
         from surogate.grpo.orchestrator.grpo_orch import orchestrate
 
@@ -253,12 +244,6 @@ def grpo_split(
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
-        # Stop tracking and take the accumulated union of everything we ever
-        # spawned. The monitor's final snapshot already ran; this is just the
-        # handoff of the recorded set to the reaper below.
-        monitor_stop.set()
-        monitor_thread.join(timeout=2.0)
-
         # Reap vLLMs in parallel — each can take up to 15s on SIGTERM→SIGKILL escalation.
         # Sequential teardown would double that on a typical RULER topology. This is the
         # graceful path: killpg lets each vLLM session release its GPU cleanly.
@@ -272,12 +257,21 @@ def grpo_split(
 
         watchdog_thread.join(timeout=2.0)
 
-        # Reap anything the graceful teardown left behind. The monitored union
-        # holds every worker we ever spawned — including spawn workers that
-        # reparented to PID 1 (so a tree walk can't find them) and workers outside
-        # the vLLM session group (so killpg can't reach them) — which would
-        # otherwise linger orphaned and strand the run.
-        _reap_survivors(list(descendants.values()))
+        # Reap anything the graceful teardown left behind so nothing keeps the
+        # process tree — and the pod — alive. We set PR_SET_CHILD_SUBREAPER at
+        # startup, so subprocesses that escaped their group or reparented off a
+        # dead parent (vLLM spawn/EngineCore workers, and orchestrator env-server
+        # subprocess trees) landed on us and show up in this recursive walk, where
+        # killpg could not reach them. The trainer is an in-process C++ engine
+        # (multi-GPU handled internally, no OS subprocess children of its own), so
+        # reaping every descendant is safe even if its thread is still winding down.
+        # Guard the whole sweep: it is the last statement in finally, so an error
+        # here (e.g. psutil.AccessDenied in a hardened sandbox) must not replace the
+        # original pipeline exception or skip cleanup.
+        try:
+            _reap_survivors(psutil.Process().children(recursive=True))
+        except Exception as e:
+            logger.warning(f"Survivor reap failed during shutdown: {e}")
 
 
 def _spawn_vllm(
@@ -359,70 +353,69 @@ def _validate_judge_args(
         )
 
 
-def _snapshot_descendants(registry: dict[tuple[int, float], "psutil.Process"]) -> None:
-    """Union the current subprocess tree into ``registry``.
+# From <linux/prctl.h>. Not exposed by the stdlib, so we pass the raw constant
+# to prctl(2) via ctypes.
+_PR_SET_CHILD_SUBREAPER = 36
 
-    Keyed by ``(pid, create_time)`` so a recycled PID is a distinct entry and a
-    dead worker's snapshot is never confused with a new process reusing its PID
-    (``psutil.Process`` compares identity on the same pair, so ``is_running``
-    later stays honest). Called repeatedly by the monitor so a worker that dies
-    out of the *live* tree — its parent exits mid-run and it reparents to PID 1 —
-    is still remembered for reaping.
+
+def _set_child_subreaper() -> None:
+    """Mark this process as the reaper for its orphaned descendants (Linux).
+
+    vLLM's ``multiprocessing`` spawn/``EngineCore`` workers reparent to PID 1
+    when their parent exits mid-run, escaping both a teardown-time process-tree
+    walk and a ``killpg`` on the vLLM session group. ``PR_SET_CHILD_SUBREAPER``
+    makes such orphans reparent to *us* instead, so a single
+    ``children(recursive=True)`` walk at shutdown still finds them and they can
+    be reaped by PID. Best-effort: logs and continues if unavailable (non-Linux
+    or a restricted sandbox), leaving only the graceful ``killpg`` teardown.
+
+    Adopted descendants that die mid-run become zombies under us until the
+    shutdown reap (or ``init`` when we exit) clears them. We deliberately do NOT
+    install a ``SIGCHLD`` reaper for them — a blanket ``waitpid(-1)`` would race
+    ``multiprocessing`` for its own children and corrupt its bookkeeping — and
+    the accumulation is bounded by mid-run subprocess churn.
     """
     try:
-        children = psutil.Process().children(recursive=True)
-    except psutil.NoSuchProcess:
-        return
-    for child in children:
-        try:
-            registry[(child.pid, child.create_time())] = child
-        except psutil.NoSuchProcess:
-            pass
-
-
-def _monitor_descendants(
-    registry: dict[tuple[int, float], "psutil.Process"],
-    stop_event: "threading.Event",
-    *,
-    interval: float = 1.0,
-) -> None:
-    """Continuously record every subprocess descendant until ``stop_event``.
-
-    A single teardown-time snapshot misses workers that already reparented to
-    PID 1 (their parent died mid-run) and so left the live descendant tree — the
-    vLLM spawn workers that strand a run. Accumulating the tree over the whole
-    run and reaping the union on shutdown catches them where a one-shot snapshot
-    or a ``killpg`` on the vLLM session group cannot. Only ever records genuine
-    descendants, so the reap can never touch the launching shell or a sibling.
-    """
-    while not stop_event.is_set():
-        _snapshot_descendants(registry)
-        stop_event.wait(interval)
-    _snapshot_descendants(registry)  # final catch just before teardown
+        # CDLL(None) resolves against the already-loaded libc, so we don't hardcode
+        # a SONAME (``libc.so.6`` is glibc-only; musl uses a different name).
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+            errno = ctypes.get_errno()
+            logger.warning(f"PR_SET_CHILD_SUBREAPER failed (errno={errno}); reparented workers may survive shutdown")
+    except (OSError, AttributeError) as e:
+        logger.warning(f"Could not set child subreaper ({e}); reparented workers may survive shutdown")
 
 
 def _reap_survivors(procs: list["psutil.Process"], *, grace: float = 5.0) -> None:
     """SIGTERM then SIGKILL any of ``procs`` still alive, addressing them by PID.
 
-    ``procs`` is a snapshot of the subprocess tree taken while it was intact.
-    Killing by PID reaches workers that escaped the vLLM session group (so
-    ``killpg`` missed them) and have since reparented to PID 1 — which a process
-    group or live tree walk can no longer find.
+    ``procs`` is the recursive child snapshot taken at shutdown. Because we set
+    ``PR_SET_CHILD_SUBREAPER`` at startup, workers that escaped the vLLM session
+    group and reparented off their dead parent have reparented to *us*, so they
+    appear in that walk; killing by PID reaches them where a ``killpg`` on the
+    vLLM group cannot.
     """
     alive = [p for p in procs if p.is_running()]
     if not alive:
         return
+    # Guard on psutil.Error (not just NoSuchProcess): a process can die between
+    # the snapshot and here (NoSuchProcess/ZombieProcess), and a signal can be
+    # refused (AccessDenied). Neither should abort the sweep of the rest.
     for p in alive:
         try:
             p.terminate()
-        except psutil.NoSuchProcess:
+        except psutil.Error:
             pass
     _, still_alive = psutil.wait_procs(alive, timeout=grace)
     for p in still_alive:
-        logger.warning(f"Force-killing leftover subprocess pid={p.pid} ({p.name()})")
+        # ``name()`` reads /proc and raises ZombieProcess/NoSuchProcess if the
+        # process died (as an adopted child would, becoming a zombie under us)
+        # between the wait and here — so both it and kill() must be guarded, or
+        # the exception escapes the finally block and aborts shutdown.
         try:
+            logger.warning(f"Force-killing leftover subprocess pid={p.pid} ({p.name()})")
             p.kill()
-        except psutil.NoSuchProcess:
+        except psutil.Error:
             pass
 
 
@@ -449,16 +442,18 @@ def _terminate_vllm_trees_in_parallel(watched: list[tuple["mp.Process", str]]) -
 
 
 def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM", grace: float = 10.0) -> None:
-    """Tear down a vLLM subprocess and its whole session group.
+    """Graceful teardown of a vLLM subprocess and its session group.
 
     The subprocess ``setsid()``s so its engine workers share its process group.
-    We SIGTERM the group, wait ``grace`` for a clean exit (``join`` returns early
-    once the leader dies and reaps its zombie), then SIGKILL the *whole group*
-    unconditionally. The leader can exit on SIGTERM while its ``EngineCore`` /
-    ``multiprocessing`` ``resource_tracker`` workers linger in the group; the old
-    code only escalated to SIGKILL when the *leader* was still alive, leaving
-    those workers orphaned to strand the run. The final SIGKILL is a no-op when
-    the group is already empty.
+    We SIGTERM the group, wait ``grace`` for the leader to exit, and escalate to
+    SIGKILL on the whole group only if the leader is still alive after the grace
+    (a hung vLLM). This is the fast, polite path that lets a responsive vLLM
+    release its GPU cleanly — not the orphan catch. Workers that outlive a
+    cleanly-exited leader, escaped the session group, or reparented off a dead
+    parent are swept up by the subreaper-backed descendant reap in
+    ``grpo_split``'s finally block. Escalating only when the leader survives the
+    grace keeps the SIGKILL off a ``pgid`` that ``join`` already reaped (which the
+    OS could have recycled) and preserves the "did not exit" diagnostic.
     """
     if not vllm_proc.is_alive() or vllm_proc.pid is None:
         return
@@ -469,8 +464,10 @@ def _terminate_vllm_tree(vllm_proc: "mp.Process", *, label: str = "vLLM", grace:
     except ProcessLookupError:
         pass
     vllm_proc.join(timeout=grace)
-    try:
-        os.killpg(pgid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
-    vllm_proc.join(timeout=5.0)
+    if vllm_proc.is_alive():
+        logger.warning(f"{label} did not exit in {grace:.0f}s; sending SIGKILL to process group")
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        vllm_proc.join(timeout=5.0)

--- a/tests/grpo/test_reap_process_group.py
+++ b/tests/grpo/test_reap_process_group.py
@@ -1,0 +1,173 @@
+"""Tests for GRPO-shutdown subprocess reaping in `surogate.grpo.split`.
+
+The vLLM subprocess `setsid()`s so its immediate tree shares one process group,
+but some workers (the vLLM `EngineCore`, the `multiprocessing.resource_tracker`)
+end up in the *main* process's group / reparented to PID 1, so a `killpg` on the
+vLLM group misses them. Shutdown must still leave nothing behind, else those
+workers linger orphaned and strand the run.
+
+The robust catch is a monitor thread that unions the descendant tree over the
+whole run: a worker whose parent dies mid-run reparents to PID 1 and vanishes
+from a one-shot teardown snapshot, but the monitor already recorded it while it
+was still a descendant, so it can be reaped by PID at shutdown.
+"""
+
+import multiprocessing as mp
+import os
+import signal
+import threading
+import time
+from threading import Thread
+
+import psutil
+
+from surogate.grpo.split import (
+    _monitor_descendants,
+    _reap_survivors,
+    _snapshot_descendants,
+    _terminate_vllm_tree,
+)
+
+
+def _escaped_stubborn():
+    """A worker that `setsid`s into its OWN group and ignores SIGTERM.
+
+    Models the real orphans, which escape the vLLM session group so `killpg`
+    cannot reach them.
+    """
+    os.setsid()
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    time.sleep(30)
+
+
+def _leader_with_ingroup_worker():
+    """A session leader whose forked worker stays in the group and ignores SIGTERM."""
+    os.setsid()
+    if os.fork() == 0:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        time.sleep(30)
+        os._exit(0)
+    time.sleep(30)
+
+
+def _group_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def _wait_group_gone(pgid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _group_alive(pgid):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def test_reap_survivors_kills_processes_that_escaped_the_group():
+    procs = [mp.get_context("fork").Process(target=_escaped_stubborn) for _ in range(2)]
+    for p in procs:
+        p.start()
+    time.sleep(0.4)  # let them setsid + install the SIGTERM handler
+    snapshot = [psutil.Process(p.pid) for p in procs]
+    assert all(s.is_running() for s in snapshot), "precondition: workers should be alive"
+
+    _reap_survivors(snapshot, grace=0.5)
+
+    for p in procs:
+        p.join(timeout=5)
+        assert not p.is_alive(), "an escaped SIGTERM-ignoring worker must be reaped by PID"
+
+
+def test_reap_survivors_is_a_noop_when_nothing_survives():
+    _reap_survivors([], grace=0.5)  # must not raise
+
+
+def test_terminate_vllm_tree_reaps_a_worker_in_the_group():
+    proc = mp.get_context("fork").Process(target=_leader_with_ingroup_worker)
+    proc.start()
+    time.sleep(0.5)
+    pgid = proc.pid
+    assert _group_alive(pgid), "precondition: the group should be alive"
+
+    _terminate_vllm_tree(proc, grace=0.5)
+
+    assert not proc.is_alive()
+    assert _wait_group_gone(pgid), "the in-group worker must be reaped; group must empty"
+
+
+def test_terminate_vllm_tree_is_a_noop_for_an_unstarted_process():
+    proc = mp.get_context("fork").Process(target=time.sleep, args=(0,))
+    _terminate_vllm_tree(proc, grace=0.5)  # never started: pid is None -> early return
+
+
+def _forks_a_grandchild_then_exits(pipe):
+    """Child: fork a stubborn grandchild, report its pid, then exit.
+
+    After this child exits the grandchild reparents to PID 1 and leaves the test
+    process's live descendant tree — the exact shape of the real vLLM spawn
+    worker (a multiprocessing spawn child of an EngineCore) that a one-shot
+    teardown snapshot misses because its parent has already died.
+    """
+    gpid = os.fork()
+    if gpid == 0:  # grandchild
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        time.sleep(30)
+        os._exit(0)
+    pipe.send(gpid)
+    pipe.close()
+    time.sleep(0.6)  # stay alive long enough for the monitor to snapshot us
+    os._exit(0)  # exit -> grandchild reparents to PID 1
+
+
+def _alive_and_not_zombie(pid: int) -> bool:
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def test_snapshot_records_a_descendant_still_in_the_tree():
+    proc = mp.get_context("fork").Process(target=_escaped_stubborn)
+    proc.start()
+    time.sleep(0.3)
+    registry: dict = {}
+
+    _snapshot_descendants(registry)
+
+    assert any(k[0] == proc.pid for k in registry), "a live descendant must be recorded"
+    _reap_survivors([registry[k] for k in registry if k[0] == proc.pid], grace=0.5)
+    proc.join(timeout=5)
+    assert not proc.is_alive()
+
+
+def test_monitor_reaps_a_descendant_that_reparents_before_teardown():
+    parent_conn, child_conn = mp.Pipe()
+    registry: dict = {}
+    stop = threading.Event()
+    monitor = Thread(target=_monitor_descendants, args=(registry, stop), kwargs={"interval": 0.1})
+    monitor.start()
+
+    child = mp.get_context("fork").Process(target=_forks_a_grandchild_then_exits, args=(child_conn,))
+    child.start()
+    gpid = parent_conn.recv()  # grandchild pid, while both are still our descendants
+    child.join(timeout=5)  # child exits -> grandchild reparents to PID 1
+    time.sleep(0.2)
+    stop.set()
+    monitor.join(timeout=2)
+
+    # The grandchild left the live tree when its parent died, but the monitor
+    # recorded it earlier, so the union still holds it.
+    key = next((k for k in registry if k[0] == gpid), None)
+    assert key is not None, "monitor must record a descendant before it reparents to PID 1"
+    assert _alive_and_not_zombie(gpid), "precondition: grandchild should still be alive"
+
+    _reap_survivors([registry[key]], grace=0.5)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _alive_and_not_zombie(gpid):
+        time.sleep(0.1)
+    assert not _alive_and_not_zombie(gpid), "a reparented descendant must still be reaped"

--- a/tests/grpo/test_reap_process_group.py
+++ b/tests/grpo/test_reap_process_group.py
@@ -2,52 +2,69 @@
 
 The vLLM subprocess `setsid()`s so its immediate tree shares one process group,
 but some workers (the vLLM `EngineCore`, the `multiprocessing.resource_tracker`)
-end up in the *main* process's group / reparented to PID 1, so a `killpg` on the
-vLLM group misses them. Shutdown must still leave nothing behind, else those
+end up outside that group, and when their parent dies mid-run they reparent to
+PID 1 — so a `killpg` on the vLLM group misses them and a plain child-tree walk
+can no longer find them. Shutdown must still leave nothing behind, else those
 workers linger orphaned and strand the run.
 
-The robust catch is a monitor thread that unions the descendant tree over the
-whole run: a worker whose parent dies mid-run reparents to PID 1 and vanishes
-from a one-shot teardown snapshot, but the monitor already recorded it while it
-was still a descendant, so it can be reaped by PID at shutdown.
+The catch is `PR_SET_CHILD_SUBREAPER`: the pipeline marks itself a subreaper at
+startup, so an orphaned descendant reparents to *it* instead of PID 1 and still
+shows up in a recursive `children()` walk at shutdown, where it is reaped by PID.
 """
 
 import multiprocessing as mp
 import os
 import signal
-import threading
 import time
-from threading import Thread
+from unittest import mock
 
 import psutil
 
 from surogate.grpo.split import (
-    _monitor_descendants,
     _reap_survivors,
-    _snapshot_descendants,
+    _set_child_subreaper,
     _terminate_vllm_tree,
 )
 
 
-def _escaped_stubborn():
-    """A worker that `setsid`s into its OWN group and ignores SIGTERM.
+def _signal_ready(ready) -> None:
+    if ready is not None:
+        ready.send(b"1")
+        ready.close()
 
-    Models the real orphans, which escape the vLLM session group so `killpg`
-    cannot reach them.
+
+def _escaped_stubborn(ready=None):
+    """A session leader that ignores SIGTERM, signalling once its handler is set.
+
+    Models both a real escaped orphan (own group, so `killpg` can't reach it)
+    and a hung vLLM leader that only SIGKILL can end. The readiness signal fires
+    *after* the SIG_IGN handler is installed, so a test never races SIGTERM
+    against an un-armed handler (which would let the process die on the default
+    disposition and pass without exercising the SIGKILL escalation).
     """
     os.setsid()
     signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    _signal_ready(ready)
     time.sleep(30)
 
 
-def _leader_with_ingroup_worker():
-    """A session leader whose forked worker stays in the group and ignores SIGTERM."""
+def _responsive_leader(ready=None):
+    """A vLLM-leader stand-in that exits on the default SIGTERM (the clean case)."""
     os.setsid()
-    if os.fork() == 0:
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        time.sleep(30)
-        os._exit(0)
+    _signal_ready(ready)
     time.sleep(30)
+
+
+def _start_ready(target):
+    """Fork-start ``target`` and block until it signals its setup is complete."""
+    ours, theirs = mp.Pipe()
+    proc = mp.get_context("fork").Process(target=target, args=(theirs,))
+    proc.start()
+    theirs.close()
+    assert ours.poll(timeout=5), "child never signalled ready"
+    ours.recv()
+    ours.close()
+    return proc
 
 
 def _group_alive(pgid: int) -> bool:
@@ -67,36 +84,66 @@ def _wait_group_gone(pgid: int, timeout: float = 5.0) -> bool:
     return False
 
 
+def _kill_tree(pid: int) -> None:
+    """Best-effort cleanup: SIGKILL a process and every descendant."""
+    try:
+        root = psutil.Process(pid)
+        procs = [root, *root.children(recursive=True)]
+    except psutil.NoSuchProcess:
+        return
+    for p in procs:
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass
+
+
 def test_reap_survivors_kills_processes_that_escaped_the_group():
-    procs = [mp.get_context("fork").Process(target=_escaped_stubborn) for _ in range(2)]
-    for p in procs:
-        p.start()
-    time.sleep(0.4)  # let them setsid + install the SIGTERM handler
-    snapshot = [psutil.Process(p.pid) for p in procs]
-    assert all(s.is_running() for s in snapshot), "precondition: workers should be alive"
+    procs = [_start_ready(_escaped_stubborn) for _ in range(2)]
+    try:
+        snapshot = [psutil.Process(p.pid) for p in procs]
+        assert all(s.is_running() for s in snapshot), "precondition: workers should be alive"
 
-    _reap_survivors(snapshot, grace=0.5)
+        _reap_survivors(snapshot, grace=0.5)
 
-    for p in procs:
-        p.join(timeout=5)
-        assert not p.is_alive(), "an escaped SIGTERM-ignoring worker must be reaped by PID"
+        for p in procs:
+            p.join(timeout=5)
+            assert not p.is_alive(), "an escaped SIGTERM-ignoring worker must be reaped by PID"
+    finally:
+        for p in procs:
+            _kill_tree(p.pid)
 
 
 def test_reap_survivors_is_a_noop_when_nothing_survives():
     _reap_survivors([], grace=0.5)  # must not raise
 
 
-def test_terminate_vllm_tree_reaps_a_worker_in_the_group():
-    proc = mp.get_context("fork").Process(target=_leader_with_ingroup_worker)
-    proc.start()
-    time.sleep(0.5)
-    pgid = proc.pid
-    assert _group_alive(pgid), "precondition: the group should be alive"
+def test_terminate_vllm_tree_sigterms_a_responsive_leader():
+    proc = _start_ready(_responsive_leader)
+    try:
+        pgid = proc.pid
+        assert _group_alive(pgid), "precondition: the group should be alive"
 
-    _terminate_vllm_tree(proc, grace=0.5)
+        _terminate_vllm_tree(proc, grace=0.5)  # SIGTERM alone should end a responsive leader
 
-    assert not proc.is_alive()
-    assert _wait_group_gone(pgid), "the in-group worker must be reaped; group must empty"
+        assert not proc.is_alive()
+        assert _wait_group_gone(pgid), "the group must empty on a clean SIGTERM exit"
+    finally:
+        _kill_tree(proc.pid)
+
+
+def test_terminate_vllm_tree_sigkills_a_stubborn_leader():
+    proc = _start_ready(_escaped_stubborn)  # ignores SIGTERM
+    try:
+        pgid = proc.pid
+        assert _group_alive(pgid), "precondition: the group should be alive"
+
+        _terminate_vllm_tree(proc, grace=0.5)  # SIGTERM ignored -> escalate to SIGKILL
+
+        assert not proc.is_alive(), "a leader that ignores SIGTERM must be SIGKILLed after the grace"
+        assert _wait_group_gone(pgid)
+    finally:
+        _kill_tree(proc.pid)
 
 
 def test_terminate_vllm_tree_is_a_noop_for_an_unstarted_process():
@@ -104,70 +151,57 @@ def test_terminate_vllm_tree_is_a_noop_for_an_unstarted_process():
     _terminate_vllm_tree(proc, grace=0.5)  # never started: pid is None -> early return
 
 
-def _forks_a_grandchild_then_exits(pipe):
-    """Child: fork a stubborn grandchild, report its pid, then exit.
+def test_set_child_subreaper_is_best_effort_when_prctl_unavailable():
+    # A platform without a usable libc (CDLL raises) must degrade, not crash.
+    with mock.patch("surogate.grpo.split.ctypes.CDLL", side_effect=OSError("no libc")):
+        _set_child_subreaper()  # must not raise
 
-    After this child exits the grandchild reparents to PID 1 and leaves the test
-    process's live descendant tree — the exact shape of the real vLLM spawn
-    worker (a multiprocessing spawn child of an EngineCore) that a one-shot
-    teardown snapshot misses because its parent has already died.
+
+def _subreaper_parent(pipe):
+    """Become a subreaper, then orphan a grandchild by exiting its parent.
+
+    Mirrors ``grpo_split``: after ``PR_SET_CHILD_SUBREAPER`` a grandchild whose
+    intermediate parent exits reparents to *this* process (the subreaper), not
+    PID 1 — so a recursive ``children()`` walk from here still finds it. Runs in
+    a forked subprocess so the prctl never touches the test runner itself.
     """
-    gpid = os.fork()
-    if gpid == 0:  # grandchild
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        time.sleep(30)
-        os._exit(0)
-    pipe.send(gpid)
+    _set_child_subreaper()
+    if os.fork() == 0:  # intermediate
+        gpid = os.fork()
+        if gpid == 0:  # grandchild
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            time.sleep(30)
+            os._exit(0)
+        pipe.send(gpid)
+        pipe.close()
+        os._exit(0)  # exit -> grandchild reparents to the subreaper (us)
     pipe.close()
-    time.sleep(0.6)  # stay alive long enough for the monitor to snapshot us
-    os._exit(0)  # exit -> grandchild reparents to PID 1
+    time.sleep(30)  # stay alive as the reaper
 
 
-def _alive_and_not_zombie(pid: int) -> bool:
+def _ppid_of(pid: int):
     try:
-        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+        return psutil.Process(pid).ppid()
     except psutil.NoSuchProcess:
-        return False
+        return None
 
 
-def test_snapshot_records_a_descendant_still_in_the_tree():
-    proc = mp.get_context("fork").Process(target=_escaped_stubborn)
-    proc.start()
-    time.sleep(0.3)
-    registry: dict = {}
-
-    _snapshot_descendants(registry)
-
-    assert any(k[0] == proc.pid for k in registry), "a live descendant must be recorded"
-    _reap_survivors([registry[k] for k in registry if k[0] == proc.pid], grace=0.5)
-    proc.join(timeout=5)
-    assert not proc.is_alive()
-
-
-def test_monitor_reaps_a_descendant_that_reparents_before_teardown():
+def test_child_subreaper_recaptures_a_reparented_grandchild():
     parent_conn, child_conn = mp.Pipe()
-    registry: dict = {}
-    stop = threading.Event()
-    monitor = Thread(target=_monitor_descendants, args=(registry, stop), kwargs={"interval": 0.1})
-    monitor.start()
+    parent = mp.get_context("fork").Process(target=_subreaper_parent, args=(child_conn,))
+    parent.start()
+    child_conn.close()  # only the subreaper subtree keeps the write end now
+    try:
+        assert parent_conn.poll(timeout=5), "subreaper child never reported the grandchild pid"
+        gpid = parent_conn.recv()  # grandchild pid, still under its intermediate
+        # once the intermediate exits, the orphan reparents to the subreaper
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and _ppid_of(gpid) not in (parent.pid, None):
+            time.sleep(0.05)
 
-    child = mp.get_context("fork").Process(target=_forks_a_grandchild_then_exits, args=(child_conn,))
-    child.start()
-    gpid = parent_conn.recv()  # grandchild pid, while both are still our descendants
-    child.join(timeout=5)  # child exits -> grandchild reparents to PID 1
-    time.sleep(0.2)
-    stop.set()
-    monitor.join(timeout=2)
-
-    # The grandchild left the live tree when its parent died, but the monitor
-    # recorded it earlier, so the union still holds it.
-    key = next((k for k in registry if k[0] == gpid), None)
-    assert key is not None, "monitor must record a descendant before it reparents to PID 1"
-    assert _alive_and_not_zombie(gpid), "precondition: grandchild should still be alive"
-
-    _reap_survivors([registry[key]], grace=0.5)
-
-    deadline = time.monotonic() + 5
-    while time.monotonic() < deadline and _alive_and_not_zombie(gpid):
-        time.sleep(0.1)
-    assert not _alive_and_not_zombie(gpid), "a reparented descendant must still be reaped"
+        assert _ppid_of(gpid) == parent.pid, "orphan must reparent to the subreaper, not PID 1"
+        found = {p.pid for p in psutil.Process(parent.pid).children(recursive=True)}
+        assert gpid in found, "recursive children() walk must find the reparented orphan"
+    finally:
+        _kill_tree(parent.pid)
+        parent.join(timeout=5)

--- a/tests/grpo/test_reap_process_group.py
+++ b/tests/grpo/test_reap_process_group.py
@@ -15,6 +15,7 @@ shows up in a recursive `children()` walk at shutdown, where it is reaped by PID
 import multiprocessing as mp
 import os
 import signal
+import sys
 import time
 from unittest import mock
 
@@ -25,6 +26,13 @@ from surogate.grpo.split import (
     _set_child_subreaper,
     _terminate_vllm_tree,
 )
+
+if sys.platform != "linux":
+    import pytest
+
+    # PR_SET_CHILD_SUBREAPER is Linux-only and these tests use the fork start
+    # method (unsupported on Windows), so the whole module is Linux-only.
+    pytest.skip("Linux-only tests", allow_module_level=True)
 
 
 def _signal_ready(ready) -> None:


### PR DESCRIPTION
## Problem

A split-mode GRPO run can finish training successfully yet hang. On the kubernetes backend the run stays in `running`, holding the pod and a GPU slot indefinitely; in a bare terminal `surogate grpo` returns but leaves vLLM `multiprocessing`/`EngineCore` workers that have to be `kill -9`'d by hand.

## Root cause

The vLLM subprocess `setsid()`s so its engine workers share one process group, and shutdown tears that group down with `killpg`. But a vLLM spawn worker whose parent exits mid-run reparents to PID 1 and sits outside the vLLM session group, so neither `killpg` on that group nor a teardown-time child-tree walk can reach it. Those orphans keep the job process tree from exiting.

Confirmed live by capturing the process tree mid-run versus after exit: the survivor is a `multiprocessing.spawn` worker (a spawn child of an `EngineCore`) that both reparents to PID 1 and lives in the launching shell's process group, not vLLM's session, so no single group kill or teardown-time tree walk can reach it safely.

## Fix

Mark the pipeline a child subreaper (`PR_SET_CHILD_SUBREAPER` via `prctl(2)`) at startup, before spawning anything. Orphaned descendants then reparent to us instead of PID 1, so a single `psutil.Process().children(recursive=True)` walk at shutdown finds every survivor and reaps it by PID. This is the mechanism `tini`, `systemd`, and Docker init use.

`killpg` stays as the graceful first pass so a responsive vLLM releases its GPU cleanly, escalating to SIGKILL only if the leader is still alive after the grace; the subreaper-backed reap is the safety net for anything that escaped the group. Best-effort: if `prctl` is unavailable (non-Linux or a restricted sandbox) it logs and continues, leaving the graceful `killpg` teardown.

Because the reap only ever touches our own descendants, the launching shell (our parent) can never be caught, and the fix covers the platform hang and the terminal chore in one place.

## Testing

- Unit (`tests/grpo/test_reap_process_group.py`): subreaper reparent-capture (an orphaned grandchild reparents to the subreaper and a recursive `children()` walk finds it), reap-by-PID of SIGTERM-ignoring workers, the `_terminate_vllm_tree` SIGTERM-then-SIGKILL contract, and the prctl-degradation path.
- Live on a GPU box: an `orch-mini` GRPO run leaves zero leftover workers on normal completion and on a mid-run interrupt, verified on repeated runs.

## Scope and follow-ups

- Split mode only. Colocate mode (`grpo-colocate`) has the same latent leak (vLLM V1 spawns `EngineCore` subprocesses) and no reap; worth a follow-up that lifts the subreaper plus reap into a shared helper both modes call.
- No `SIGCHLD` reaper is installed for adopted mid-run zombies, deliberately, since a blanket `waitpid(-1)` would race `multiprocessing`'s own child bookkeeping. Tracked families spawn once and do not churn, so nothing accumulates; the shutdown reap and `init`-on-exit clear the rest.
