### PR TITLE
feat: knowledge distillation (offline top-K logit KD + cross-tokenizer transplant)

### DIFF
--- a/csrc/src/binding/binding.cpp
+++ b/csrc/src/binding/binding.cpp
@@ -2036,6 +2036,75 @@ NB_MODULE(_surogate, m) {
                 return out;
             },
             "Return native GRPO metrics accumulated since the current grad-accum step started.")
+        .def(
+            "step_with_kd",
+            [](MultiGPUPyTrainer* trainer,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> input_ids,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> targets,
+               nb::ndarray<int32_t, nb::ndim<3>, nb::c_contig> kd_ids,
+               nb::ndarray<float, nb::ndim<3>, nb::c_contig> kd_logprobs,
+               nb::object position_ids_obj,
+               int top_k,
+               float temperature,
+               float kd_weight,
+               float ce_weight) {
+                // Pin the arrays to the trainer's geometry: py_train slices per
+                // GPU with the trainer's B/T, so self-consistent-but-wrong
+                // shapes would read out of bounds on the host.
+                CHECK_SHAPE(input_ids, trainer->batch_size() * trainer->local_world_size(), trainer->seq_length());
+                const std::size_t rows = input_ids.shape(0);
+                const std::size_t seq = input_ids.shape(1);
+                if (targets.shape(0) != rows || targets.shape(1) != seq) {
+                    throw std::invalid_argument("step_with_kd: targets shape must match input_ids");
+                }
+                if (top_k <= 0) {
+                    throw std::invalid_argument("step_with_kd: top_k must be positive");
+                }
+                if (kd_ids.shape(0) != rows || kd_ids.shape(1) != seq ||
+                    kd_ids.shape(2) != static_cast<std::size_t>(top_k)) {
+                    throw std::invalid_argument("step_with_kd: kd_ids must have shape [rows, seq_len, top_k]");
+                }
+                if (kd_logprobs.shape(0) != rows || kd_logprobs.shape(1) != seq ||
+                    kd_logprobs.shape(2) != static_cast<std::size_t>(top_k)) {
+                    throw std::invalid_argument("step_with_kd: kd_logprobs must have shape [rows, seq_len, top_k]");
+                }
+                const std::int32_t* pos_ptr = nullptr;
+                if (!position_ids_obj.is_none()) {
+                    auto pos = nb::cast<nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig>>(position_ids_obj);
+                    if (pos.shape(0) != rows || pos.shape(1) != seq) {
+                        throw std::invalid_argument("step_with_kd: position_ids shape must match input_ids");
+                    }
+                    pos_ptr = pos.data();
+                }
+                trainer->step_with_kd(input_ids.data(),
+                                      targets.data(),
+                                      kd_ids.data(),
+                                      kd_logprobs.data(),
+                                      pos_ptr,
+                                      top_k,
+                                      temperature,
+                                      kd_weight,
+                                      ce_weight);
+            },
+            nb::arg("input_ids"),
+            nb::arg("targets"),
+            nb::arg("kd_ids"),
+            nb::arg("kd_logprobs"),
+            nb::arg("position_ids") = nb::none(),
+            nb::arg("top_k") = 32,
+            nb::arg("temperature") = 1.0f,
+            nb::arg("kd_weight") = 0.5f,
+            nb::arg("ce_weight") = 0.5f,
+            "Run one knowledge-distillation training micro-step.\n\n"
+            "Standard SFT forward/backward with a top-K teacher signal injected into the\n"
+            "fused LM-head loss: total = ce_weight*CE + kd_weight*tau^2*KL(teacher||student).\n"
+            "kd_ids/kd_logprobs are [rows, seq_len, top_k] arrays with row i aligned with\n"
+            "targets[i] (the teacher's next-token distribution at input position i).\n"
+            "Call update_with_config() after grad_accum micro-steps, then get_kd_loss().")
+        .def(
+            "get_kd_loss",
+            [](MultiGPUPyTrainer* trainer) { return trainer->get_kd_loss(); },
+            "Mean KD loss per valid token accumulated since the last call (rank-0 local).")
         .def("set_grad_accumulation",
              &MultiGPUPyTrainer::set_grad_accumulation,
              nb::arg("n"),
@@ -2648,8 +2717,8 @@ NB_MODULE(_surogate, m) {
                              inputs.device_id()};
                 d->load_batch(inp_t, tgt_t);
             },
-            nb::arg("inputs"),
-            nb::arg("targets"),
+            nb::arg("inputs").noconvert(),
+            nb::arg("targets").noconvert(),
             "Fill `inputs` and `targets` with the next batch.\n\n"
             "Parameters:\n"
             "- inputs: Preallocated int32 array [batch, seq_len].\n"
@@ -2678,14 +2747,81 @@ NB_MODULE(_surogate, m) {
                              position_ids.device_id()};
                 d->load_batch(inp_t, tgt_t, &pos_t);
             },
-            nb::arg("inputs"),
-            nb::arg("targets"),
-            nb::arg("position_ids"),
+            nb::arg("inputs").noconvert(),
+            nb::arg("targets").noconvert(),
+            nb::arg("position_ids").noconvert(),
             "Fill `inputs`, `targets`, and `position_ids` with the next batch.\n\n"
             "Parameters:\n"
             "- inputs: Preallocated int32 array [batch, seq_len].\n"
             "- targets: Preallocated int32 array [batch, seq_len].\n"
             "- position_ids: Preallocated int32 array [batch, seq_len].")
+        .def(
+            "load_batch",
+            [](DataLoader* d,
+               TokenArray inputs,
+               TokenArray targets,
+               TokenArray position_ids,
+               TokenArray3 kd_ids,
+               nb::ndarray<float, nb::shape<-1, -1, -1>, nb::c_contig, nb::device::cpu> kd_logprobs) {
+                CHECK_SHAPE(position_ids, static_cast<int>(inputs.shape(0)), static_cast<int>(inputs.shape(1)));
+                const int k = d->kd_top_k();
+                if (k <= 0) {
+                    throw std::runtime_error("load_batch: KD arrays passed but enable_kd() was not called");
+                }
+                CHECK_SHAPE(kd_ids, static_cast<int>(inputs.shape(0)), static_cast<int>(inputs.shape(1)), k);
+                CHECK_SHAPE(kd_logprobs, static_cast<int>(inputs.shape(0)), static_cast<int>(inputs.shape(1)), k);
+                Tensor inp_t{ETensorDType::INT32,
+                             {static_cast<long>(inputs.shape(0)), static_cast<long>(inputs.shape(1))},
+                             reinterpret_cast<std::byte*>(inputs.data()),
+                             nullptr,
+                             2,
+                             inputs.device_id()};
+                Tensor tgt_t{ETensorDType::INT32,
+                             {static_cast<long>(targets.shape(0)), static_cast<long>(targets.shape(1))},
+                             reinterpret_cast<std::byte*>(targets.data()),
+                             nullptr,
+                             2,
+                             targets.device_id()};
+                Tensor pos_t{ETensorDType::INT32,
+                             {static_cast<long>(position_ids.shape(0)), static_cast<long>(position_ids.shape(1))},
+                             reinterpret_cast<std::byte*>(position_ids.data()),
+                             nullptr,
+                             2,
+                             position_ids.device_id()};
+                Tensor kd_ids_t{ETensorDType::INT32,
+                                {static_cast<long>(kd_ids.shape(0)),
+                                 static_cast<long>(kd_ids.shape(1)),
+                                 static_cast<long>(kd_ids.shape(2))},
+                                reinterpret_cast<std::byte*>(kd_ids.data()),
+                                nullptr,
+                                3,
+                                kd_ids.device_id()};
+                Tensor kd_lp_t{ETensorDType::FP32,
+                               {static_cast<long>(kd_logprobs.shape(0)),
+                                static_cast<long>(kd_logprobs.shape(1)),
+                                static_cast<long>(kd_logprobs.shape(2))},
+                               reinterpret_cast<std::byte*>(kd_logprobs.data()),
+                               nullptr,
+                               3,
+                               kd_logprobs.device_id()};
+                d->load_batch(inp_t, tgt_t, &pos_t, &kd_ids_t, &kd_lp_t);
+            },
+            nb::arg("inputs").noconvert(),
+            nb::arg("targets").noconvert(),
+            nb::arg("position_ids").noconvert(),
+            nb::arg("kd_ids").noconvert(),
+            nb::arg("kd_logprobs").noconvert(),
+            "Fill token buffers plus the KD teacher top-K arrays with the next batch.\n\n"
+            "Requires enable_kd(). Parameters:\n"
+            "- inputs/targets/position_ids: Preallocated int32 arrays [batch, seq_len].\n"
+            "- kd_ids: Preallocated int32 array [batch, seq_len, top_k].\n"
+            "- kd_logprobs: Preallocated float32 array [batch, seq_len, top_k].")
+        .def("enable_kd",
+             &DataLoader::enable_kd,
+             nb::arg("expected_k"),
+             "Enable knowledge-distillation sidecar loading. Validates a `<shard>.kd` sidecar for\n"
+             "every token file (matching token count and `expected_k`) and raises otherwise.")
+        .def_prop_ro("has_kd", &DataLoader::has_kd, "True if KD sidecar loading is enabled.")
         .def("epoch", &DataLoader::epoch, "Return the current epoch number (0-based).")
         .def("progress", &DataLoader::progress, "Return progress within the current epoch (percent).")
         .def("advance_epoch", &DataLoader::advance_epoch, "Advance to the next epoch and reshuffle chunk order.")
@@ -2847,6 +2983,17 @@ NB_MODULE(_surogate, m) {
              "- norm: Gradient norm.\n"
              "- loss: Training loss.\n"
              "- lr: Learning rate.")
+        .def("log_step_kd",
+             &TrainingRunLogger::log_step_kd,
+             nb::arg("step"),
+             nb::arg("epoch"),
+             nb::arg("step_tokens"),
+             nb::arg("duration_ms"),
+             nb::arg("norm"),
+             nb::arg("loss"),
+             nb::arg("lr"),
+             nb::arg("kd_loss"),
+             "Log a knowledge-distillation training step (adds kd_loss to the step record).")
         .def("log_step_moe",
              nb::overload_cast<int,
                                float,

--- a/csrc/src/binding/py_train.cpp
+++ b/csrc/src/binding/py_train.cpp
@@ -2897,6 +2897,113 @@ void MultiGPUPyTrainer::step_grpo_native(const std::int32_t* inputs,
     ++mTrainMicroStep;
 }
 
+void MultiGPUPyTrainer::step_with_kd(const std::int32_t* inputs,
+                                     const std::int32_t* targets,
+                                     const std::int32_t* kd_ids,
+                                     const float* kd_logprobs,
+                                     const std::int32_t* position_ids,
+                                     int top_k,
+                                     float temperature,
+                                     float kd_weight,
+                                     float ce_weight) {
+    const int ep_size = std::max(1, mOptions.EPSize);
+    for (int i = 0; i < (int)mContexts.size(); ++i) {
+        auto& ctx = mContexts.at(i);
+        if (!ctx.Model) {
+            throw std::runtime_error(fmt::format("step_with_kd: ctx[{}].Model is null", i));
+        }
+        auto* ib = ctx.Model->get_input_buffer().get<std::int32_t>();
+        auto* tb = ctx.Model->get_target_buffer().get<std::int32_t>();
+        Tensor pos_buf = ctx.Model->get_position_ids_buffer();
+        auto* pb = pos_buf.get<std::int32_t>();
+        const int pos_planes = (pos_buf.Rank == 3) ? static_cast<int>(pos_buf.Sizes[0]) : 1;
+        const std::size_t bt = static_cast<std::size_t>(B) * static_cast<std::size_t>(T);
+        const int src_row = host_batch_row_for_local_rank(i, ep_size);
+
+        std::memcpy(ib, inputs + src_row * B * T, B * T * sizeof(std::int32_t));
+        std::memcpy(tb, targets + src_row * B * T, B * T * sizeof(std::int32_t));
+        if (position_ids) {
+            const auto* src = position_ids + static_cast<std::ptrdiff_t>(src_row) * static_cast<std::ptrdiff_t>(bt);
+            for (int p = 0; p < pos_planes; ++p) {
+                std::memcpy(pb + p * bt, src, bt * sizeof(std::int32_t));
+            }
+        } else {
+            fill_sequential_position_ids(pb, pos_planes, B, T);
+        }
+    }
+
+    if (mTrainMicroStep >= mGradAccumulation) {
+        throw std::runtime_error(
+            fmt::format("step_with_kd: micro_step {} >= grad_accumulation {}", mTrainMicroStep, mGradAccumulation));
+    }
+
+    const dsl::KdLossConfig kd_config{
+        .top_k = top_k,
+        .temperature = temperature,
+        .kd_weight = kd_weight,
+        .ce_weight = ce_weight,
+    };
+
+    run_work([micro_idx = mTrainMicroStep,
+              micro_batches = mGradAccumulation,
+              kd_ids,
+              kd_logprobs,
+              kd_config,
+              B = this->B,
+              T = this->T](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("step_with_kd: model is not a DslModel");
+        }
+
+        Tensor inputs_tensor = ctx.Model->get_input_buffer();
+        Tensor position_ids_tensor = ctx.Model->get_position_ids_buffer();
+        Tensor targets_tensor = ctx.Model->get_target_buffer();
+
+        const int gpu_rank = ctx.Communicator->local_rank();
+        const int gpu_ep_size = ctx.Communicator->ep_size();
+        const int src_row = host_batch_row_for_local_rank(gpu_rank, gpu_ep_size);
+        const std::ptrdiff_t kd_stride = static_cast<std::ptrdiff_t>(B) * static_cast<std::ptrdiff_t>(T) *
+                                         static_cast<std::ptrdiff_t>(kd_config.top_k);
+
+        dsl_model->step_with_kd(inputs_tensor,
+                                position_ids_tensor,
+                                targets_tensor,
+                                kd_ids + src_row * kd_stride,
+                                kd_logprobs + src_row * kd_stride,
+                                micro_batches,
+                                micro_idx,
+                                *ctx.Communicator,
+                                kd_config);
+    });
+
+    ++mTrainMicroStep;
+}
+
+float MultiGPUPyTrainer::get_kd_loss() {
+    float result = 0.0f;
+    run_work([&result](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("get_kd_loss: model is not a DslModel");
+        }
+        // Consume on every rank so accumulators reset; report rank 0 only.
+        const float kd_sum = dsl_model->consume_kd_loss_sum();
+        if (ctx.Communicator->local_rank() != 0) {
+            return;
+        }
+        auto& rs = dsl_model->get_run_state();
+        int valid_tokens = 0;
+        if (rs.ValidTokenCount.Data) {
+            CUDA_CHECK(cudaMemcpy(&valid_tokens, rs.ValidTokenCount.Data, sizeof(int), cudaMemcpyDeviceToHost));
+        }
+        const int world_size = std::max(1, ctx.Communicator->world_size());
+        const float avg_valid = valid_tokens > 0 ? static_cast<float>(valid_tokens) / world_size : 0.0f;
+        result = avg_valid > 0.0f ? kd_sum / avg_valid : 0.0f;
+    });
+    return result;
+}
+
 std::unordered_map<std::string, float> MultiGPUPyTrainer::get_grpo_native_metrics() {
     std::unordered_map<std::string, float> result;
     run_work([&result](sThreadContext& ctx) {

--- a/csrc/src/binding/py_train.h
+++ b/csrc/src/binding/py_train.h
@@ -292,6 +292,24 @@ public:
                           float kl_tau);
     std::unordered_map<std::string, float> get_grpo_native_metrics();
 
+    // Knowledge-distillation training micro-step: standard SFT forward/backward
+    // with a top-K teacher signal. kd_ids/kd_logprobs are host arrays of shape
+    // [ngpu*B, T, top_k], sliced per GPU like inputs/targets.
+    void step_with_kd(const std::int32_t* inputs,
+                      const std::int32_t* targets,
+                      const std::int32_t* kd_ids,
+                      const float* kd_logprobs,
+                      const std::int32_t* position_ids,
+                      int top_k,
+                      float temperature,
+                      float kd_weight,
+                      float ce_weight);
+
+    // Mean KD loss per valid token accumulated since the last call (rank-0
+    // local, mirroring get_grpo_native_metrics). Consumes the accumulator on
+    // every rank.
+    float get_kd_loss();
+
 private:
     std::unique_ptr<PretrainedConfig> mConfig;  // unique_ptr to preserve polymorphism
     RuntimeOptions mOptions;

--- a/csrc/src/kernels/fused_classifier.cu
+++ b/csrc/src/kernels/fused_classifier.cu
@@ -789,6 +789,292 @@ __global__ void chunked_cross_entropy_backward_kernel(floatX* dlogits,
     }
 }
 
+// ----------------------------------------------------------------------------
+// Knowledge-distillation variants of the cross-entropy backward.
+//
+// dlogit = dloss[t] * (ce_w*(p - onehot) + kd_scale*(p_tau - q_scatter))
+// where p_tau = softmax(capped_logits / tau) and q is the renormalized
+// teacher top-K distribution. Kept as separate kernels so the standard CE
+// backward's inner loop stays untouched.
+//
+// dlogits aliases logits (in-place), so the capped logit values at the
+// teacher's top-K ids are preloaded into shared memory before the dense
+// pass overwrites them.
+
+constexpr int KD_MAX_TOPK_SMEM = 1024;
+
+template <class floatX>
+__global__ void kd_cross_entropy_backward_kernel(floatX* dlogits,
+                                                 const floatX* logits,
+                                                 const float* logsumexp,
+                                                 const float* dloss,
+                                                 const int* targets,
+                                                 int BT,
+                                                 int V,
+                                                 int P,
+                                                 float softcap,
+                                                 KdBackwardArgs kd) {
+    __shared__ float kd_capped[KD_MAX_TOPK_SMEM];
+
+    int idx = static_cast<int>(blockIdx.x);
+    if (idx >= BT) {
+        return;
+    }
+    int ix = targets[idx];
+    if (ix == -100) {
+        for (int i = threadIdx.x; i < V; i += blockDim.x) {
+            dlogits[static_cast<int64_t>(idx) * P + i] = (floatX)0.0f;
+        }
+        return;
+    }
+
+    float lse = 0.0f;
+    if (logsumexp) {
+        lse = logsumexp[idx];
+    } else {
+        SoftmaxParams sp = prepare_softmax_blockwide3(idx, logits, V, P);
+        lse = sp.Offset + logf(1.0f / sp.Scale);
+    }
+    const float lse_tau = kd.lse_tau[idx];
+    const float dloss_val = dloss ? dloss[idx] : 1.0f;
+    const floatX* logits_vec = logits + static_cast<int64_t>(idx) * P;
+    const float inv_softcap = softcap > 0.0f ? 1.0f / softcap : 0.0f;
+    const int64_t kd_base = static_cast<int64_t>(idx) * kd.K;
+
+    // Preserve the capped logit at each teacher id before the dense pass
+    // overwrites the (aliased) logits buffer with gradients.
+    for (int k = threadIdx.x; k < kd.K; k += blockDim.x) {
+        int id = kd.ids[kd_base + k];
+        if (id >= 0 && id < V) {
+            kd_capped[k] = maybe_softcap_value((float)logits_vec[id], softcap);
+        }
+    }
+    __syncthreads();
+
+    for (int i = threadIdx.x; i < V; i += blockDim.x) {
+        float raw = (float)logits_vec[i];
+        float capped = maybe_softcap_value(raw, softcap);
+        float prob = expf(capped - lse);
+        float prob_tau = expf(capped * kd.inv_tau - lse_tau);
+        float indicator = (i == ix) ? 1.0f : 0.0f;
+        float dlogit = (kd.ce_w * (prob - indicator) + kd.kd_scale * prob_tau) * dloss_val;
+        if (softcap > 0.0f) {
+            float y = capped * inv_softcap;
+            dlogit *= 1.0f - y * y;
+        }
+        dlogits[static_cast<int64_t>(idx) * P + i] = (floatX)dlogit;
+    }
+    __syncthreads();
+
+    float kl_partial = 0.0f;
+    for (int k = threadIdx.x; k < kd.K; k += blockDim.x) {
+        int id = kd.ids[kd_base + k];
+        if (id < 0 || id >= V) {
+            continue;
+        }
+        float qk = kd.q[kd_base + k];
+        float capped = kd_capped[k];
+        float sub = kd.kd_scale * qk * dloss_val;
+        if (softcap > 0.0f) {
+            float y = capped * inv_softcap;
+            sub *= 1.0f - y * y;
+        }
+        int64_t out_idx = static_cast<int64_t>(idx) * P + id;
+        dlogits[out_idx] = (floatX)((float)dlogits[out_idx] - sub);
+        kl_partial += qk * (logf(fmaxf(qk, 1e-30f)) - (capped * kd.inv_tau - lse_tau));
+    }
+    if (kd.kd_loss_accum) {
+        float row_kl = blockReduce<warpReduceSum>(kl_partial);
+        if (threadIdx.x == 0) {
+            atomicAdd(kd.kd_loss_accum, kd.tau_sq * row_kl);
+        }
+    }
+}
+
+template <class floatX>
+__global__ void kd_chunked_cross_entropy_backward_kernel(floatX* dlogits,
+                                                         const floatX* logits,
+                                                         const float* logsumexp,
+                                                         const float* dloss,
+                                                         const int* targets,
+                                                         int BT,
+                                                         int V,
+                                                         int P,
+                                                         int chunk_size,
+                                                         float softcap,
+                                                         KdBackwardArgs kd) {
+    __shared__ float kd_capped[KD_MAX_TOPK_SMEM];
+
+    int row_idx = static_cast<int>(blockIdx.x);
+    int block_idx = static_cast<int>(blockIdx.y);
+    int start = block_idx * chunk_size;
+    if (row_idx >= BT || start >= V) {
+        return;
+    }
+    int end = (start + chunk_size < V) ? (start + chunk_size) : V;
+
+    int ix = targets[row_idx];
+    if (ix == -100) {
+        for (int i = start + threadIdx.x; i < end; i += blockDim.x) {
+            dlogits[static_cast<int64_t>(row_idx) * P + i] = (floatX)0.0f;
+        }
+        return;
+    }
+
+    float lse = logsumexp ? logsumexp[row_idx] : 0.0f;
+    const float lse_tau = kd.lse_tau[row_idx];
+    const float dloss_val = dloss ? dloss[row_idx] : 1.0f;
+    const floatX* logits_vec = logits + static_cast<int64_t>(row_idx) * P;
+    const float inv_softcap = softcap > 0.0f ? 1.0f / softcap : 0.0f;
+    const int64_t kd_base = static_cast<int64_t>(row_idx) * kd.K;
+
+    // Each (row, chunk) block owns [start, end) exclusively, so preloading
+    // only the in-range teacher ids is race-free against other chunks.
+    for (int k = threadIdx.x; k < kd.K; k += blockDim.x) {
+        int id = kd.ids[kd_base + k];
+        if (id >= start && id < end) {
+            kd_capped[k] = maybe_softcap_value((float)logits_vec[id], softcap);
+        }
+    }
+    __syncthreads();
+
+    for (int i = start + threadIdx.x; i < end; i += blockDim.x) {
+        float raw = (float)logits_vec[i];
+        float capped = maybe_softcap_value(raw, softcap);
+        float prob = expf(capped - lse);
+        float prob_tau = expf(capped * kd.inv_tau - lse_tau);
+        float indicator = (i == ix) ? 1.0f : 0.0f;
+        float dlogit = (kd.ce_w * (prob - indicator) + kd.kd_scale * prob_tau) * dloss_val;
+        if (softcap > 0.0f) {
+            float y = capped * inv_softcap;
+            dlogit *= 1.0f - y * y;
+        }
+        dlogits[static_cast<int64_t>(row_idx) * P + i] = (floatX)dlogit;
+    }
+    __syncthreads();
+
+    float kl_partial = 0.0f;
+    for (int k = threadIdx.x; k < kd.K; k += blockDim.x) {
+        int id = kd.ids[kd_base + k];
+        if (id < start || id >= end) {
+            continue;
+        }
+        float qk = kd.q[kd_base + k];
+        float capped = kd_capped[k];
+        float sub = kd.kd_scale * qk * dloss_val;
+        if (softcap > 0.0f) {
+            float y = capped * inv_softcap;
+            sub *= 1.0f - y * y;
+        }
+        int64_t out_idx = static_cast<int64_t>(row_idx) * P + id;
+        dlogits[out_idx] = (floatX)((float)dlogits[out_idx] - sub);
+        kl_partial += qk * (logf(fmaxf(qk, 1e-30f)) - (capped * kd.inv_tau - lse_tau));
+    }
+    if (kd.kd_loss_accum) {
+        float row_kl = blockReduce<warpReduceSum>(kl_partial);
+        if (threadIdx.x == 0) {
+            atomicAdd(kd.kd_loss_accum, kd.tau_sq * row_kl);
+        }
+    }
+}
+
+// Renormalize teacher top-K logprobs into probabilities at temperature tau.
+// Entries whose id falls outside the student vocab [0, V) are excluded from
+// the normalization and receive q = 0 — otherwise their probability mass would
+// be counted in the normalizer but never scattered, leaving the KD gradient's
+// vocab-sum non-zero (a uniform drift on every logit of that token).
+__global__ void kd_normalize_teacher_topk_kernel(float* q_out,
+                                                 const float* teacher_logprobs,
+                                                 const int* ids,
+                                                 const int* targets,
+                                                 int BT,
+                                                 int K,
+                                                 int V,
+                                                 float inv_tau) {
+    int row = static_cast<int>(blockIdx.x);
+    if (row >= BT) {
+        return;
+    }
+    const int64_t base = static_cast<int64_t>(row) * K;
+    if (targets[row] == -100) {
+        for (int k = threadIdx.x; k < K; k += blockDim.x) {
+            q_out[base + k] = 0.0f;
+        }
+        return;
+    }
+
+    float thread_max = -INFINITY;
+    for (int k = threadIdx.x; k < K; k += blockDim.x) {
+        int id = ids[base + k];
+        if (id >= 0 && id < V) {
+            thread_max = fmaxf(thread_max, teacher_logprobs[base + k] * inv_tau);
+        }
+    }
+    float block_max = blockReduce<warpReduceMax>(thread_max, true, -INFINITY);
+    if (block_max == -INFINITY) {
+        // No usable teacher entries (all out of range or -inf) — no KD signal.
+        for (int k = threadIdx.x; k < K; k += blockDim.x) {
+            q_out[base + k] = 0.0f;
+        }
+        return;
+    }
+
+    float thread_sum = 0.0f;
+    for (int k = threadIdx.x; k < K; k += blockDim.x) {
+        int id = ids[base + k];
+        if (id >= 0 && id < V) {
+            thread_sum += expf(teacher_logprobs[base + k] * inv_tau - block_max);
+        }
+    }
+    float block_sum = blockReduce<warpReduceSum>(thread_sum, true);
+
+    const float inv_sum = 1.0f / block_sum;
+    for (int k = threadIdx.x; k < K; k += blockDim.x) {
+        int id = ids[base + k];
+        q_out[base + k] =
+            (id >= 0 && id < V) ? expf(teacher_logprobs[base + k] * inv_tau - block_max) * inv_sum : 0.0f;
+    }
+}
+
+// Per-(row, chunk) partial logsumexp of softcapped logits scaled by inv_tau.
+// Final per-row reduction is done by logsumexp_reduce_kernel.
+template <class floatX>
+__global__ void kd_row_chunk_logsumexp_kernel(float* chunk_lse,
+                                              const floatX* logits,
+                                              int BT,
+                                              int V,
+                                              int P,
+                                              int n_chunks,
+                                              int chunk_size,
+                                              float inv_tau,
+                                              float softcap) {
+    int row_idx = static_cast<int>(blockIdx.x);
+    int chunk_idx = static_cast<int>(blockIdx.y);
+    int start = chunk_idx * chunk_size;
+    if (row_idx >= BT || start >= V) {
+        return;
+    }
+    int end = (start + chunk_size < V) ? (start + chunk_size) : V;
+
+    float thread_maxval = -INFINITY;
+    float thread_sumval = 0.0f;
+    for (int i = start + threadIdx.x; i < end; i += blockDim.x) {
+        float v = maybe_softcap_value((float)logits[static_cast<int64_t>(row_idx) * P + i], softcap) * inv_tau;
+        float old_max = thread_maxval;
+        thread_maxval = fmaxf(thread_maxval, v);
+        thread_sumval *= expf(old_max - thread_maxval);
+        thread_sumval += expf(v - thread_maxval);
+    }
+
+    float block_maxval = blockReduce<warpReduceMax>(thread_maxval, false, -INFINITY);
+    thread_sumval *= expf(thread_maxval - block_maxval);
+    float block_sumval = blockReduce<warpReduceSum>(thread_sumval);
+
+    if (threadIdx.x == 0) {
+        chunk_lse[static_cast<int64_t>(row_idx) * n_chunks + chunk_idx] = block_maxval + logf(block_sumval);
+    }
+}
+
 template <class floatX>
 __global__ void
 argmax_correct_kernel(const floatX* logits, const int* targets, int* correct_count, int BT, int V, int P) {
@@ -909,6 +1195,58 @@ void fused_cross_entropy_forward(nv_bfloat16* logits,
     CUDA_CHECK(cudaGetLastError());
 }
 
+namespace {
+
+void validate_kd_args(const KdBackwardArgs* kd) {
+    if (!kd) {
+        return;
+    }
+    assert(kd->ids != nullptr && kd->q != nullptr && kd->lse_tau != nullptr);
+    assert(kd->K > 0 && kd->K <= 1024);
+}
+
+}  // namespace
+
+template <typename Type>
+static void fused_cross_entropy_backward_imp(Type* dlogits,
+                                             const Type* logits,
+                                             const float* logsumexp,
+                                             const float* dloss,
+                                             const int* targets,
+                                             int BT,
+                                             int V,
+                                             int P,
+                                             float softcap,
+                                             cudaStream_t stream,
+                                             const KdBackwardArgs* kd) {
+    const int block_size = 256;
+    const int grid_size = BT;
+    if (kd && kd->ids) {
+        validate_kd_args(kd);
+        kd_cross_entropy_backward_kernel<<<grid_size, block_size, 0, stream>>>(dlogits,
+                                                                               logits,
+                                                                               logsumexp,
+                                                                               dloss,
+                                                                               targets,
+                                                                               BT,
+                                                                               V,
+                                                                               P,
+                                                                               softcap,
+                                                                               *kd);
+    } else {
+        cross_entropy_backward_kernel<<<grid_size, block_size, 0, stream>>>(dlogits,
+                                                                            logits,
+                                                                            logsumexp,
+                                                                            dloss,
+                                                                            targets,
+                                                                            BT,
+                                                                            V,
+                                                                            P,
+                                                                            softcap);
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
 void fused_cross_entropy_backward(float* dlogits,
                                   const float* logits,
                                   const float* logsumexp,
@@ -918,19 +1256,9 @@ void fused_cross_entropy_backward(float* dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream) {
-    const int block_size = 256;
-    const int grid_size = BT;
-    cross_entropy_backward_kernel<<<grid_size, block_size, 0, stream>>>(dlogits,
-                                                                        logits,
-                                                                        logsumexp,
-                                                                        dloss,
-                                                                        targets,
-                                                                        BT,
-                                                                        V,
-                                                                        P,
-                                                                        softcap);
-    CUDA_CHECK(cudaGetLastError());
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd) {
+    fused_cross_entropy_backward_imp(dlogits, logits, logsumexp, dloss, targets, BT, V, P, softcap, stream, kd);
 }
 
 void fused_cross_entropy_backward(nv_bfloat16* dlogits,
@@ -942,19 +1270,9 @@ void fused_cross_entropy_backward(nv_bfloat16* dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream) {
-    const int block_size = 256;
-    const int grid_size = BT;
-    cross_entropy_backward_kernel<<<grid_size, block_size, 0, stream>>>(dlogits,
-                                                                        logits,
-                                                                        logsumexp,
-                                                                        dloss,
-                                                                        targets,
-                                                                        BT,
-                                                                        V,
-                                                                        P,
-                                                                        softcap);
-    CUDA_CHECK(cudaGetLastError());
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd) {
+    fused_cross_entropy_backward_imp(dlogits, logits, logsumexp, dloss, targets, BT, V, P, softcap, stream, kd);
 }
 
 void chunked_cross_entropy_forward(float* logits,
@@ -1041,6 +1359,49 @@ void chunked_cross_entropy_forward(nv_bfloat16* logits,
     }
 }
 
+template <typename Type>
+static void chunked_cross_entropy_backward_imp(Type* dlogits,
+                                               const Type* logits,
+                                               const float* logsumexp,
+                                               const float* dloss,
+                                               const int* targets,
+                                               int BT,
+                                               int V,
+                                               int P,
+                                               float softcap,
+                                               cudaStream_t stream,
+                                               const KdBackwardArgs* kd) {
+    const int block_size = 256;
+    const int n_blocks = (V + CROSS_ENTROPY_BACKWARD_CHUNK_SIZE - 1) / CROSS_ENTROPY_BACKWARD_CHUNK_SIZE;
+    dim3 grid(BT, n_blocks);
+    if (kd && kd->ids) {
+        validate_kd_args(kd);
+        kd_chunked_cross_entropy_backward_kernel<<<grid, block_size, 0, stream>>>(dlogits,
+                                                                                  logits,
+                                                                                  logsumexp,
+                                                                                  dloss,
+                                                                                  targets,
+                                                                                  BT,
+                                                                                  V,
+                                                                                  P,
+                                                                                  CROSS_ENTROPY_BACKWARD_CHUNK_SIZE,
+                                                                                  softcap,
+                                                                                  *kd);
+    } else {
+        chunked_cross_entropy_backward_kernel<<<grid, block_size, 0, stream>>>(dlogits,
+                                                                               logits,
+                                                                               logsumexp,
+                                                                               dloss,
+                                                                               targets,
+                                                                               BT,
+                                                                               V,
+                                                                               P,
+                                                                               CROSS_ENTROPY_BACKWARD_CHUNK_SIZE,
+                                                                               softcap);
+    }
+    CUDA_CHECK(cudaGetLastError());
+}
+
 void chunked_cross_entropy_backward(float* dlogits,
                                     const float* logits,
                                     const float* logsumexp,
@@ -1050,21 +1411,9 @@ void chunked_cross_entropy_backward(float* dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream) {
-    const int block_size = 256;
-    const int n_blocks = (V + CROSS_ENTROPY_BACKWARD_CHUNK_SIZE - 1) / CROSS_ENTROPY_BACKWARD_CHUNK_SIZE;
-    dim3 grid(BT, n_blocks);
-    chunked_cross_entropy_backward_kernel<<<grid, block_size, 0, stream>>>(dlogits,
-                                                                           logits,
-                                                                           logsumexp,
-                                                                           dloss,
-                                                                           targets,
-                                                                           BT,
-                                                                           V,
-                                                                           P,
-                                                                           CROSS_ENTROPY_BACKWARD_CHUNK_SIZE,
-                                                                           softcap);
-    CUDA_CHECK(cudaGetLastError());
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd) {
+    chunked_cross_entropy_backward_imp(dlogits, logits, logsumexp, dloss, targets, BT, V, P, softcap, stream, kd);
 }
 
 void chunked_cross_entropy_backward(nv_bfloat16* dlogits,
@@ -1076,21 +1425,9 @@ void chunked_cross_entropy_backward(nv_bfloat16* dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream) {
-    const int block_size = 256;
-    const int n_blocks = (V + CROSS_ENTROPY_BACKWARD_CHUNK_SIZE - 1) / CROSS_ENTROPY_BACKWARD_CHUNK_SIZE;
-    dim3 grid(BT, n_blocks);
-    chunked_cross_entropy_backward_kernel<<<grid, block_size, 0, stream>>>(dlogits,
-                                                                           logits,
-                                                                           logsumexp,
-                                                                           dloss,
-                                                                           targets,
-                                                                           BT,
-                                                                           V,
-                                                                           P,
-                                                                           CROSS_ENTROPY_BACKWARD_CHUNK_SIZE,
-                                                                           softcap);
-    CUDA_CHECK(cudaGetLastError());
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd) {
+    chunked_cross_entropy_backward_imp(dlogits, logits, logsumexp, dloss, targets, BT, V, P, softcap, stream, kd);
 }
 
 // ----------------------------------------------------------------------------
@@ -1458,4 +1795,81 @@ void launch_softcap_logits_backward_fp32(float* d_logits,
     int grid = static_cast<int>((n + block_size - 1) / block_size);
     softcap_logits_backward_kernel<<<grid, block_size, 0, stream>>>(d_logits, capped, 1.0f / softcap, n);
     CUDA_CHECK(cudaGetLastError());
+}
+
+// ----------------------------------------------------------------------------
+// Knowledge-distillation helper launchers
+
+void kd_normalize_teacher_topk(float* q_out,
+                               const float* teacher_logprobs,
+                               const int* ids,
+                               const int* targets,
+                               int BT,
+                               int K,
+                               int V,
+                               float inv_tau,
+                               cudaStream_t stream) {
+    const int block_size = 128;
+    kd_normalize_teacher_topk_kernel<<<BT, block_size, 0, stream>>>(q_out,
+                                                                    teacher_logprobs,
+                                                                    ids,
+                                                                    targets,
+                                                                    BT,
+                                                                    K,
+                                                                    V,
+                                                                    inv_tau);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+template <typename Type>
+static void kd_row_logsumexp_imp(float* lse_out,
+                                 float* chunk_scratch,
+                                 const Type* logits,
+                                 int BT,
+                                 int V,
+                                 int P,
+                                 int n_chunks,
+                                 float inv_tau,
+                                 float softcap,
+                                 cudaStream_t stream) {
+    const int block_size = 256;
+    dim3 grid(BT, n_chunks);
+    kd_row_chunk_logsumexp_kernel<<<grid, block_size, 0, stream>>>(chunk_scratch,
+                                                                   logits,
+                                                                   BT,
+                                                                   V,
+                                                                   P,
+                                                                   n_chunks,
+                                                                   (V + n_chunks - 1) / n_chunks,
+                                                                   inv_tau,
+                                                                   softcap);
+    CUDA_CHECK(cudaGetLastError());
+    logsumexp_reduce_kernel<<<BT, block_size, 0, stream>>>(lse_out, chunk_scratch, BT, n_chunks);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const float* logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream) {
+    kd_row_logsumexp_imp(lse_out, chunk_scratch, logits, BT, V, P, n_chunks, inv_tau, softcap, stream);
+}
+
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const nv_bfloat16* logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream) {
+    kd_row_logsumexp_imp(lse_out, chunk_scratch, logits, BT, V, P, n_chunks, inv_tau, softcap, stream);
 }

--- a/csrc/src/kernels/kernels.cpp
+++ b/csrc/src/kernels/kernels.cpp
@@ -977,7 +977,8 @@ void fused_cross_entropy_backward(Tensor& dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream) {
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd) {
     const float* lse_ptr = logsumexp ? logsumexp->get<float>() : nullptr;
     const float* dloss_ptr = dloss.get<float>();
     if (dlogits.DType == ETensorDType::FP32) {
@@ -990,7 +991,8 @@ void fused_cross_entropy_backward(Tensor& dlogits,
                                      V,
                                      P,
                                      softcap,
-                                     stream);
+                                     stream,
+                                     kd);
     } else if (dlogits.DType == ETensorDType::BF16) {
         fused_cross_entropy_backward(dlogits.get<nv_bfloat16>(),
                                      logits.get<nv_bfloat16>(),
@@ -1001,7 +1003,8 @@ void fused_cross_entropy_backward(Tensor& dlogits,
                                      V,
                                      P,
                                      softcap,
-                                     stream);
+                                     stream,
+                                     kd);
     } else {
         throw std::runtime_error("fused_cross_entropy_backward: unsupported dtype");
     }
@@ -1068,7 +1071,8 @@ void chunked_cross_entropy_backward(Tensor& dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream) {
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd) {
     const float* lse_ptr = logsumexp ? logsumexp->get<float>() : nullptr;
     if (!lse_ptr) {
         throw std::runtime_error("chunked_cross_entropy_backward: logsumexp buffer is required");
@@ -1084,7 +1088,8 @@ void chunked_cross_entropy_backward(Tensor& dlogits,
                                        V,
                                        P,
                                        softcap,
-                                       stream);
+                                       stream,
+                                       kd);
     } else if (dlogits.DType == ETensorDType::BF16) {
         chunked_cross_entropy_backward(dlogits.get<nv_bfloat16>(),
                                        logits.get<nv_bfloat16>(),
@@ -1095,9 +1100,38 @@ void chunked_cross_entropy_backward(Tensor& dlogits,
                                        V,
                                        P,
                                        softcap,
-                                       stream);
+                                       stream,
+                                       kd);
     } else {
         throw std::runtime_error("chunked_cross_entropy_backward: unsupported dtype");
+    }
+}
+
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const Tensor& logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream) {
+    if (logits.DType == ETensorDType::FP32) {
+        kd_row_logsumexp(lse_out, chunk_scratch, logits.get<float>(), BT, V, P, n_chunks, inv_tau, softcap, stream);
+    } else if (logits.DType == ETensorDType::BF16) {
+        kd_row_logsumexp(lse_out,
+                         chunk_scratch,
+                         logits.get<nv_bfloat16>(),
+                         BT,
+                         V,
+                         P,
+                         n_chunks,
+                         inv_tau,
+                         softcap,
+                         stream);
+    } else {
+        throw std::runtime_error("kd_row_logsumexp: unsupported dtype");
     }
 }
 

--- a/csrc/src/kernels/kernels.h
+++ b/csrc/src/kernels/kernels.h
@@ -1497,6 +1497,75 @@ void fused_classifier(Tensor& logits,
 constexpr int CROSS_ENTROPY_MAX_FUSED_SIZE = 65536;
 constexpr int CROSS_ENTROPY_BACKWARD_CHUNK_SIZE = 4096;
 
+/// Optional knowledge-distillation extension for the cross-entropy backward.
+/// When passed (non-null), the backward computes
+///   dlogit = dloss[t] * (ce_w*(p - onehot) + kd_scale*(p_tau - q_topk_scatter))
+/// where p_tau = softmax(logits/tau) and q is the renormalized teacher top-K
+/// distribution at tau. Pointers are per-token indexed: row t uses
+/// ids[t*K .. t*K+K) / q[t*K ..). `lse_tau` must hold logsumexp(logits/tau)
+/// per row (pass the tau=1 logsumexp when tau == 1). `kd_loss_accum` (may be
+/// null) accumulates tau^2 * KL(q || p_tau) over valid tokens via atomicAdd.
+struct KdBackwardArgs {
+    const int* ids = nullptr;       ///< [BT, K] teacher top-K token ids
+    const float* q = nullptr;       ///< [BT, K] renormalized teacher probs at tau
+    const float* lse_tau = nullptr; ///< [BT] logsumexp of logits/tau
+    float inv_tau = 1.0f;           ///< 1/tau
+    float ce_w = 1.0f;              ///< weight of the CE gradient term
+    float kd_scale = 0.0f;          ///< kd_weight * tau (gradient scale of the KD term)
+    float tau_sq = 1.0f;            ///< tau^2 (KD loss metric scale)
+    float* kd_loss_accum = nullptr; ///< [1] scalar accumulator for the KD loss metric
+    int K = 0;                      ///< top-K entries per token
+};
+
+/// Renormalize per-token teacher top-K logprobs into a probability
+/// distribution at temperature tau: q_k = softmax(logprobs_k * inv_tau).
+/// Entries with ids outside [0, V) are excluded from the normalization and
+/// receive q = 0. Rows with targets[row] == -100 are zero-filled.
+void kd_normalize_teacher_topk(float* q_out,
+                               const float* teacher_logprobs,
+                               const int* ids,
+                               const int* targets,
+                               int BT,
+                               int K,
+                               int V,
+                               float inv_tau,
+                               cudaStream_t stream);
+
+/// Per-row logsumexp of (softcapped) logits scaled by inv_tau.
+/// `chunk_scratch` must hold [BT, n_chunks] floats (scratch); the final
+/// reduction writes lse_out[BT]. Softcap is applied before temperature
+/// scaling, matching the KD backward's p_tau computation.
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const float* logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream);
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const nv_bfloat16* logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream);
+void kd_row_logsumexp(float* lse_out,
+                      float* chunk_scratch,
+                      const Tensor& logits,
+                      int BT,
+                      int V,
+                      int P,
+                      int n_chunks,
+                      float inv_tau,
+                      float softcap,
+                      cudaStream_t stream);
+
 void fused_cross_entropy_forward(float* logits,
                                  float* losses,
                                  float* logsumexp,
@@ -1528,7 +1597,8 @@ void fused_cross_entropy_backward(float* dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream);
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd = nullptr);
 void fused_cross_entropy_backward(nv_bfloat16* dlogits,
                                   const nv_bfloat16* logits,
                                   const float* logsumexp,
@@ -1538,7 +1608,8 @@ void fused_cross_entropy_backward(nv_bfloat16* dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream);
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd = nullptr);
 void chunked_cross_entropy_forward(float* logits,
                                    float* losses,
                                    float* logsumexp,
@@ -1574,7 +1645,8 @@ void chunked_cross_entropy_backward(float* dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream);
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd = nullptr);
 void chunked_cross_entropy_backward(nv_bfloat16* dlogits,
                                     const nv_bfloat16* logits,
                                     const float* logsumexp,
@@ -1584,7 +1656,8 @@ void chunked_cross_entropy_backward(nv_bfloat16* dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream);
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd = nullptr);
 void fused_cross_entropy_forward(Tensor& logits,
                                  Tensor& losses,
                                  Tensor* logsumexp,
@@ -1605,7 +1678,8 @@ void fused_cross_entropy_backward(Tensor& dlogits,
                                   int V,
                                   int P,
                                   float softcap,
-                                  cudaStream_t stream);
+                                  cudaStream_t stream,
+                                  const KdBackwardArgs* kd = nullptr);
 void chunked_cross_entropy_forward(Tensor& logits,
                                    Tensor& losses,
                                    Tensor* logsumexp,
@@ -1628,7 +1702,8 @@ void chunked_cross_entropy_backward(Tensor& dlogits,
                                     int V,
                                     int P,
                                     float softcap,
-                                    cudaStream_t stream);
+                                    cudaStream_t stream,
+                                    const KdBackwardArgs* kd = nullptr);
 
 // --- lmhead_compact: token-row compaction for the lm_head loss path -------
 // Compute valid_idx[n_valid] from targets[BT] in-place; n_valid is written to

--- a/csrc/src/runtime/dsl/dsl_model.h
+++ b/csrc/src/runtime/dsl/dsl_model.h
@@ -75,6 +75,15 @@ struct GrpoNativeMetrics {
     float total_tokens = 0.0f;
 };
 
+/// Configuration for the offline knowledge-distillation step.
+/// Total loss: ce_weight * CE + kd_weight * tau^2 * KL(teacher_topk || student).
+struct KdLossConfig {
+    int top_k = 32;
+    float temperature = 1.0f;
+    float kd_weight = 0.5f;
+    float ce_weight = 0.5f;
+};
+
 class EmptyTensorContainer final : public ITensorContainer {
 public:
     void iterate_tensors(const std::function<void(std::string, const TensorShard&)>&) override {
@@ -390,6 +399,30 @@ public:
                           const float* temperatures_cpu = nullptr,
                           const float* teacher_logprobs_cpu = nullptr);
     GrpoNativeMetrics consume_grpo_native_metrics();
+
+    /// Knowledge-distillation training step: standard SFT forward + backward
+    /// with a top-K teacher signal injected into the fused LM-head loss.
+    /// Unlike the GRPO steps this keeps standard loss semantics: CE losses and
+    /// ValidTokenCount accumulate across micro-steps, gradients are normalized
+    /// by 1/valid_token_count (mUseTokenScale), and get_loss() reports mean CE.
+    ///
+    /// kd_ids_cpu / kd_logprobs_cpu: CPU arrays of shape [B*T*top_k] holding
+    /// the teacher's top-K token ids / raw logprobs, row i aligned with
+    /// targets[i]. The KD loss metric accumulates on device; read it once per
+    /// optimizer step via consume_kd_loss_sum().
+    void step_with_kd(Tensor inputs,
+                      Tensor position_ids,
+                      Tensor targets,
+                      const std::int32_t* kd_ids_cpu,
+                      const float* kd_logprobs_cpu,
+                      int grad_accum_steps,
+                      int micro_step,
+                      NCCLCommunicator& comm,
+                      const KdLossConfig& kd_config);
+
+    /// Rank-local sum of the KD loss over all micro-steps since the last call
+    /// (synchronous D2H read; zeroes the accumulator).
+    float consume_kd_loss_sum();
 
     void init_weights(NCCLCommunicator& comm) override;
     void import_weights(const std::string& file_name, bool allow_cast, NCCLCommunicator& comm) override;

--- a/csrc/src/runtime/dsl/dsl_model_execution.cpp
+++ b/csrc/src/runtime/dsl/dsl_model_execution.cpp
@@ -1020,6 +1020,141 @@ GrpoNativeMetrics DslModel::consume_grpo_native_metrics() {
     return metrics;
 }
 
+void DslModel::step_with_kd(Tensor inputs,
+                            Tensor position_ids,
+                            Tensor targets,
+                            const std::int32_t* kd_ids_cpu,
+                            const float* kd_logprobs_cpu,
+                            int grad_accum_steps,
+                            int micro_step,
+                            NCCLCommunicator& comm,
+                            const KdLossConfig& kd_config) {
+    if (!mExecutor) {
+        throw std::logic_error("DslModel::step_with_kd called before allocate_run_state()");
+    }
+    if (!kd_ids_cpu || !kd_logprobs_cpu) {
+        throw std::invalid_argument("step_with_kd requires teacher top-K ids and logprobs");
+    }
+    if (kd_config.top_k <= 0 || kd_config.top_k > 1024) {
+        throw std::invalid_argument("step_with_kd: top_k must be in [1, 1024]");
+    }
+    if (!(kd_config.temperature > 0.0f) || !std::isfinite(kd_config.temperature)) {
+        throw std::invalid_argument("step_with_kd: temperature must be finite and positive");
+    }
+    if (kd_config.kd_weight < 0.0f || kd_config.ce_weight < 0.0f) {
+        throw std::invalid_argument("step_with_kd: loss weights must be non-negative");
+    }
+
+    auto& rs = *mRunState;
+    cudaStream_t main_stream = rs.MainStream;
+    const int B_val = static_cast<int>(inputs.Sizes[0]);
+    const int T_val = static_cast<int>(inputs.Sizes[1]);
+    const std::size_t bt = static_cast<std::size_t>(B_val) * static_cast<std::size_t>(T_val);
+
+    rs.set_kd_config(kd_config.top_k, static_cast<long>(bt));
+    auto& kd = rs.kd_scratch();
+    const std::size_t count = bt * static_cast<std::size_t>(kd_config.top_k);
+
+    // Standard SFT loss semantics: CE loss / ValidTokenCount accumulate over
+    // micro-steps and grads get 1/valid_token_count via global_norm_sqrt.
+    mUseTokenScale = true;
+
+    if (micro_step == 0) {
+        CUDA_CHECK(cudaMemsetAsync(kd.loss_accum, 0, sizeof(float), main_stream));
+    }
+
+    const int staging_slot = kd.next_slot;
+    kd.next_slot = (kd.next_slot + 1) % DslRunState::KdNativeScratch::kStagingSlots;
+    if (kd.copy_recorded[staging_slot]) {
+        CUDA_CHECK(cudaEventSynchronize(kd.copy_done[staging_slot]));
+    }
+    std::memcpy(kd.host_ids[staging_slot], kd_ids_cpu, count * sizeof(std::int32_t));
+    std::memcpy(kd.host_logprobs[staging_slot], kd_logprobs_cpu, count * sizeof(float));
+    CUDA_CHECK(cudaMemcpyAsync(kd.topk_ids,
+                               kd.host_ids[staging_slot],
+                               count * sizeof(std::int32_t),
+                               cudaMemcpyHostToDevice,
+                               main_stream));
+    CUDA_CHECK(cudaMemcpyAsync(kd.topk_logprobs,
+                               kd.host_logprobs[staging_slot],
+                               count * sizeof(float),
+                               cudaMemcpyHostToDevice,
+                               main_stream));
+    CUDA_CHECK(cudaEventRecord(kd.copy_done[staging_slot], main_stream));
+    kd.copy_recorded[staging_slot] = true;
+
+    mDocMaskingActive =
+        causal_lm_profile().apply_doc_masking(*mExecutor, mOptions, mModelConfig, inputs, position_ids, micro_step);
+
+    if (lora_enabled()) {
+        ensure_lora_run_state(comm, B_val, T_val);
+        if (qlora_enabled() && micro_step == 0 && mQLoRAProvider) {
+            mQLoRAProvider->invalidate_cache();
+        }
+        mLoRARunState->micro_step = micro_step;
+        mLoRARunState->is_training = true;
+    }
+
+    auto stamp_kd_fields = [&](ExecutionRequest& request) {
+        request.kd_topk_ids_gpu = kd.topk_ids;
+        request.kd_topk_logprobs_gpu = kd.topk_logprobs;
+        request.kd_loss_accum_gpu = kd.loss_accum;
+        request.kd_top_k = kd_config.top_k;
+        request.kd_temperature = kd_config.temperature;
+        request.kd_weight = kd_config.kd_weight;
+        request.kd_ce_weight = kd_config.ce_weight;
+    };
+
+    // make_forward_request keeps initialize_loss_buffers = (micro_step == 0)
+    // and reads targets from rs.Targets_CPU — the standard training forward.
+    rs.Targets_CPU = targets;
+    auto forward_request =
+        causal_lm_profile().make_forward_request(rs, mModelConfig, mOptions, inputs, position_ids, micro_step);
+    stamp_kd_fields(forward_request);
+    mExecutor->execute_forward(forward_request, comm);
+
+    if (!lora_enabled()) {
+        auto backward_request =
+            causal_lm_profile()
+                .make_backward_request(rs, mModelConfig, mOptions, inputs, targets, grad_accum_steps, micro_step);
+        stamp_kd_fields(backward_request);
+        mExecutor->execute_backward(backward_request, comm);
+        if (mDocMaskingActive) {
+            mExecutor->clear_doc_masking();
+            mDocMaskingActive = false;
+        }
+        return;
+    }
+
+    mLoRAGrads->start_micro_step(main_stream, micro_step, grad_accum_steps);
+    auto backward_request =
+        causal_lm_profile()
+            .make_backward_request(rs, mModelConfig, mOptions, inputs, targets, grad_accum_steps, micro_step);
+    stamp_kd_fields(backward_request);
+    mExecutor->execute_backward(backward_request, comm);
+    if (mDocMaskingActive) {
+        mExecutor->clear_doc_masking();
+        mDocMaskingActive = false;
+    }
+    mLoRAGrads->end_micro_step(main_stream, comm);
+    internal::record_event_if_not_capturing(rs.BackwardDone, main_stream);
+}
+
+float DslModel::consume_kd_loss_sum() {
+    if (!mRunState) {
+        throw std::logic_error("DslModel::consume_kd_loss_sum called before allocate_run_state()");
+    }
+    auto& rs = *mRunState;
+    auto& kd = rs.kd_scratch();
+    if (!kd.loss_accum) {
+        return 0.0f;
+    }
+    float value = 0.0f;
+    CUDA_CHECK(cudaMemcpy(&value, kd.loss_accum, sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemset(kd.loss_accum, 0, sizeof(float)));
+    return value;
+}
+
 // ---- Debug-only dispatch-PP sub-range parity (BF16 full-FT, resident) ------
 
 std::vector<float> DslModel::dispatch_pp_forward_hidden(Tensor inputs,

--- a/csrc/src/runtime/dsl/dsl_run_state.cpp
+++ b/csrc/src/runtime/dsl/dsl_run_state.cpp
@@ -430,6 +430,7 @@ DslRunState::DslRunState(const PretrainedConfig& config,
 DslRunState::~DslRunState() {
     destroy_cuda_graphs();
     release_cuda_resources();
+    free_kd_scratch();
     if (mMoEStatsDevice) {
         (void)cudaFree(mMoEStatsDevice);
         mMoEStatsDevice = nullptr;
@@ -1340,6 +1341,63 @@ void DslRunState::configure_backward_graphs(bool hooked) {
         }
     }
     mBackwardGraphsHooked = hooked;
+}
+
+void DslRunState::set_kd_config(int top_k, long max_tokens) {
+    if (top_k <= 0 || max_tokens <= 0) {
+        throw std::runtime_error("set_kd_config: top_k and max_tokens must be positive");
+    }
+    if (mKdScratch.topk_ids && mKdScratch.top_k == top_k && mKdScratch.max_tokens >= max_tokens) {
+        return;
+    }
+    free_kd_scratch();
+    const std::size_t count = static_cast<std::size_t>(max_tokens) * static_cast<std::size_t>(top_k);
+    CUDA_CHECK(cudaMalloc(&mKdScratch.topk_ids, count * sizeof(std::int32_t)));
+    CUDA_CHECK(cudaMalloc(&mKdScratch.topk_logprobs, count * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&mKdScratch.loss_accum, sizeof(float)));
+    CUDA_CHECK(cudaMemset(mKdScratch.loss_accum, 0, sizeof(float)));
+    for (int slot = 0; slot < KdNativeScratch::kStagingSlots; ++slot) {
+        CUDA_CHECK(cudaMallocHost(&mKdScratch.host_ids[slot], count * sizeof(std::int32_t)));
+        CUDA_CHECK(cudaMallocHost(&mKdScratch.host_logprobs[slot], count * sizeof(float)));
+        CUDA_CHECK(cudaEventCreateWithFlags(&mKdScratch.copy_done[slot], cudaEventDisableTiming));
+        mKdScratch.copy_recorded[slot] = false;
+    }
+    mKdScratch.next_slot = 0;
+    mKdScratch.top_k = top_k;
+    mKdScratch.max_tokens = max_tokens;
+}
+
+void DslRunState::free_kd_scratch() noexcept {
+    if (mKdScratch.topk_ids) {
+        (void)cudaFree(mKdScratch.topk_ids);
+        mKdScratch.topk_ids = nullptr;
+    }
+    if (mKdScratch.topk_logprobs) {
+        (void)cudaFree(mKdScratch.topk_logprobs);
+        mKdScratch.topk_logprobs = nullptr;
+    }
+    if (mKdScratch.loss_accum) {
+        (void)cudaFree(mKdScratch.loss_accum);
+        mKdScratch.loss_accum = nullptr;
+    }
+    for (int slot = 0; slot < KdNativeScratch::kStagingSlots; ++slot) {
+        if (mKdScratch.host_ids[slot]) {
+            (void)cudaFreeHost(mKdScratch.host_ids[slot]);
+            mKdScratch.host_ids[slot] = nullptr;
+        }
+        if (mKdScratch.host_logprobs[slot]) {
+            (void)cudaFreeHost(mKdScratch.host_logprobs[slot]);
+            mKdScratch.host_logprobs[slot] = nullptr;
+        }
+        if (mKdScratch.copy_done[slot]) {
+            (void)cudaEventDestroy(mKdScratch.copy_done[slot]);
+            mKdScratch.copy_done[slot] = nullptr;
+        }
+        mKdScratch.copy_recorded[slot] = false;
+    }
+    mKdScratch.top_k = 0;
+    mKdScratch.max_tokens = 0;
+    mKdScratch.next_slot = 0;
 }
 
 void DslRunState::set_moe_config(int num_experts, float aux_loss_coef, float z_loss_coef) {

--- a/csrc/src/runtime/dsl/dsl_run_state.h
+++ b/csrc/src/runtime/dsl/dsl_run_state.h
@@ -355,6 +355,30 @@ public:
 
     /// @brief Set MoE config and allocate stats buffers (call once after construction)
     void set_moe_config(int num_experts, float aux_loss_coef, float z_loss_coef);
+
+    /// Knowledge-distillation scratch: device buffers for the top-K teacher
+    /// signal plus pinned staging mirrors (event-synced double buffer, GRPO
+    /// idiom). Lazily sized by set_kd_config on the first step_with_kd call;
+    /// raw allocations are freed in the destructor.
+    struct KdNativeScratch {
+        static constexpr int kStagingSlots = 2;
+        std::int32_t* topk_ids = nullptr;  ///< Device INT32 [max_tokens * top_k]
+        float* topk_logprobs = nullptr;    ///< Device FP32 [max_tokens * top_k]
+        float* loss_accum = nullptr;       ///< Device FP32 [1] KD loss metric accumulator
+        std::int32_t* host_ids[kStagingSlots] = {};  ///< Pinned INT32 [max_tokens * top_k]
+        float* host_logprobs[kStagingSlots] = {};    ///< Pinned FP32 [max_tokens * top_k]
+        cudaEvent_t copy_done[kStagingSlots] = {};
+        bool copy_recorded[kStagingSlots] = {};
+        int next_slot = 0;
+        int top_k = 0;
+        long max_tokens = 0;
+    };
+    /// @brief Allocate (or re-shape) the KD scratch for `top_k` entries over `max_tokens` tokens.
+    void set_kd_config(int top_k, long max_tokens);
+    KdNativeScratch& kd_scratch() {
+        return mKdScratch;
+    }
+
     [[nodiscard]] int moe_num_experts() const {
         return mNumMoEExperts;
     }
@@ -460,6 +484,9 @@ private:
     int mNumMoEExperts = 0;            ///< 0 = not MoE
     float mMoEAuxLossCoef = 0.01f;     ///< Auxiliary loss coefficient
     float mMoEZLossCoef = 0.001f;      ///< Router z-loss coefficient
+
+    KdNativeScratch mKdScratch;
+    void free_kd_scratch() noexcept;
 };
 
 }  // namespace dsl

--- a/csrc/src/runtime/executor/compiled_ops.h
+++ b/csrc/src/runtime/executor/compiled_ops.h
@@ -132,6 +132,19 @@ public:
         mInvTemperatureGpu = request ? request->inv_temperature_gpu : nullptr;
         mCustomDLossGpu = request ? request->custom_dloss_gpu : nullptr;
         mSkippedBackwardTensors = request ? &request->skipped_backward_tensors : nullptr;
+        mKdTopkIdsGpu = request ? request->kd_topk_ids_gpu : nullptr;
+        mKdTopkLogprobsGpu = request ? request->kd_topk_logprobs_gpu : nullptr;
+        mKdLossAccumGpu = request ? request->kd_loss_accum_gpu : nullptr;
+        mKdTopK = request ? request->kd_top_k : 0;
+        mKdTemperature = request ? request->kd_temperature : 1.0f;
+        mKdWeight = request ? request->kd_weight : 0.0f;
+        mKdCeWeight = request ? request->kd_ce_weight : 1.0f;
+    }
+
+    /// True when a knowledge-distillation teacher signal is attached to the
+    /// current execution request.
+    bool kd_active() const {
+        return mKdTopkIdsGpu != nullptr;
     }
 
     /// Set document masking context for Flash Attention varlen dispatch.
@@ -755,6 +768,17 @@ private:
     // Custom per-token d_loss for GRPO backward (null = standard d_loss=1 seeding)
     float* mCustomDLossGpu = nullptr;
     const float* mInvTemperatureGpu = nullptr;
+
+    // Knowledge-distillation teacher context (null = KD inactive). Consumed by
+    // dispatch_fused_lm_head_loss_backward; also gates off the compact row path
+    // (KD + row compaction is unsupported).
+    const std::int32_t* mKdTopkIdsGpu = nullptr;   // [BT, K] teacher top-K ids
+    const float* mKdTopkLogprobsGpu = nullptr;     // [BT, K] raw teacher logprobs
+    float* mKdLossAccumGpu = nullptr;              // [1] KD loss accumulator
+    int mKdTopK = 0;
+    float mKdTemperature = 1.0f;
+    float mKdWeight = 0.0f;
+    float mKdCeWeight = 1.0f;
 
     // --- LM-head row-compaction state (shared across forward/backward) ---
     // Lazily allocated owned device buffers, shared between dispatch_fused_lm_head_loss_compact

--- a/csrc/src/runtime/executor/execution_request.h
+++ b/csrc/src/runtime/executor/execution_request.h
@@ -6,6 +6,7 @@
 #ifndef SUROGATE_SRC_RUNTIME_EXECUTOR_EXECUTION_REQUEST_H
 #define SUROGATE_SRC_RUNTIME_EXECUTOR_EXECUTION_REQUEST_H
 
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -80,6 +81,17 @@ struct ExecutionRequest {
     float* logprobs_gpu = nullptr;
     float* custom_dloss_gpu = nullptr;
     const float* inv_temperature_gpu = nullptr;
+
+    // Knowledge distillation: top-K teacher signal, active when
+    // kd_topk_ids_gpu != nullptr. Set on BOTH forward and backward requests
+    // so the lm-head compact-path gate agrees between the two passes.
+    const std::int32_t* kd_topk_ids_gpu = nullptr;       ///< [B*T, K] teacher top-K token ids
+    const float* kd_topk_logprobs_gpu = nullptr;         ///< [B*T, K] raw teacher logprobs (tau = 1)
+    float* kd_loss_accum_gpu = nullptr;                  ///< [1] KD loss metric accumulator
+    int kd_top_k = 0;
+    float kd_temperature = 1.0f;
+    float kd_weight = 0.0f;
+    float kd_ce_weight = 1.0f;
 
     [[nodiscard]] const RuntimeBinding* find_binding(const std::string& name) const {
         for (const auto& binding : bindings) {

--- a/csrc/src/runtime/ops/fused_lm_head_loss.cpp
+++ b/csrc/src/runtime/ops/fused_lm_head_loss.cpp
@@ -210,7 +210,10 @@ void CompiledExecutor::dispatch_fused_lm_head_loss(const CompiledOp& op) {
     // on-the-fly quantization for the gathered xF_compact / dlogits_compact
     // slices. NOTE: forward and backward gates MUST stay aligned so backward
     // reads the per-valid-row logsumexp the compact forward saved.
-    if (mOptions.SkipIgnoredLMHeadRows && !mLogprobsGpu && xF_flat.DType == ETensorDType::BF16 &&
+    // KD disables row compaction: the compact backward has no teacher-row
+    // gather path. The kd_* request fields are set on both forward and
+    // backward requests so this gate stays aligned with the backward's.
+    if (mOptions.SkipIgnoredLMHeadRows && !mLogprobsGpu && !kd_active() && xF_flat.DType == ETensorDType::BF16 &&
         weight.DType == ETensorDType::BF16) {
         dispatch_fused_lm_head_loss_compact(op);
         return;
@@ -398,8 +401,8 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
     // Dispatch to the compact backward only if the matching forward also took
     // that path (signalled by mLmheadCompactNValid >= 0). Forward and backward
     // gates MUST match — otherwise backward reads stale logsumexp scratch.
-    if (mOptions.SkipIgnoredLMHeadRows && mLmheadCompactNValid >= 0 && xF_flat.DType == ETensorDType::BF16 &&
-        weight.DType == ETensorDType::BF16) {
+    if (mOptions.SkipIgnoredLMHeadRows && !kd_active() && mLmheadCompactNValid >= 0 &&
+        xF_flat.DType == ETensorDType::BF16 && weight.DType == ETensorDType::BF16) {
         dispatch_fused_lm_head_loss_backward_compact(op);
         return;
     }
@@ -454,6 +457,31 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
     const int V = static_cast<int>(weight.Sizes[0]);
     const int C = static_cast<int>(weight.Sizes[1]);
     const int P = V;
+
+    // Knowledge distillation: renormalize the teacher top-K logprobs into a
+    // probability distribution at the distillation temperature, once for the
+    // full BT (nano-chunks below slice into it by token_offset).
+    const bool kd_enabled = kd_active();
+    Tensor kd_q{};
+    if (kd_enabled) {
+        if (mInvTemperatureGpu) {
+            throw std::runtime_error(
+                "fused_lm_head_loss_backward: distillation is not supported with per-token temperatures");
+        }
+        if (mKdTopK <= 0 || mKdTopK > 1024) {
+            throw std::runtime_error("fused_lm_head_loss_backward: kd_top_k must be in [1, 1024]");
+        }
+        kd_q = mRunState.temp_alloc(ETensorDType::FP32, {BT, static_cast<long>(mKdTopK)}, "kd_teacher_q");
+        kd_normalize_teacher_topk(kd_q.get<float>(),
+                                  mKdTopkLogprobsGpu,
+                                  mKdTopkIdsGpu,
+                                  targets.get<int>(),
+                                  static_cast<int>(BT),
+                                  mKdTopK,
+                                  V,
+                                  1.0f / mKdTemperature,
+                                  mRunState.MainStream);
+    }
 
     const int lmhead_chunks = std::max(1, mOptions.LMHeadChunks);
     const long nano_batch_size = BT / static_cast<long>(lmhead_chunks);
@@ -541,6 +569,45 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
             scale_logits_rows(logits, inv_t, static_cast<int>(nano_batch_size), V, P, mRunState.MainStream);
         }
 
+        KdBackwardArgs kd_args;
+        const KdBackwardArgs* kd_ptr = nullptr;
+        Tensor kd_lse_tau{};
+        Tensor kd_lse_scratch{};
+        bool kd_lse_allocated = false;
+        if (kd_enabled) {
+            kd_args.ids = mKdTopkIdsGpu + token_offset * static_cast<long>(mKdTopK);
+            kd_args.q = kd_q.get<float>() + token_offset * static_cast<long>(mKdTopK);
+            kd_args.inv_tau = 1.0f / mKdTemperature;
+            kd_args.ce_w = mKdCeWeight;
+            kd_args.kd_scale = mKdWeight * mKdTemperature;
+            kd_args.tau_sq = mKdTemperature * mKdTemperature;
+            kd_args.kd_loss_accum = mKdLossAccumGpu;
+            kd_args.K = mKdTopK;
+            const bool tau_is_one = std::fabs(mKdTemperature - 1.0f) < 1e-6f;
+            if (tau_is_one && logsumexp) {
+                kd_args.lse_tau = logsumexp->get<float>();
+            } else {
+                const int lse_chunks = (V + CROSS_ENTROPY_MAX_FUSED_SIZE - 1) / CROSS_ENTROPY_MAX_FUSED_SIZE;
+                kd_lse_tau = mRunState.temp_alloc(ETensorDType::FP32, {nano_batch_size}, "kd_lse_tau");
+                kd_lse_scratch = mRunState.temp_alloc(ETensorDType::FP32,
+                                                      {nano_batch_size, static_cast<long>(lse_chunks)},
+                                                      "kd_lse_scratch");
+                kd_lse_allocated = true;
+                kd_row_logsumexp(kd_lse_tau.get<float>(),
+                                 kd_lse_scratch.get<float>(),
+                                 logits,
+                                 static_cast<int>(nano_batch_size),
+                                 V,
+                                 P,
+                                 lse_chunks,
+                                 kd_args.inv_tau,
+                                 fuse_softcap_backward ? op.attrs.softcap : 0.0f,
+                                 mRunState.MainStream);
+                kd_args.lse_tau = kd_lse_tau.get<float>();
+            }
+            kd_ptr = &kd_args;
+        }
+
         if (V > CROSS_ENTROPY_MAX_FUSED_SIZE) {
             chunked_cross_entropy_backward(logits,
                                            logits,
@@ -551,7 +618,8 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
                                            V,
                                            P,
                                            fuse_softcap_backward ? op.attrs.softcap : 0.0f,
-                                           mRunState.MainStream);
+                                           mRunState.MainStream,
+                                           kd_ptr);
         } else {
             fused_cross_entropy_backward(logits,
                                          logits,
@@ -562,7 +630,13 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
                                          V,
                                          P,
                                          fuse_softcap_backward ? op.attrs.softcap : 0.0f,
-                                         mRunState.MainStream);
+                                         mRunState.MainStream,
+                                         kd_ptr);
+        }
+
+        if (kd_lse_allocated) {
+            mRunState.temp_free(kd_lse_scratch);
+            mRunState.temp_free(kd_lse_tau);
         }
 
         if (mInvTemperatureGpu) {
@@ -625,6 +699,10 @@ void CompiledExecutor::dispatch_fused_lm_head_loss_backward(const CompiledOp& op
                        mRunState.MainStream);
             }
         }
+    }
+
+    if (kd_enabled) {
+        mRunState.temp_free(kd_q);
     }
 
     if (need_lm_head) {

--- a/csrc/src/runtime/training/dataloader.cpp
+++ b/csrc/src/runtime/training/dataloader.cpp
@@ -19,6 +19,42 @@
 #include "utilities/tensor.h"
 #include "utilities/philox.h"
 
+namespace {
+
+constexpr char KD_MAGIC[] = {'K', 'D', '.', 'L', 'O', 'G', 'P', '\n'};
+constexpr long KD_HEADER_BYTES = 1024;
+
+// IEEE fp16 -> fp32 (CPU, no CUDA dependency).
+inline float half_bits_to_float(std::uint16_t h) {
+    const std::uint32_t sign = static_cast<std::uint32_t>(h & 0x8000u) << 16;
+    std::uint32_t exponent = (h >> 10) & 0x1Fu;
+    std::uint32_t mantissa = h & 0x3FFu;
+    std::uint32_t bits;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            bits = sign;
+        } else {
+            // subnormal: normalize
+            exponent = 127 - 15 + 1;
+            while ((mantissa & 0x400u) == 0) {
+                mantissa <<= 1;
+                --exponent;
+            }
+            mantissa &= 0x3FFu;
+            bits = sign | (exponent << 23) | (mantissa << 13);
+        }
+    } else if (exponent == 0x1Fu) {
+        bits = sign | 0x7F800000u | (mantissa << 13);
+    } else {
+        bits = sign | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+    }
+    float out;
+    std::memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+}  // namespace
+
 /**
  * @brief Construct a DataLoader from a glob pattern.
  *
@@ -183,6 +219,84 @@ DataLoader::TokenFileInfo DataLoader::parse_token_file_header(const std::string&
 }
 
 /**
+ * @brief Validate the KD sidecar header for one token file.
+ *
+ * The sidecar `<token_file>.kd` layout: 1024-byte header (magic "KD.LOGP\n",
+ * int32 fields: [2] version, [3] k, [4] n_tokens, [5] vocab_size,
+ * [6] logprob_dtype 0=fp16), then n_tokens*k uint32 ids and n_tokens*k fp16
+ * logprobs as two contiguous blocks. Row i holds the teacher's next-token
+ * distribution at input position i (aligned with targets[i]).
+ */
+void DataLoader::validate_kd_sidecar(const TokenFileInfo& token_info, int expected_k) {
+    const std::string kd_name = token_info.FileName + ".kd";
+    std::ifstream kd_file(kd_name, std::ios::binary);
+    if (!kd_file.is_open() || !kd_file.good()) {
+        throw std::runtime_error(
+            fmt::format("Missing KD sidecar '{}'. Run `surogate distill-capture <config>` to create teacher "
+                        "logit sidecars for the tokenized dataset.",
+                        kd_name));
+    }
+    int header[256];
+    kd_file.read(reinterpret_cast<char*>(header), sizeof(header));
+    if (kd_file.gcount() != static_cast<std::streamsize>(sizeof(header)) ||
+        std::memcmp(header, KD_MAGIC, sizeof(KD_MAGIC)) != 0) {
+        throw std::runtime_error(fmt::format("Invalid KD sidecar header in '{}'", kd_name));
+    }
+    if (header[2] != 1) {
+        throw std::runtime_error(fmt::format("Unsupported KD sidecar version {} in '{}'", header[2], kd_name));
+    }
+    if (header[3] != expected_k) {
+        throw std::runtime_error(fmt::format(
+            "KD sidecar '{}' was captured with top_k={} but the run is configured with top_k={}. Re-run "
+            "distill-capture or adjust distillation.top_k.",
+            kd_name,
+            header[3],
+            expected_k));
+    }
+    if (header[4] != token_info.NumTokens) {
+        throw std::runtime_error(fmt::format(
+            "KD sidecar '{}' holds {} tokens but token shard has {}. The dataset was re-tokenized after "
+            "capture; re-run distill-capture.",
+            kd_name,
+            header[4],
+            token_info.NumTokens));
+    }
+    if (header[6] != 0) {
+        throw std::runtime_error(fmt::format("Unsupported KD logprob dtype {} in '{}'", header[6], kd_name));
+    }
+    if (header[5] <= 0) {
+        throw std::runtime_error(fmt::format("KD sidecar '{}' has invalid vocab_size {}", kd_name, header[5]));
+    }
+}
+
+/**
+ * @brief Enable KD sidecar loading: validate a sidecar for every token file and
+ * open the one belonging to the currently active file.
+ */
+void DataLoader::enable_kd(int expected_k) {
+    if (expected_k <= 0 || expected_k > 1024) {
+        throw std::runtime_error("enable_kd: expected_k must be in [1, 1024]");
+    }
+    for (const auto& info : mFileInfos) {
+        validate_kd_sidecar(info, expected_k);
+    }
+    mKdTopK = expected_k;
+    open_kd_sidecar_for_current_file();
+}
+
+void DataLoader::open_kd_sidecar_for_current_file() {
+    if (mKdTopK <= 0 || mFileIndex < 0 || mFileIndex >= static_cast<std::int32_t>(mShuffledFiles.size())) {
+        return;
+    }
+    const std::string kd_name = mShuffledFiles.at(mFileIndex)->FileName + ".kd";
+    mKdFile = std::ifstream(kd_name, std::ios::binary);
+    if (!mKdFile.is_open() || !mKdFile.good()) {
+        throw std::runtime_error("Could not open KD sidecar: " + kd_name);
+    }
+    mKdFile.exceptions(std::ifstream::failbit);
+}
+
+/**
  * @brief Compute loader progress through the current epoch as a percentage.
  *
  * Progress is measured as (tokens consumed so far in the epoch) / (total tokens across all files).
@@ -255,6 +369,7 @@ bool DataLoader::advance_file() {
         throw std::runtime_error("Could not open token file: " + file_name);
     }
     mTokenFile.exceptions(std::ifstream::failbit);
+    open_kd_sidecar_for_current_file();
 
     shuffle_chunks();
 
@@ -313,7 +428,7 @@ std::int32_t DataLoader::chunk_index() const {
  *
  * @throws std::runtime_error On size/device mismatch, end-of-data, incomplete reads, or underlying I/O errors.
  */
-void DataLoader::load_seq(Tensor& inputs, Tensor& targets, Tensor* position_ids) {
+void DataLoader::load_seq(Tensor& inputs, Tensor& targets, Tensor* position_ids, Tensor* kd_ids, Tensor* kd_logprobs) {
     assert(inputs.Device == -1);
     assert(targets.Device == -1);
     if (inputs.nelem() != mSeqLen) {
@@ -386,6 +501,44 @@ void DataLoader::load_seq(Tensor& inputs, Tensor& targets, Tensor* position_ids)
             }
         }
 
+        if (kd_ids != nullptr || kd_logprobs != nullptr) {
+            if (mKdTopK <= 0) {
+                throw std::runtime_error("load_seq: KD buffers passed but enable_kd() was not called");
+            }
+            if (kd_ids == nullptr || kd_logprobs == nullptr) {
+                throw std::runtime_error("load_seq: kd_ids and kd_logprobs must be passed together");
+            }
+            assert(kd_ids->Device == -1);
+            assert(kd_logprobs->Device == -1);
+            const long k = mKdTopK;
+            const long n = static_cast<long>(mSeqLen) * k;
+            if (kd_ids->nelem() != n || kd_logprobs->nelem() != n) {
+                throw std::runtime_error(fmt::format(
+                    "load_seq: expected KD tensors of {} elements, got {} / {}", n, kd_ids->nelem(), kd_logprobs->nelem()));
+            }
+
+            // Sidecar row i is aligned with input position i (targets[i]), so
+            // the chunk's rows are exactly [chunk_pos, chunk_pos + seq_len).
+            const long ids_offset = KD_HEADER_BYTES + 4L * k * chunk_pos;
+            mKdFile.seekg(ids_offset, std::ios::beg);
+            mKdFile.read(reinterpret_cast<char*>(kd_ids->Data), n * 4);
+            if (mKdFile.gcount() != static_cast<std::streamsize>(n * 4)) {
+                throw std::runtime_error("Incomplete read of KD sidecar ids");
+            }
+
+            const long lp_offset = KD_HEADER_BYTES + 4L * k * file_info->NumTokens + 2L * k * chunk_pos;
+            mKdHalfBuffer.resize(n);
+            mKdFile.seekg(lp_offset, std::ios::beg);
+            mKdFile.read(reinterpret_cast<char*>(mKdHalfBuffer.data()), n * 2);
+            if (mKdFile.gcount() != static_cast<std::streamsize>(n * 2)) {
+                throw std::runtime_error("Incomplete read of KD sidecar logprobs");
+            }
+            float* lp_out = kd_logprobs->get<float>();
+            for (long i = 0; i < n; ++i) {
+                lp_out[i] = half_bits_to_float(mKdHalfBuffer[i]);
+            }
+        }
+
         if (file_info->HasMasks) {
             long masks_start = element_size * file_info->NumTokens + header_offset;
             if (file_info->Version >= 3) {
@@ -428,17 +581,28 @@ void DataLoader::load_seq(Tensor& inputs, Tensor& targets, Tensor* position_ids)
  *
  * @throws std::runtime_error If sharding or underlying sequence loading fails.
  */
-void DataLoader::load_batch(Tensor& inputs, Tensor& targets, Tensor* position_ids) {
+void DataLoader::load_batch(Tensor& inputs, Tensor& targets, Tensor* position_ids, Tensor* kd_ids, Tensor* kd_logprobs) {
     int batch_size = div_exact((int)inputs.nelem(), mSeqLen);
     for (int i = 0; i < batch_size; ++i) {
         Tensor bi = shard_view(inputs, i, batch_size);
         Tensor bt = shard_view(targets, i, batch_size);
+        Tensor bp{};
+        Tensor bki{};
+        Tensor bkl{};
+        Tensor* bp_ptr = nullptr;
+        Tensor* bki_ptr = nullptr;
+        Tensor* bkl_ptr = nullptr;
         if (position_ids) {
-            Tensor bp = shard_view(*position_ids, i, batch_size);
-            load_seq(bi, bt, &bp);
-        } else {
-            load_seq(bi, bt, nullptr);
+            bp = shard_view(*position_ids, i, batch_size);
+            bp_ptr = &bp;
         }
+        if (kd_ids && kd_logprobs) {
+            bki = shard_view(*kd_ids, i, batch_size);
+            bkl = shard_view(*kd_logprobs, i, batch_size);
+            bki_ptr = &bki;
+            bkl_ptr = &bkl;
+        }
+        load_seq(bi, bt, bp_ptr, bki_ptr, bkl_ptr);
     }
 }
 
@@ -456,6 +620,24 @@ void DataLoader::load_batch(Tensor& inputs, Tensor& targets, Tensor* position_id
 void DataLoader::set_state(std::uint64_t seed, std::int32_t epoch, std::int32_t file_index, std::int32_t chunk_index) {
     mSeed = seed;
     mEpoch = epoch;
+    // Recompute all derived state exactly as advance_epoch/advance_file do:
+    // the shuffled file order depends on (seed, epoch), and the token/sidecar
+    // streams plus the chunk shuffle must follow the restored file index —
+    // otherwise reads use the previously-open file's bytes with the restored
+    // file's metadata.
+    shuffle_files();
+    if (file_index < 0 || file_index >= static_cast<std::int32_t>(mShuffledFiles.size())) {
+        throw std::runtime_error(
+            fmt::format("set_state: file_index {} out of range [0, {})", file_index, mShuffledFiles.size()));
+    }
     mFileIndex = file_index;
+    const std::string& file_name = mShuffledFiles.at(mFileIndex)->FileName;
+    mTokenFile = std::ifstream(file_name, std::ios::binary);
+    if (!mTokenFile.is_open() || !mTokenFile.good()) {
+        throw std::runtime_error("Could not open token file: " + file_name);
+    }
+    mTokenFile.exceptions(std::ifstream::failbit);
+    open_kd_sidecar_for_current_file();
+    shuffle_chunks();
     mChunkIndex = chunk_index + mRank;
 }

--- a/csrc/src/runtime/training/dataloader.h
+++ b/csrc/src/runtime/training/dataloader.h
@@ -48,9 +48,30 @@ public:
     static std::vector<std::string> match_files(const std::string& pattern);
 
     //! Fills `inputs` and `targets` with the next chunk of token indices, where targets is shifted left by one position.
-    void load_seq(Tensor& inputs, Tensor& targets, Tensor* position_ids = nullptr);
+    //! When KD is enabled (enable_kd), `kd_ids`/`kd_logprobs` (shape [seq_len * k], INT32/FP32) receive the
+    //! teacher top-K signal for the chunk; sidecar row i is aligned with targets[i].
+    void load_seq(Tensor& inputs,
+                  Tensor& targets,
+                  Tensor* position_ids = nullptr,
+                  Tensor* kd_ids = nullptr,
+                  Tensor* kd_logprobs = nullptr);
     //! Fills `inputs` and `targets` with a batch of sequences
-    void load_batch(Tensor& inputs, Tensor& targets, Tensor* position_ids = nullptr);
+    void load_batch(Tensor& inputs,
+                    Tensor& targets,
+                    Tensor* position_ids = nullptr,
+                    Tensor* kd_ids = nullptr,
+                    Tensor* kd_logprobs = nullptr);
+
+    //! Enable knowledge-distillation sidecar loading. For every token file `<name>` a sidecar
+    //! `<name>.kd` must exist with matching token count and `expected_k` top-K entries per token.
+    //! Throws with an actionable message listing missing or mismatched sidecars.
+    void enable_kd(int expected_k);
+    bool has_kd() const {
+        return mKdTopK > 0;
+    }
+    int kd_top_k() const {
+        return mKdTopK;
+    }
 
     //! Increment the epoch counter, reset the iterators, and re-shuffle the files and chunks.
     void advance_epoch();
@@ -117,6 +138,9 @@ private:
 
     static TokenFileInfo parse_token_file_header(const std::string& file_name);
 
+    void open_kd_sidecar_for_current_file();
+    static void validate_kd_sidecar(const TokenFileInfo& token_info, int expected_k);
+
     // immutable config
     std::int32_t mVocabSize = -1;
     std::int32_t mSeqLen;
@@ -140,6 +164,11 @@ private:
 
     // buffers
     std::vector<std::uint8_t> mMaskBuffer;
+
+    // Knowledge-distillation sidecar state (inactive unless enable_kd was called)
+    int mKdTopK = 0;
+    std::ifstream mKdFile;
+    std::vector<std::uint16_t> mKdHalfBuffer;
 };
 
 #endif  //SUROGATE_TRAINING_DATALOADER_H

--- a/csrc/src/runtime/training/logging.cpp
+++ b/csrc/src/runtime/training/logging.cpp
@@ -253,6 +253,37 @@ void TrainingRunLogger::log_step(int step,
                                  float norm,
                                  float loss,
                                  float lr) {
+    log_step_impl(step, epoch, step_tokens, duration_ms, norm, loss, lr, "", "");
+}
+
+void TrainingRunLogger::log_step_kd(int step,
+                                    float epoch,
+                                    int step_tokens,
+                                    int duration_ms,
+                                    float norm,
+                                    float loss,
+                                    float lr,
+                                    float kd_loss) {
+    log_step_impl(step,
+                  epoch,
+                  step_tokens,
+                  duration_ms,
+                  norm,
+                  loss,
+                  lr,
+                  fmt::format(" | kd {:6.4f}", kd_loss),
+                  fmt::format(R"(, "kd_loss": {})", sanitize_float_for_json(kd_loss)));
+}
+
+void TrainingRunLogger::log_step_impl(int step,
+                                      float epoch,
+                                      int step_tokens,
+                                      int duration_ms,
+                                      float norm,
+                                      float loss,
+                                      float lr,
+                                      const std::string& extra_console,
+                                      const std::string& extra_json) {
     if (mRank != 0) return;
     mTotalTrainingLoss += loss;
     ++mTotalTrainingSteps;
@@ -318,7 +349,7 @@ void TrainingRunLogger::log_step(int step,
 
         std::string phase_str = mPhase.empty() ? "" : fmt::format(" | {}", mPhase);
 
-        printf(":: step %7d [%5.1f%%] %c loss %6.4f | norm %c%6.4f | %5.1fk tps | %5d ms%s%s%s\n",
+        printf(":: step %7d [%5.1f%%] %c loss %6.4f | norm %c%6.4f | %5.1fk tps | %5d ms%s%s%s%s\n",
                step,
                progress,
                trend,
@@ -327,6 +358,7 @@ void TrainingRunLogger::log_step(int step,
                norm,
                tps / 1000.0f,
                duration_ms,
+               extra_console.c_str(),
                sol_str.c_str(),
                eta_str.c_str(),
                phase_str.c_str());
@@ -335,7 +367,7 @@ void TrainingRunLogger::log_step(int step,
 
     std::string phase_json = mPhase.empty() ? "" : fmt::format(R"(, "phase": "{}")", mPhase);
     log_line(fmt::format(
-        R"(  {{"log": "step", "time": "{}", "step": {}, "epoch": {}, "step_tokens": {}, "duration_ms": {}, "norm": {}, "loss": {}, "lr": {}{}}})",
+        R"(  {{"log": "step", "time": "{}", "step": {}, "epoch": {}, "step_tokens": {}, "duration_ms": {}, "norm": {}, "loss": {}, "lr": {}{}{}}})",
         std::chrono::system_clock::now(),
         step,
         epoch,
@@ -344,6 +376,7 @@ void TrainingRunLogger::log_step(int step,
         sanitize_float_for_json(norm),
         sanitize_float_for_json(loss),
         sanitize_float_for_json(lr),
+        extra_json,
         phase_json));
 }
 

--- a/csrc/src/runtime/training/logging.h
+++ b/csrc/src/runtime/training/logging.h
@@ -58,6 +58,17 @@ public:
     void log_gpu_model(NCCLCommunicator& comm);
     void log_dataset(const DataLoader& train_loader, const DataLoader& eval_loader);
     void log_step(int step, float epoch, int step_tokens, int duration_ms, float norm, float loss, float lr);
+    /// log_step variant for knowledge-distillation runs: adds a "kd_loss"
+    /// field to the step JSON line (picked up by all reporters) and the
+    /// console progress line.
+    void log_step_kd(int step,
+                     float epoch,
+                     int step_tokens,
+                     int duration_ms,
+                     float norm,
+                     float loss,
+                     float lr,
+                     float kd_loss);
     void log_step(int step,
                   float epoch,
                   int step_tokens,
@@ -120,6 +131,15 @@ public:
 
 private:
     void log_line(std::string_view line);
+    void log_step_impl(int step,
+                       float epoch,
+                       int step_tokens,
+                       int duration_ms,
+                       float norm,
+                       float loss,
+                       float lr,
+                       const std::string& extra_console,
+                       const std::string& extra_json);
     std::string mFileName;
     std::fstream mLogFile;
     bool mFirst = true;

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -16,6 +16,12 @@ Fine-tuning examples for chat and instruction models.
 - **[Qwen 3 QLoRA (FP4/FP8)](examples/sft/qwen3-qlora.md)**: Memory-efficient fine-tuning using quantization on modern GPUs.
 - **[Qwen 3 MoE (QLoRA)](examples/sft/qwen3moe-lora.md)**: Fine-tuning Mixture-of-Experts models.
 
+## Knowledge Distillation (KD)
+
+Offline top-K logit distillation on the SFT path: capture teacher logprobs once, then train the student.
+
+- **Qwen 3 KD (BF16)**: `examples/distillation/qwen3-kd.yaml` — Qwen3-1.7B teacher distilled into a Qwen3-0.6B student (run `surogate distill-capture`, then `surogate sft`). See the [Knowledge Distillation guide](../guides/distillation.md).
+
 ## How to use these examples
 
 All examples are provided as YAML configuration files. You can run them using the Surogate CLI:

--- a/docs/getting-started/quickstart-sft.md
+++ b/docs/getting-started/quickstart-sft.md
@@ -222,6 +222,7 @@ sequence_len: 2048
 ## Notes
 
 - For private Hugging Face models/datasets, pass `--hub_token`.
+- To distill a larger teacher model into the student during SFT, add a `distillation:` block and run `surogate distill-capture` before `surogate sft` — see the [Knowledge Distillation guide](../guides/distillation.md).
 
 ## See also
 

--- a/docs/getting-started/training-modes.md
+++ b/docs/getting-started/training-modes.md
@@ -21,6 +21,7 @@ They differ in *which parameters are updated*, *how much data you need*, and *ho
 | Fast adaptation, smaller GPU, cheaper runs, easy iteration | **LoRA** |
 | Same as LoRA but you’re VRAM-limited | **QLoRA** |
 | Improve reasoning, math, coding via reward-based training | **GRPO** |
+| Compress a larger model into a smaller one from the same family | **SFT + [Knowledge Distillation](../guides/distillation.md)** |
 
 ---
 
@@ -159,5 +160,6 @@ surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml
 - [Configuration](../guides/configuration.md)
 - [Precision & recipes](../guides/precision-and-recipes.md)
 - [QLoRA](../guides/qlora.md)
+- [Knowledge Distillation](../guides/distillation.md)
 - [Config reference](../reference/config.md)
 - [Back to docs index](../index.mdx)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -6,6 +6,7 @@ Surogate is driven by a YAML config file.
 
 - SFT examples live in `examples/sft/`
 - Pretraining examples live in `examples/pt/`
+- Knowledge-distillation examples live in `examples/distillation/`
 
 Run via CLI:
 
@@ -14,6 +15,8 @@ surogate sft path/to/config.yaml
 # or
 surogate pt path/to/config.yaml
 ```
+
+To distill a larger teacher into the student during SFT, add a `distillation:` block and run `surogate distill-capture` before `surogate sft` — see [Knowledge Distillation](distillation.md).
 
 ## What to edit first
 
@@ -29,4 +32,5 @@ For most runs you’ll edit:
 
 - [Config reference](../reference/config.md)
 - [Datasets](datasets.md)
+- [Knowledge Distillation](distillation.md)
 - [Back to docs index](../index.mdx)

--- a/docs/guides/distillation.md
+++ b/docs/guides/distillation.md
@@ -1,0 +1,255 @@
+# Knowledge Distillation
+
+Surogate supports **offline top-K logit distillation** on the SFT path: a larger *teacher* model is run once over your tokenized training data, its top-K next-token log-probabilities are stored on disk, and the *student* then trains against a combined cross-entropy + KL loss that pulls its output distribution towards the teacher's.
+
+Because the teacher runs offline (once, before training), the training loop itself pays no teacher-inference cost — the teacher signal is streamed from disk by the native DataLoader alongside the token shards.
+
+**Hard requirement: the teacher and student must share a tokenizer.** The sidecar stores teacher-vocab token ids against the student's token stream. Distilling within a model family (e.g. Qwen3-1.7B → Qwen3-0.6B) satisfies this. For teachers with a different tokenizer, see [Cross-tokenizer distillation](#cross-tokenizer-distillation) — a vocabulary transplant turns it into a same-tokenizer setup.
+
+## When to use it
+
+- **Compressing a model**: transfer a large model's behavior into a smaller, cheaper one from the same family.
+- **Better soft targets**: the teacher's full next-token distribution carries more signal per token than the one-hot label, which typically improves small-model quality on the same data.
+- **Pure distillation on unlabeled text**: with `kd_weight: 1.0` and `ce_weight: 0.0`, the labels only select which positions are trained; the training signal is entirely the teacher's.
+
+## Two-step workflow
+
+Both steps read the **same config file** — one with a `distillation:` block:
+
+```bash
+# Step 1: run the teacher over the tokenized shards, write .kd sidecars
+surogate distill-capture config.yaml
+
+# Step 2: train the student against the sidecars
+surogate sft config.yaml
+```
+
+`distill-capture` tokenizes the datasets first if the shards are missing or stale (the same hash-cached flow `surogate sft` uses), then writes one `train-NNN.bin.kd` sidecar next to each `{output_dir}/train-NNN.bin` token shard. Shards that already have a valid sidecar are skipped, so an interrupted capture can simply be re-run.
+
+### Capture CLI flags
+
+```bash
+surogate distill-capture config.yaml [--api-base URL] [--device cuda:0] [--allow-cross-doc-attention] [--hub_token TOKEN]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--api-base` | none | OpenAI-compatible base URL of a served teacher (e.g. `http://localhost:8000/v1`); overrides `distillation.teacher_api_base` and switches capture to the API backend (below). |
+| `--device` | `cuda:0` | Device to run the local teacher model on (e.g. `cuda:1`). Ignored with a warning in API mode. |
+| `--allow-cross-doc-attention` | off | Local backend only: allow the `sdpa` fallback when flash-attention-2 is unavailable. Packed documents will then attend across document boundaries during capture (an approximation). Ignored with a warning in API mode. |
+| `--hub_token` | none | Hugging Face token for private model access |
+
+By default the teacher is loaded locally with `transformers` in bf16. The local backend **requires flash-attention-2** for per-document attention isolation of packed samples (the shard's per-document `position_ids` resets drive varlen attention); without flash-attn it errors out unless you pass `--allow-cross-doc-attention`.
+
+### Remote teacher (vLLM API)
+
+Setting `distillation.teacher_api_base` (or passing `--api-base`) switches capture to an **OpenAI-compatible vLLM server** instead of loading the teacher locally — useful when the teacher does not fit next to your capture GPU. In this mode `distillation.teacher_model` is the **served model name**.
+
+```bash
+# serve the teacher (must expose at least top_k prompt logprobs)
+vllm serve Qwen/Qwen3-32B --max-logprobs 64
+
+# capture against it
+surogate distill-capture config.yaml --api-base http://localhost:8000/v1
+```
+
+How it works: capture sends **token-id prompts** through vLLM's `prompt_logprobs` completions extension — one request per packed document (split at the shard's position-id resets, with a one-token lookahead), which gives **exact per-document context isolation with no flash-attn requirement**. Up to `teacher_api_concurrency` requests are in flight at once (default 8), each with a `teacher_api_timeout` of 1200 s; transient failures (transport errors, HTTP 429/5xx) are retried 3 times with backoff. The API key is read from the environment variable named by `teacher_api_key_var` (default `VLLM_API_KEY`); if unset, `EMPTY` is sent, which local unauthenticated vLLM servers accept.
+
+Two hard requirements:
+
+- The server **must be started with `--max-logprobs >= distillation.top_k`**, or capture aborts with: `The server at <url> returned only <N> prompt_logprobs candidates but distillation.top_k=<K>; restart the vLLM server with --max-logprobs >= <K>.`
+- It must be a **vLLM-compatible server, not an aggregator**. OpenAI-compatible aggregators/providers (e.g. OpenRouter) do not expose per-position prompt logprobs or token-id prompts; capture fails with: `The server at <url> did not return prompt_logprobs. distill-capture requires a vLLM-compatible inference server started with --max-logprobs >= <K>, serving a teacher that SHARES the student's tokenizer.`
+
+## Configuration reference
+
+```yaml
+model: Qwen/Qwen3-0.6B          # the student
+
+distillation:
+  teacher_model: Qwen/Qwen3-1.7B
+  top_k: 64
+  temperature: 1.0
+  kd_weight: 0.5
+```
+
+The `distillation:` block:
+
+| Option | Type | Default | Used by | Description |
+|--------|------|---------|---------|-------------|
+| `teacher_model` | str | `null` | capture | Teacher model id or path. Required by `distill-capture`; ignored at train time. |
+| `top_k` | int | `32` | both | Number of teacher logprobs stored per token. Must be in `[1, 1024]` and not exceed the teacher vocab size. Training validates that the sidecars were captured with exactly this value. |
+| `temperature` | float | `1.0` | train | Distillation temperature τ. Must be > 0. |
+| `kd_weight` | float | `0.5` | train | Weight of the KD (KL) term. Must be ≥ 0. |
+| `ce_weight` | float | `1 - kd_weight` | train | Weight of the CE term. Must be ≥ 0. When `kd_weight > 1` the default would be negative, so `ce_weight` must then be set explicitly. |
+| `teacher_batch_size` | int | `4` | capture | Local backend only: windows of `sequence_len` tokens per teacher forward pass during capture. Must be ≥ 1. Raise it until the teacher fills its GPU. |
+| `kd_dir` | str | `null` | both | Sidecar directory override (default: alongside the token shards). The trainer validates the sidecars there and bridges them to the native DataLoader with `<shard>.kd` symlinks automatically. |
+| `teacher_api_base` | str | `null` | capture | OpenAI-compatible base URL of a served teacher (e.g. `http://localhost:8000/v1`). When set, capture queries the API instead of loading `teacher_model` locally — see [Remote teacher](#remote-teacher-vllm-api). |
+| `teacher_api_key_var` | str | `"VLLM_API_KEY"` | capture | Name of the environment variable holding the API key. Empty/unset resolves to `EMPTY` (accepted by local vLLM servers). |
+| `teacher_api_concurrency` | int | `8` | capture | Concurrent in-flight capture requests in API mode. Must be ≥ 1. |
+| `teacher_api_timeout` | int | `1200` | capture | Per-request timeout in seconds in API mode. Must be ≥ 1. |
+
+Enabling distillation also changes a few top-level behaviors automatically (logged at startup):
+
+- `use_cuda_graphs` is forced to `false` — KD micro-steps run eagerly in v1.
+- `lmhead_drop_ignored_rows` is forced to `false` — the compact LM-head row path does not support KD in v1.
+
+## The loss
+
+Per valid token *t* (i.e. `target != -100`), with student logits *z*:
+
+```
+L_t = ce_weight · CE_t  +  kd_weight · τ² · KL(q ‖ p_τ)
+```
+
+where
+
+- `CE_t = -log softmax(z)[target_t]` — the standard cross-entropy, at temperature 1;
+- `p_τ = softmax(z / τ)` — the student distribution at temperature τ;
+- `q` — the teacher's stored top-K logprobs `lp`, renormalized over the K entries at temperature τ: `q_k = exp(lp_k/τ) / Σ_j exp(lp_j/τ)`.
+
+Probability mass outside the teacher's top-K is dropped and the top-K renormalized to sum to 1 (the "zero" missing-mass policy, DistillKit's default). The `τ²` factor keeps gradient magnitudes comparable across temperatures. The loss is a mean over valid tokens; masked positions (`target == -100`, e.g. prompt tokens in completion-only SFT) contribute nothing to either term.
+
+The KD term is fused into the LM-head cross-entropy backward kernel, so there is no extra logit materialization or separate KD pass.
+
+## Choosing hyperparameters
+
+- **`top_k` (32–128)**: how much of the teacher distribution is preserved. `32` already captures the bulk of the mass for a confident teacher; `64` is a good default trade-off; go to `128` for high-entropy targets or when using higher temperatures (a flatter teacher puts more mass outside a small top-K, and renormalization discards it). Storage scales linearly with K (see below).
+- **`temperature` (1–2)**: `1.0` matches the teacher distribution as-is; `1.5`–`2.0` softens both distributions, giving the "dark knowledge" in near-miss tokens more gradient weight. Values much above 2 interact poorly with top-K truncation because the renormalization drops an increasingly large tail.
+- **`kd_weight` / `ce_weight`**: the default `kd_weight: 0.5` (with `ce_weight` resolving to `0.5`) balances label fitting and teacher matching. Use `kd_weight: 1.0`, `ce_weight: 0.0` for pure distillation. If you set `kd_weight > 1`, you must set `ce_weight` explicitly.
+
+## Storage cost
+
+A sidecar stores, per token, K uint32 ids + K fp16 logprobs = **6·K bytes per token** (plus a fixed 1 KiB header per shard):
+
+| `top_k` | Bytes/token | 100M tokens | 1B tokens |
+|---------|-------------|-------------|-----------|
+| 32 | 192 B | ~19 GB | ~192 GB |
+| 64 | 384 B | ~38 GB | ~384 GB |
+| 128 | 768 B | ~77 GB | ~768 GB |
+
+## The `kd_loss` metric
+
+During KD training the step log line carries an extra `kd_loss` field:
+
+- `loss` is the plain (unweighted) cross-entropy mean per valid token, exactly as in normal SFT.
+- `kd_loss` is the mean **τ²-scaled KL divergence** `τ² · KL(teacher_topk ‖ student)` per valid token, accumulated over the micro-steps of the optimizer step. It is reported **rank-0 local** (like the GRPO metrics).
+
+The actual optimized objective is `ce_weight · loss + kd_weight · kd_loss`. A healthy run shows `kd_loss` decreasing as the student's distribution moves towards the teacher's. Note that for MoE models the step log line carries the MoE metrics instead; `kd_loss` remains available in the structured step metrics.
+
+Evaluation is unaffected by distillation: **eval loss is CE-only** (the eval loader never reads sidecars), so eval numbers stay comparable with non-KD runs.
+
+## The `.kd` sidecar format
+
+One sidecar per token shard, named `train-NNN.bin.kd` next to `train-NNN.bin`:
+
+```
+[Header: 1024 bytes]
+  bytes 0..7   : magic "KD.LOGP\n"
+  int32 fields (little-endian, int32 index = byte offset / 4):
+    [2] version = 1
+    [3] k                (top-K per token, 1..1024)
+    [4] n_tokens         (must equal the token shard's n_tokens)
+    [5] vocab_size       (teacher vocab)
+    [6] logprob_dtype    (0 = fp16; only fp16 in v1)
+    [7] reserved = 0
+  bytes 64..79 : tokenize hash (16 ASCII hex chars from .tokenize_hash,
+                 zero-padded) — validated by the Python layer before
+                 training (C++ ignores it)
+[ids      : n_tokens × k uint32]   at byte 1024
+[logprobs : n_tokens × k fp16]     at byte 1024 + 4·k·n_tokens
+```
+
+**Alignment**: row *i* holds the teacher's next-token distribution at input position *i* — the distribution predicting `tokens[i+1]`, i.e. aligned with `targets[i]`. The DataLoader reads sidecar rows `[chunk_pos, chunk_pos + sequence_len)` for a chunk starting at `chunk_pos`, with no extra shift.
+
+Capture runs the teacher over non-overlapping `sequence_len` windows — exactly the chunks the DataLoader serves. The last row of each window is captured too (it predicts the first token of the next window and is consumed by training, since a chunk's targets are `tokens[chunk_pos+1 .. chunk_pos+S]`). Only rows past the last full window (the shard tail) are zero-filled; training never reads past the last full chunk. Masked positions are captured normally and skipped at train time via `target == -100`.
+
+Teacher top-K entries whose token id falls **outside the student's vocabulary** (padded teacher LM-head rows) are masked to `-inf` logprob at capture time, so the training-side renormalization drops their mass (missing-probability = zero). The trainer logs a warning when the sidecar's teacher vocab exceeds the student vocab. In API mode the header's `vocab_size` is the shard's (student) vocab — identical to the teacher's under the shared-tokenizer requirement.
+
+The reader/writer lives in `surogate/distill/sidecar.py` (pure numpy) if you need to inspect or post-process sidecars.
+
+## Cross-tokenizer distillation
+
+The `.kd` sidecar stores **teacher token ids**, and training uses them to index the **student's LM head** — which is why the tokenizers must match. To distill from a teacher with a *different* tokenizer, transplant the teacher's tokenizer onto the student first with `surogate transplant-tokenizer`: the student's embedding and LM-head rows are rebuilt for the teacher's vocabulary (shared tokens copied exactly, new tokens approximated), after which the standard same-tokenizer pipeline runs unchanged.
+
+The default approximation is **OMP with `--k 64`** (arXiv:2506.06607): each new token's teacher-space embedding is expressed as a sparse combination of at most k shared tokens, and the same coefficients are applied to the student's embeddings of those tokens. This is the recipe Arcee used to build **SuperNova-Medius** (Llama-3.1-405B logits distilled into Qwen2.5-14B: transplant → offline top-K capture → KD → transplant back).
+
+**Dependency**: transplantation wraps Arcee's `mergekit-tokensurgeon` as an **external subprocess** — mergekit is LGPL-3.0 and is deliberately *not* a surogate dependency (never imported or vendored). Install it with `pip install mergekit` so `mergekit-tokensurgeon` is on `PATH` (or run in a separate environment via `uvx --from mergekit ...` to avoid its dependency pins).
+
+The workflow:
+
+```bash
+# 1) Transplant the teacher's tokenizer onto the student
+surogate transplant-tokenizer --student Qwen/Qwen3-8B --teacher deepseek-ai/DeepSeek-V3 \
+    --output ./qwen3-8b-dsv3-vocab --device cuda
+
+# 2) Point the KD config's `model:` at ./qwen3-8b-dsv3-vocab
+#    (distillation.teacher_model stays the real teacher)
+
+# 3-5) Run the standard pipeline against it — now same-tokenizer by construction
+surogate tokenize config.yaml          # optional; distill-capture tokenizes if needed
+surogate distill-capture config.yaml
+surogate sft config.yaml
+
+# 6) Optional: restore the student's native tokenizer, then run a short
+#    healing SFT on native-template data
+surogate transplant-tokenizer --restore ./qwen3-8b-dsv3-vocab/transplant_manifest.json \
+    --student ./output/merged --output ./qwen3-8b-distilled-native
+```
+
+Notes:
+
+- The transplanted model carries the teacher's tokenizer *and chat template*, so tokenization, loss masking, and capture are consistent end-to-end; the tokenize-hash machinery guards drift as usual.
+- The forward transplant needs no separate healing stage — the KD run itself supplies dense gradients to exactly the rows that were approximated. After the *reverse* transplant (`--restore`), a short SFT on native-template data is recommended before release (chat-template semantics shift back with the tokenizer).
+- A `transplant_manifest.json` is written next to the transplanted model; `--restore` consumes it (the original student acts as the tokenizer donor, reusing the recorded method and k).
+- **Tied-embedding students**: small models with `tie_word_embeddings=true` (e.g. Qwen3-0.6B/1.7B) share one matrix between input embeddings and LM head, so the transplant solves a compromise between the two approximations. They heal, but expect a few hundred million KD tokens before quality recovers; prefer untied students where possible.
+- `--method` accepts mergekit's other approximation methods (`common_interpolation`, `subword`, `mean`, ...), but `omp` is the recommended default.
+
+## Limitations (v1)
+
+- **Shared tokenizer only.** The teacher's token ids are stored against the student's token stream. Capture validates that every token id in the shards is below the teacher's vocab size, but that is a necessary check, not a sufficient one — using teachers from a different tokenizer family produces garbage supervision. Escape hatch: transplant the teacher's tokenizer onto the student first — see [Cross-tokenizer distillation](#cross-tokenizer-distillation).
+- **Offline only.** No online/on-the-fly teacher during training; the teacher signal is frozen at capture time (capture itself may query a served teacher over the [vLLM API](#remote-teacher-vllm-api), but the result is still a fixed sidecar).
+- **CUDA graphs are auto-disabled** (`use_cuda_graphs: false` is forced); KD micro-steps run eagerly.
+- **Eval loss is CE-only.** The KD term is train-time only.
+- **Single-node only.** Combining `distillation:` with a `distributed:` block raises an error, and `parallelism: dispatch_pp` is rejected.
+- **LM-head row compaction is auto-disabled.** `lmhead_drop_ignored_rows` is forced off with a warning.
+- **No on-the-fly vision training.** `train_vision` is not supported with KD (KD needs tokenized shards with sidecars).
+- Sidecar logprobs are fp16 only (`logprob_dtype = 0`).
+
+## Troubleshooting
+
+All sidecars are validated before training starts (magic, version, `n_tokens`, `top_k`, file size, and the embedded tokenize hash against `{output_dir}/.tokenize_hash`). The errors are actionable:
+
+**Missing sidecar** — `KD sidecar '<shard>.kd' is missing for token shard '<shard>'. Run 'surogate distill-capture <config.yaml>' to capture teacher logprobs.`
+You ran `surogate sft` with a `distillation:` block before capturing. Run the capture step. (When `kd_dir` is set, the trainer looks there and symlinks `<shard>.kd` automatically — but if a *different* real sidecar already sits at `<shard>.kd`, training aborts with `distillation.kd_dir points at <sidecar> but a different sidecar already exists at <shard>.kd; remove one of them.`)
+
+**Tokenize-hash mismatch** — `KD sidecar '<path>' embeds tokenize hash '<old>' but the current token shards have hash '<new>'. The token shards were re-tokenized — re-run 'surogate distill-capture'.`
+Anything that changes tokenization (datasets, `sequence_len`, packing, template) re-tokenizes the shards and invalidates existing sidecars; the alignment between teacher rows and tokens would silently break, so training refuses to start. Re-run the capture (it recaptures only invalid sidecars). A `n_tokens` mismatch between sidecar and shard is caught the same way.
+
+**top_k mismatch** — `KD sidecar '<path>' was captured with top_k=<K> but the config requests top_k=<K'>. Re-run 'surogate distill-capture' with the desired distillation.top_k.`
+`distillation.top_k` is baked into the sidecars at capture time. Either set the config back to the captured value or recapture.
+
+**Truncated sidecar** — `KD sidecar '<path>' is truncated or oversized: ... The capture likely did not finish — re-run 'surogate distill-capture'.`
+Captures write to a `.tmp` file and rename atomically on completion, so this normally means a stray or hand-copied file; re-running the capture fixes it.
+
+**Missing `.tokenize_hash`** — `distillation is enabled but no <output_dir>/.tokenize_hash was found...`
+The output dir has shards but no tokenization hash (e.g. partially copied). Re-run tokenization and the capture.
+
+**Capture: flash-attention-2 not available** — `distill-capture requires flash-attention-2 for per-document attention isolation...`
+Install flash-attn, or accept the cross-document-attention approximation with `--allow-cross-doc-attention` (packed documents will then see each other during teacher capture).
+
+**Capture: token id out of teacher vocab** — `Token shard '<path>' contains token id <X> but the teacher vocab size is <Y>. Student and teacher must share a tokenizer. For cross-tokenizer distillation, first transplant the teacher's tokenizer onto the student ... then re-tokenize and re-capture against the transplanted model.`
+Your teacher does not share the student's tokenizer. Pick a teacher from the same family, or follow the error's advice — see [Cross-tokenizer distillation](#cross-tokenizer-distillation).
+
+**Capture (API): server rejects or omits `prompt_logprobs`** — see [Remote teacher](#remote-teacher-vllm-api): the endpoint must be a vLLM-compatible server started with `--max-logprobs >= top_k`; aggregators such as OpenRouter cannot be used.
+
+## Example
+
+A complete runnable config lives at [`examples/distillation/qwen3-kd.yaml`](https://github.com/invergent-ai/surogate/blob/main/examples/distillation/qwen3-kd.yaml) (Qwen3-1.7B teacher → Qwen3-0.6B student).
+
+## See also
+
+- [Configuration](configuration.md)
+- [Datasets](datasets.md)
+- [Metrics](metrics.md)
+- [Config reference](../reference/config.md)
+- [Back to docs index](../index.mdx)

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -10,6 +10,7 @@ Surogate provides comprehensive training metrics that can be logged to file (JSO
 | Evaluation  | loss, tps                                     | Validation performance          |
 | GPU         | power, temperature, utilization, memory, PCIe | Hardware monitoring             |
 | MoE         | aux_loss, z_loss, utilization, imbalance      | Router health (MoE models only) |
+| Distillation | kd_loss                                      | Teacher-student KL ([KD training](distillation.md) only) |
 | Performance | SOL, FLOPs                                    | Speed-of-Light estimates        |
 | Memory      | allocations by segment                        | Memory usage breakdown          |
 
@@ -39,11 +40,17 @@ Logged every training step via `log_step()`:
 :: step     100 [ 12.5%] \ loss 2.3456 | norm  0.1234 | 125.3k tps |   156 ms | aux 0.0234 | imbal 1.45 | sol 78.2 | eta 02h15m
 ```
 
+**Knowledge distillation (includes kd_loss inline):**
+```
+:: step     100 [ 12.5%] \ loss 2.3456 | norm  0.1234 | 125.3k tps |   156 ms | kd 0.5678 | sol 78.2 | eta 02h15m
+```
+
 Legend:
 - `\ / ` - Loss trend indicator (decreasing/increasing)
 - `!` before norm - Gradient spike detected (>5x moving average)
 - `aux` - MoE auxiliary load balancing loss (MoE models only)
 - `imbal` - MoE load imbalance ratio (MoE models only)
+- `kd` - Distillation KL term (KD training only, see below)
 - `sol` - Speed-of-light percentage (actual vs theoretical peak)
 - `eta` - Estimated time remaining
 
@@ -81,6 +88,19 @@ Legend:
   "moe_load_imbalance": 1.4500
 }
 ```
+
+**Knowledge distillation (adds `kd_loss` to the step line):**
+```json
+{
+  "log": "step",
+  "step": 100,
+  "loss": 2.3456,
+  "lr": 0.0002,
+  "kd_loss": 0.5678
+}
+```
+
+`kd_loss` is the mean τ²-scaled KL divergence `τ² · KL(teacher_topk ‖ student)` per valid token, accumulated over the micro-steps of the optimizer step and reported rank-0 local. `loss` remains the plain (unweighted) cross-entropy; the optimized objective is `ce_weight · loss + kd_weight · kd_loss`. See the [Knowledge Distillation guide](distillation.md). For MoE models the step line carries the MoE metrics instead.
 
 ## Evaluation Metrics
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ By combining a native **C++/CUDA execution engine**, a low-overhead [Python DSL]
 Surogate is built for developers and enterprises that need fast experimentation scalability and predictable outcomes — whether running on-premise, in private clouds, or inside turnkey systems such as the [DenseMAX Appliance](https://www.invergent.ai/densemax-appliance).
 
 - **🔧 Pre-training + Fine-tuning**: full fine-tuning, LoRA/QLoRA
+- [**🎓 Knowledge Distillation**](./guides/distillation.md): offline top-K logit distillation — capture teacher logprobs once, then train the student with a fused CE + KL loss
 - [**🔧 BF16, FP8 and NVFP4 Reinforcement Learning**](./guides/rl-training.md): advanced GRPO training and evaluation with custom, deterministic environments
 - [**🔧 RL Environments**](./guides/rl-environments.md): predictable environments for RL training
 - [**🖥️...🖥️ Native multi-GPU**](./guides/multi-gpu.md) training with the multi-threaded backend

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,6 +49,41 @@ Options:
 - `--debug`: print tokens with labels to confirm masking/ignores
 - `--hub_token <token>`: optional, Hugging Face token for private model access
 
+### `distill-capture`
+
+Capture teacher top-K logprobs for offline knowledge distillation. Writes a `.kd` sidecar next to each tokenized `train-*.bin` shard; a following `surogate sft` run with the same config trains against them. See the [Knowledge Distillation guide](../guides/distillation.md).
+
+```bash
+surogate distill-capture examples/distillation/qwen3-kd.yaml
+```
+
+Options:
+
+- `--api-base <url>`: OpenAI-compatible base URL of a served teacher, e.g. `http://localhost:8000/v1` (overrides `distillation.teacher_api_base`). Requires a vLLM-compatible server started with `--max-logprobs >= distillation.top_k`
+- `--device <device>`: device to run the local teacher model on (default `cuda:0`); ignored with a warning in API mode
+- `--allow-cross-doc-attention`: allow the sdpa fallback when flash-attention-2 is unavailable; packed documents will attend across document boundaries during capture; ignored with a warning in API mode
+- `--hub_token <token>`: optional, Hugging Face token for private model access
+
+### `transplant-tokenizer`
+
+Transplant a teacher's tokenizer onto a student model for cross-tokenizer distillation (wraps `mergekit-tokensurgeon` as an external subprocess; requires `pip install mergekit`). The output model uses the teacher's tokenizer, so the standard KD pipeline runs unchanged against it. See [Cross-tokenizer distillation](../guides/distillation.md#cross-tokenizer-distillation).
+
+```bash
+surogate transplant-tokenizer --student Qwen/Qwen3-8B --teacher deepseek-ai/DeepSeek-V3 \
+    --output ./qwen3-8b-dsv3-vocab
+```
+
+Options:
+
+- `--student <model>`: student model directory or HuggingFace ID (the model to be trained). Required unless `--restore` (where it is the KD-trained model to convert back)
+- `--teacher <model>`: teacher model directory or HuggingFace ID (tokenizer donor). Required unless `--restore`
+- `--output <dir>`: required, output directory for the transplanted model
+- `--method <name>`: approximation method for new vocabulary rows (default `omp`, recommended)
+- `--k <int>`: sparsity level / neighbor count for the approximation (default `64`)
+- `--device <device>`: device for the approximation solve (e.g. `cuda`)
+- `--trust-remote-code`: pass `--trust-remote-code` to `mergekit-tokensurgeon`
+- `--restore <manifest>`: reverse mode — path to a `transplant_manifest.json`; transplants the distilled model (given via `--student`) back to the original student tokenizer
+
 ### `merge`
 
 Merge a LoRA checkpoint into the base model, producing a ready-to-serve model directory.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -137,6 +137,33 @@ distributed:
   worker_output_dir: /shared/surogate-data
 ```
 
+## Knowledge Distillation
+
+Offline top-K logit distillation on the SFT path: capture teacher logprobs once with `surogate distill-capture config.yaml`, then train with `surogate sft config.yaml`. The teacher and student must share a tokenizer. See the [Knowledge Distillation Guide](../guides/distillation.md). Single-node only (mutually exclusive with `distributed:` and `parallelism: dispatch_pp`); CUDA graphs and `lmhead_drop_ignored_rows` are auto-disabled.
+
+| Option                            | Type   | Default           | Description                                                                                                                                                  |
+| --------------------------------- | ------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `distillation.teacher_model`      | string | `null`            | Teacher model id or path. Required by `distill-capture`; ignored at train time.                                                                              |
+| `distillation.top_k`              | int    | `32`              | Teacher logprobs stored per token. Range `[1, 1024]`; training validates that sidecars were captured with this exact value.                                  |
+| `distillation.temperature`        | float  | `1.0`             | Distillation temperature τ (> 0).                                                                                                                            |
+| `distillation.kd_weight`          | float  | `0.5`             | Weight of the KD (KL) term (≥ 0).                                                                                                                            |
+| `distillation.ce_weight`          | float  | `1 - kd_weight`   | Weight of the CE term (≥ 0). Must be set explicitly when `kd_weight > 1`.                                                                                    |
+| `distillation.teacher_batch_size` | int    | `4`               | Capture-time only (local backend): windows of `sequence_len` tokens per teacher forward pass (≥ 1).                                                          |
+| `distillation.kd_dir`             | string | `null`            | Sidecar directory override. Default: alongside the token shards. The trainer bridges `kd_dir` captures to the native DataLoader via `<shard>.kd` symlinks.   |
+| `distillation.teacher_api_base`   | string | `null`            | Capture-time only: OpenAI-compatible base URL of a served teacher (e.g. `http://localhost:8000/v1`). Switches capture to a vLLM API backend; `teacher_model` is then the served model name. Requires a vLLM server started with `--max-logprobs >= top_k`; aggregators (e.g. OpenRouter) cannot be used. |
+| `distillation.teacher_api_key_var` | string | `"VLLM_API_KEY"` | Capture-time only: env var holding the API key. Empty/unset resolves to `EMPTY` (accepted by local vLLM).                                                    |
+| `distillation.teacher_api_concurrency` | int | `8`             | Capture-time only: concurrent in-flight API capture requests (≥ 1).                                                                                          |
+| `distillation.teacher_api_timeout` | int   | `1200`            | Capture-time only: per-request API timeout in seconds (≥ 1).                                                                                                 |
+
+**Example configuration:**
+```yaml
+distillation:
+  teacher_model: Qwen/Qwen3-1.7B
+  top_k: 64
+  temperature: 1.0
+  kd_weight: 0.5
+```
+
 ## Hardware Settings
 
 | Option            | Type | Default | Description                                                         |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -36,6 +36,7 @@ Typical usage:
 - `SurogateTrainer.import_weights(path)`: import weights from a Hugging Face safetensors file
 - `SurogateTrainer.export_model(path)`: export full model weights
 - `SurogateTrainer.export_adapter(path, base_model_path=...)`: export LoRA adapters (PEFT-compatible)
+- `SurogateTrainer.step_with_kd(...)` / `SurogateTrainer.get_kd_loss()`: knowledge-distillation micro-step with a teacher top-K signal, and the resulting KD metric (see [Knowledge Distillation](../guides/distillation.md))
 - `SurogateTrainer.get_allocator_info(gpu_id=0)`: allocator stats (useful for memory debugging)
 
 ## Where to look next

--- a/examples/distillation/README.md
+++ b/examples/distillation/README.md
@@ -1,0 +1,52 @@
+# Knowledge distillation examples
+
+Offline top-K logit distillation: a teacher model is run once over the
+tokenized training data (`.kd` sidecars next to the token shards), then the
+student trains against `ce_weight * CE + kd_weight * tau^2 * KL(teacher || student)`.
+The teacher and student must share a tokenizer.
+
+## What's in this directory
+
+| File | Purpose |
+|---|---|
+| [`qwen3-kd.yaml`](qwen3-kd.yaml) | Qwen3-1.7B teacher → Qwen3-0.6B student, LoRA + bf16, one config for both steps. |
+
+## Run
+
+```bash
+# Step 1: capture teacher top-K logprobs (writes train-NNN.bin.kd sidecars)
+surogate distill-capture examples/distillation/qwen3-kd.yaml
+
+# Step 2: train the student against the sidecars
+surogate sft examples/distillation/qwen3-kd.yaml
+```
+
+## Remote teacher
+
+If the teacher is too big to load next to your capture GPU, serve it with vLLM
+and let capture query the API (set `distillation.teacher_model` to the served
+model name):
+
+```bash
+vllm serve Qwen/Qwen3-1.7B --max-logprobs 64   # must be >= distillation.top_k
+surogate distill-capture examples/distillation/qwen3-kd.yaml --api-base http://localhost:8000/v1
+```
+
+## Cross-tokenizer variant
+
+If the teacher uses a different tokenizer, transplant it onto the student
+first (requires `pip install mergekit`), point `model:` at the transplanted
+directory, then run the same two steps. Optionally restore the native
+tokenizer afterwards and follow with a short healing SFT:
+
+```bash
+surogate transplant-tokenizer --student Qwen/Qwen3-8B --teacher deepseek-ai/DeepSeek-V3 \
+    --output ./qwen3-8b-dsv3-vocab
+# ... capture + sft with model: ./qwen3-8b-dsv3-vocab ...
+surogate transplant-tokenizer --restore ./qwen3-8b-dsv3-vocab/transplant_manifest.json \
+    --student ./output/merged --output ./qwen3-8b-distilled-native
+```
+
+See the [Knowledge Distillation guide](../../docs/guides/distillation.md) for
+the full `distillation:` reference, loss details, sidecar format,
+cross-tokenizer transplantation, and troubleshooting.

--- a/examples/distillation/qwen3-kd.yaml
+++ b/examples/distillation/qwen3-kd.yaml
@@ -1,0 +1,56 @@
+# Offline knowledge distillation: Qwen3-1.7B (teacher) -> Qwen3-0.6B (student).
+#
+# Two-step workflow, same config file for both:
+#   1. surogate distill-capture examples/distillation/qwen3-kd.yaml
+#   2. surogate sft examples/distillation/qwen3-kd.yaml
+#
+# Step 1 tokenizes the datasets (if needed), runs the teacher once over the
+# token shards and writes train-NNN.bin.kd sidecars into output_dir.
+# Step 2 trains the student with loss = ce_weight*CE + kd_weight*tau^2*KL.
+#
+# The teacher and student MUST share a tokenizer. Qwen3-0.6B and Qwen3-1.7B
+# are both Qwen3 dense models and use the identical Qwen3 tokenizer.
+# Capture requires flash-attention-2 for packed data (or pass
+# --allow-cross-doc-attention to accept the sdpa approximation).
+
+model: Qwen/Qwen3-0.6B
+output_dir: ./output
+
+distillation:
+  teacher_model: Qwen/Qwen3-1.7B # capture-time only
+  top_k: 64
+  temperature: 1.0
+  kd_weight: 0.5 # ce_weight defaults to 1 - kd_weight = 0.5
+  teacher_batch_size: 4 # capture-time only: sequence_len windows per teacher forward
+
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 4
+
+sample_packing: true
+sequence_len: 2048
+
+max_steps: 100
+eval_steps: 25
+
+learning_rate: 2e-4
+
+recipe: bf16
+warmup_ratio: 0.15
+
+lora: true
+lora_rank: 16
+lora_alpha: 32
+lora_dropout: 0
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+dataloader_num_workers: 4
+datasets:
+  - path: "OpenLLM-Ro/ro_gsm8k"
+    type: auto

--- a/surogate/_surogate.pyi
+++ b/surogate/_surogate.pyi
@@ -223,6 +223,7 @@ class DataLoader:
         """
         Return True if at least `chunks` more chunks are available in the current epoch.
         """
+    @typing.overload
     def load_batch(self, inputs: npt.NDArray[np.int32], targets: npt.NDArray[np.int32]) -> None:
         """
         Fill `inputs` and `targets` with the next batch.
@@ -230,6 +231,41 @@ class DataLoader:
         Parameters:
         - inputs: Preallocated int32 array [batch, seq_len].
         - targets: Preallocated int32 array [batch, seq_len].
+        """
+    @typing.overload
+    def load_batch(
+        self,
+        inputs: npt.NDArray[np.int32],
+        targets: npt.NDArray[np.int32],
+        position_ids: npt.NDArray[np.int32],
+    ) -> None:
+        """
+        Fill `inputs`, `targets`, and `position_ids` with the next batch.
+        """
+    @typing.overload
+    def load_batch(
+        self,
+        inputs: npt.NDArray[np.int32],
+        targets: npt.NDArray[np.int32],
+        position_ids: npt.NDArray[np.int32],
+        kd_ids: npt.NDArray[np.int32],
+        kd_logprobs: npt.NDArray[np.float32],
+    ) -> None:
+        """
+        Fill token buffers plus the KD teacher top-K arrays with the next batch.
+
+        Requires enable_kd(). kd_ids/kd_logprobs are preallocated
+        [batch, seq_len, top_k] arrays (int32 / float32).
+        """
+    def enable_kd(self, expected_k: int) -> None:
+        """
+        Enable knowledge-distillation sidecar loading. Validates a `<shard>.kd`
+        sidecar for every token file (matching token count and `expected_k`).
+        """
+    @property
+    def has_kd(self) -> bool:
+        """
+        True if KD sidecar loading is enabled.
         """
     def progress(self) -> float:
         """
@@ -1468,6 +1504,40 @@ class SurogateTrainer:
         Equivalent to step() but uses provided per-token gradients instead of d_loss=1.0.
         Call update_with_config() after grad_accum steps to apply gradients.
         """
+    def step_with_kd(
+        self,
+        input_ids: npt.NDArray[np.int32],
+        targets: npt.NDArray[np.int32],
+        kd_ids: npt.NDArray[np.int32],
+        kd_logprobs: npt.NDArray[np.float32],
+        position_ids: npt.NDArray[np.int32] | None = None,
+        top_k: int = 32,
+        temperature: float = 1.0,
+        kd_weight: float = 0.5,
+        ce_weight: float = 0.5,
+    ) -> None:
+        """
+        Run one knowledge-distillation training micro-step.
+
+        Standard SFT forward/backward with a top-K teacher signal injected into
+        the fused LM-head loss:
+        total = ce_weight*CE + kd_weight*tau^2*KL(teacher || student).
+
+        Parameters:
+        - input_ids:   int32 token IDs shaped [ngpu*B, T].
+        - targets:     int32 target IDs shaped [ngpu*B, T]; -100 for masked positions.
+        - kd_ids:      int32 teacher top-K token ids shaped [ngpu*B, T, top_k],
+                       row i aligned with targets[i].
+        - kd_logprobs: float32 raw teacher logprobs shaped [ngpu*B, T, top_k].
+        - position_ids: Optional int32 position IDs shaped [ngpu*B, T].
+        - top_k / temperature / kd_weight / ce_weight: distillation hyperparameters.
+
+        Call update_with_config() after grad_accum micro-steps, then get_kd_loss().
+        """
+    def get_kd_loss(self) -> float:
+        """
+        Mean KD loss per valid token accumulated since the last call (rank-0 local).
+        """
     def export_model(self, path: str) -> None:
         """
         Export model weights and config to a directory.
@@ -1760,6 +1830,20 @@ class TrainingRunLogger:
         - norm: Gradient norm.
         - loss: Training loss.
         - lr: Learning rate.
+        """
+    def log_step_kd(
+        self,
+        step: int,
+        epoch: float,
+        step_tokens: int,
+        duration_ms: int,
+        norm: float,
+        loss: float,
+        lr: float,
+        kd_loss: float,
+    ) -> None:
+        """
+        Log a knowledge-distillation training step (adds kd_loss to the step record).
         """
     def set_expected_time_per_token(self, trainer: SurogateTrainer) -> None:
         """

--- a/surogate/cli/distill_capture.py
+++ b/surogate/cli/distill_capture.py
@@ -1,0 +1,51 @@
+import argparse
+import sys
+
+from surogate.core.config.loader import load_config
+from surogate.core.config.sft_config import SFTConfig
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+from surogate.utils.dict import DictDefault
+
+
+def prepare_command_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.add_argument("config", type=str, help="Path or HTTP(s) URL to config file")
+    parser.add_argument(
+        "--api-base",
+        type=str,
+        default=None,
+        help="OpenAI-compatible base URL of a served teacher, e.g. http://localhost:8000/v1 "
+        "(overrides distillation.teacher_api_base). Requires a vLLM-compatible server "
+        "started with --max-logprobs >= distillation.top_k.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to run the local teacher model on (default cuda:0). "
+        "Ignored with a warning in API mode (--api-base).",
+    )
+    parser.add_argument(
+        "--allow-cross-doc-attention",
+        action="store_true",
+        help="Allow sdpa fallback when flash-attention-2 is unavailable; packed documents "
+        "will attend across document boundaries during capture. "
+        "Ignored with a warning in API mode (--api-base).",
+    )
+    parser.add_argument("--hub_token", type=str, help="Hugging Face token for private model access", default=None)
+
+    return parser
+
+
+if __name__ == "__main__":
+    args = prepare_command_parser().parse_args(sys.argv[1:])
+    config = load_config(SFTConfig, args.config)
+
+    from surogate.distill.capture import distill_capture_main
+
+    distill_capture_main(config, DictDefault(**args.__dict__))

--- a/surogate/cli/main.py
+++ b/surogate/cli/main.py
@@ -50,6 +50,8 @@ COMMAND_MAPPING: dict[str, str] = {
     "vf-init": "surogate.cli.vf_init",
     "vf-eval": "surogate.cli.vf_eval",
     "tokenize": "surogate.cli.tokenize_cmd",
+    "distill-capture": "surogate.cli.distill_capture",
+    "transplant-tokenizer": "surogate.cli.transplant",
     "merge": "surogate.cli.merge",
     "debug": "surogate.cli.debug",
 }
@@ -128,6 +130,23 @@ def parse_args():
 
     tokenize_prepare_command_parser(subparsers.add_parser("tokenize", help="Tokenize datasets for training"))
 
+    # distill-capture command
+    from surogate.cli.distill_capture import prepare_command_parser as distill_capture_prepare_command_parser
+
+    distill_capture_prepare_command_parser(
+        subparsers.add_parser("distill-capture", help="Capture teacher top-K logprobs for knowledge distillation")
+    )
+
+    # transplant-tokenizer command
+    from surogate.cli.transplant import prepare_command_parser as transplant_prepare_command_parser
+
+    transplant_prepare_command_parser(
+        subparsers.add_parser(
+            "transplant-tokenizer",
+            help="Transplant a teacher's tokenizer onto a student model for cross-tokenizer distillation",
+        )
+    )
+
     # merge command
     from surogate.cli.merge import prepare_command_parser as merge_prepare_command_parser
 
@@ -150,7 +169,7 @@ def parse_args():
         parser.print_help()
         sys.exit(1)
 
-    commands_with_config = ["sft", "pt", "grpo_train", "grpo_infer", "grpo_orch", "tokenize"]
+    commands_with_config = ["sft", "pt", "grpo_train", "grpo_infer", "grpo_orch", "tokenize", "distill-capture"]
     if args.command in commands_with_config and not getattr(args, "config", None):
         parser.print_help()
         sys.exit(1)

--- a/surogate/cli/transplant.py
+++ b/surogate/cli/transplant.py
@@ -1,0 +1,73 @@
+import argparse
+import sys
+
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def prepare_command_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--student",
+        help="Student model directory or HuggingFace ID (the model to be trained). Required unless --restore.",
+    )
+    parser.add_argument(
+        "--teacher",
+        help="Teacher model directory or HuggingFace ID (tokenizer donor). Required unless --restore.",
+    )
+    parser.add_argument("--output", required=True, help="Output directory for the transplanted model")
+    parser.add_argument(
+        "--method",
+        default="omp",
+        help="Approximation method for new vocabulary rows (default: omp, recommended)",
+    )
+    parser.add_argument(
+        "--k", type=int, default=64, help="Sparsity level / neighbor count for the approximation (default: 64)"
+    )
+    parser.add_argument("--device", default=None, help="Device for the approximation solve (e.g. cuda)")
+    parser.add_argument(
+        "--trust-remote-code", action="store_true", help="Pass --trust-remote-code to mergekit-tokensurgeon"
+    )
+    parser.add_argument(
+        "--restore",
+        metavar="MANIFEST",
+        default=None,
+        help="Reverse mode: path to a transplant_manifest.json; transplants the distilled model "
+        "(given via --student) back to the original student tokenizer.",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    args = prepare_command_parser().parse_args(sys.argv[1:])
+
+    from surogate.transplant import run_transplant, run_transplant_back
+
+    if args.restore:
+        if not args.student:
+            logger.error("--restore requires --student (the KD-trained model to convert back).")
+            sys.exit(1)
+        run_transplant_back(
+            distilled_model=args.student,
+            manifest_path=args.restore,
+            out_dir=args.output,
+            device=args.device,
+            trust_remote_code=args.trust_remote_code,
+        )
+    else:
+        if not args.student or not args.teacher:
+            logger.error("transplant-tokenizer requires --student and --teacher (or --restore MANIFEST).")
+            sys.exit(1)
+        run_transplant(
+            student_model=args.student,
+            teacher_model=args.teacher,
+            out_dir=args.output,
+            method=args.method,
+            k=args.k,
+            device=args.device,
+            trust_remote_code=args.trust_remote_code,
+        )

--- a/surogate/core/config/sft_config.py
+++ b/surogate/core/config/sft_config.py
@@ -43,6 +43,51 @@ class DistributedConfig:
 
 
 @dataclass
+class DistillationConfig:
+    """
+    Configuration for offline top-K knowledge distillation.
+
+    Training consumes `.kd` sidecar files produced by `surogate distill-capture`
+    (teacher top-K next-token logprobs aligned with the token shards). The
+    per-token loss is `ce_weight * CE + kd_weight * tau^2 * KL(teacher || student)`
+    with teacher top-K probabilities renormalized at `temperature`.
+
+    Args:
+        teacher_model: Teacher model id or path (capture-time only). With
+            teacher_api_base set, this is the served model name.
+        top_k: Number of teacher logprobs stored per token (1..1024).
+        temperature: Distillation temperature tau (> 0).
+        kd_weight: Weight of the KD (KL) term.
+        ce_weight: Weight of the CE term. Defaults to 1 - kd_weight.
+        teacher_batch_size: Windows per teacher forward during capture (capture-time only).
+        kd_dir: Sidecar output directory override (capture-time only).
+            Default: alongside the token shards, which is where training reads them.
+        teacher_api_base: OpenAI-compatible base URL of a served teacher
+            (e.g. "http://localhost:8000/v1"); when set, capture queries the API
+            instead of loading teacher_model locally. Must be a vLLM-compatible
+            server (prompt_logprobs support); OpenAI-compatible aggregators such
+            as OpenRouter cannot be used. Capture-time only.
+        teacher_api_key_var: Env var holding the API key; empty/unset resolves
+            to "EMPTY" like local vLLM servers accept. Capture-time only.
+        teacher_api_concurrency: Concurrent in-flight capture requests (>= 1).
+            Capture-time only.
+        teacher_api_timeout: Per-request timeout in seconds (>= 1). Capture-time only.
+    """
+
+    teacher_model: str | None = None  # capture-time only
+    top_k: int = 32
+    temperature: float = 1.0
+    kd_weight: float = 0.5
+    ce_weight: float | None = None  # default: 1 - kd_weight
+    teacher_batch_size: int = 4  # capture-time only
+    kd_dir: str | None = None  # sidecar dir override; default: alongside token shards
+    teacher_api_base: str | None = None  # capture-time only
+    teacher_api_key_var: str | None = "VLLM_API_KEY"  # capture-time only
+    teacher_api_concurrency: int = 8  # capture-time only
+    teacher_api_timeout: int = 1200  # capture-time only, seconds
+
+
+@dataclass
 class SFTConfig(ModelConfig, TrainDatasetConfig):
     """
     SFTConfig class is a dataclass that holds configuration parameters for Supervised Fine-Tuning (SFT)
@@ -412,6 +457,9 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
     # Multi-node distributed training config (optional)
     distributed: DistributedConfig | None = None
 
+    # Offline knowledge distillation config (optional)
+    distillation: DistillationConfig | None = None
+
     def __init__(self, cfg: DictDefault):
         super().__init__(cfg)
 
@@ -569,6 +617,29 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
         else:
             self.distributed = None
 
+        # Parse distillation config
+        distillation_cfg = cfg.get("distillation", None)
+        if distillation_cfg:
+            if isinstance(distillation_cfg, dict):
+                ce_weight = distillation_cfg.get("ce_weight", None)
+                self.distillation = DistillationConfig(
+                    teacher_model=distillation_cfg.get("teacher_model", None),
+                    top_k=int(distillation_cfg.get("top_k", 32)),
+                    temperature=float(distillation_cfg.get("temperature", 1.0)),
+                    kd_weight=float(distillation_cfg.get("kd_weight", 0.5)),
+                    ce_weight=float(ce_weight) if ce_weight is not None else None,
+                    teacher_batch_size=int(distillation_cfg.get("teacher_batch_size", 4)),
+                    kd_dir=distillation_cfg.get("kd_dir", None),
+                    teacher_api_base=distillation_cfg.get("teacher_api_base", None),
+                    teacher_api_key_var=distillation_cfg.get("teacher_api_key_var", "VLLM_API_KEY"),
+                    teacher_api_concurrency=int(distillation_cfg.get("teacher_api_concurrency", 8)),
+                    teacher_api_timeout=int(distillation_cfg.get("teacher_api_timeout", 1200)),
+                )
+            elif isinstance(distillation_cfg, DistillationConfig):
+                self.distillation = distillation_cfg
+        else:
+            self.distillation = None
+
     def __post_init__(self):
         logger = get_logger()
 
@@ -659,6 +730,10 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
             if not shard_gradients:
                 raise ValueError("offload_grads requires cpu_training=true, shard_gradients=true, or zero_level >= 2.")
 
+        # Validate distillation before create_runtime_config so the forced
+        # lmhead_drop_ignored_rows=False lands in RuntimeOptions.
+        self._validate_distillation_config()
+
         # Validate dispatch-PP before EP so its explicit ep_size>1 rejection wins
         # over the generic "EP requires MoE" check.
         self._validate_dispatch_pp_config()
@@ -703,6 +778,50 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
                 f"per_device_train_batch_size * sequence_len ({batch_size} * {seq_len} = {total_tokens}). "
                 f"Either adjust batch size or sequence length, or reduce lmhead_chunks."
             )
+
+    def _validate_distillation_config(self):
+        """Validate the distillation block and resolve derived defaults."""
+        d = self.distillation
+        if d is None:
+            return
+
+        if not 1 <= d.top_k <= 1024:
+            raise ValueError(f"distillation.top_k must be in [1, 1024], got {d.top_k}.")
+        if d.temperature <= 0:
+            raise ValueError(f"distillation.temperature must be > 0, got {d.temperature}.")
+        if d.kd_weight < 0:
+            raise ValueError(f"distillation.kd_weight must be >= 0, got {d.kd_weight}.")
+        if d.ce_weight is None:
+            d.ce_weight = 1.0 - d.kd_weight
+            if d.ce_weight < 0:
+                raise ValueError(
+                    f"distillation.ce_weight defaults to 1 - kd_weight = {d.ce_weight}, which is "
+                    "negative. Set distillation.ce_weight explicitly when kd_weight > 1."
+                )
+        if d.ce_weight < 0:
+            raise ValueError(f"distillation.ce_weight must be >= 0, got {d.ce_weight}.")
+        if d.teacher_batch_size < 1:
+            raise ValueError(f"distillation.teacher_batch_size must be >= 1, got {d.teacher_batch_size}.")
+        if d.teacher_api_concurrency < 1:
+            raise ValueError(
+                f"distillation.teacher_api_concurrency must be >= 1, got {d.teacher_api_concurrency}."
+            )
+        if d.teacher_api_timeout < 1:
+            raise ValueError(f"distillation.teacher_api_timeout must be >= 1, got {d.teacher_api_timeout}.")
+
+        if self.distributed:
+            raise ValueError(
+                "distillation does not support multi-node distributed training in v1; "
+                "remove the `distributed:` block or the `distillation:` block."
+            )
+        if self.parallelism == "dispatch_pp":
+            raise ValueError("distillation is not supported with parallelism=dispatch_pp in v1.")
+        if self.lmhead_drop_ignored_rows:
+            logger.warning(
+                "[distillation]: forcing lmhead_drop_ignored_rows=False (the compact LM-head "
+                "row path does not support KD in v1)."
+            )
+            self.lmhead_drop_ignored_rows = False
 
     def _validate_dispatch_pp_config(self):
         """Normalize and validate parallelism=dispatch_pp (opt-in model-parallel mode).
@@ -932,6 +1051,10 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
                 "[lmhead_drop_ignored_rows]: disabling CUDA graphs (n_valid varies per step, "
                 "so the captured matmul dimensions can't be replayed)."
             )
+
+        if self.distillation is not None and self.use_cuda_graphs:
+            self.use_cuda_graphs = False
+            logger.info("[distillation]: disabling CUDA graphs (KD micro-steps run eagerly in v1).")
 
         self.runtime_config = _surogate.RuntimeOptions(
             recompute="true" if self.recompute else "false",

--- a/surogate/distill/__init__.py
+++ b/surogate/distill/__init__.py
@@ -1,0 +1,34 @@
+"""Offline knowledge-distillation support: `.kd` sidecar format and teacher capture.
+
+Only the sidecar API is re-exported here; the capture driver
+(`surogate.distill.capture`) pulls in torch/transformers and must be imported
+explicitly.
+"""
+
+from surogate.distill.sidecar import (
+    KD_MAGIC,
+    KD_MAX_TOP_K,
+    SidecarHeader,
+    SidecarWriter,
+    TokenShardHeader,
+    read_sidecar,
+    read_sidecar_header,
+    read_token_shard_header,
+    sidecar_path_for,
+    validate_sidecar,
+    write_sidecar_header,
+)
+
+__all__ = [
+    "KD_MAGIC",
+    "KD_MAX_TOP_K",
+    "SidecarHeader",
+    "SidecarWriter",
+    "TokenShardHeader",
+    "read_sidecar",
+    "read_sidecar_header",
+    "read_token_shard_header",
+    "sidecar_path_for",
+    "validate_sidecar",
+    "write_sidecar_header",
+]

--- a/surogate/distill/capture.py
+++ b/surogate/distill/capture.py
@@ -1,0 +1,545 @@
+"""Teacher top-K logprob capture for offline knowledge distillation.
+
+Reads each tokenized `train-NNN.bin` shard directly (tokens + per-doc
+position_ids), runs the teacher over non-overlapping `sequence_len` windows —
+exactly the chunks the native DataLoader serves — and writes a
+`train-NNN.bin.kd` sidecar (see `surogate.distill.sidecar` for the format).
+
+Sidecar row w*S+i stores the teacher's top-k next-token logprobs from output
+position i of window w, i.e. the distribution predicting tokens[w*S+i+1].
+This includes i == S-1 (predicting the first token of the next window): the
+DataLoader's targets for a chunk at chunk_pos are tokens[chunk_pos+1 ..
+chunk_pos+S], so the last row of every window is consumed, not discarded.
+Rows past the last full window are zero-filled.
+
+Two teacher backends:
+- Local HF model (default): teacher loaded via transformers, whole windows per
+  forward, flash-attention-2 varlen for per-document isolation.
+- OpenAI-compatible API (`distillation.teacher_api_base`): one vLLM
+  `prompt_logprobs` completions request per document (split at position-id
+  resets, one-token lookahead), which gives exact context isolation with no
+  flash-attn requirement. Requires a vLLM-compatible server started with
+  `--max-logprobs >= top_k`; aggregators like OpenRouter cannot be used.
+
+torch/transformers are imported lazily inside functions; the API backend never
+imports them.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+
+from surogate.core.config.sft_config import SFTConfig
+from surogate.distill.sidecar import (
+    SidecarWriter,
+    read_token_shard_header,
+    sidecar_path_for,
+    validate_sidecar,
+)
+from surogate.utils.dict import DictDefault
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def _read_shard(path: str) -> tuple[np.ndarray, np.ndarray | None, int]:
+    """Memory-map a token shard; returns (tokens, position_ids or None, n_tokens)."""
+    header = read_token_shard_header(path)
+    n_tokens = header.n_tokens
+    tokens = np.memmap(path, dtype="<i4", mode="r", offset=header.tokens_offset, shape=(n_tokens,))
+    position_ids = None
+    if header.version >= 3:
+        position_ids = np.memmap(
+            path, dtype="<i4", mode="r", offset=header.position_ids_offset, shape=(n_tokens,)
+        )
+    return tokens, position_ids, n_tokens
+
+
+def _load_teacher(teacher_model: str, device: str, allow_cross_doc_attention: bool):
+    import torch
+    from transformers import AutoModelForCausalLM
+    from transformers.utils import is_flash_attn_2_available
+
+    if is_flash_attn_2_available():
+        attn_implementation = "flash_attention_2"
+    elif allow_cross_doc_attention:
+        attn_implementation = "sdpa"
+        logger.warning(
+            "flash-attention-2 is not available; falling back to sdpa. Packed documents will "
+            "attend across document boundaries during capture (--allow-cross-doc-attention)."
+        )
+    else:
+        raise RuntimeError(
+            "distill-capture requires flash-attention-2 for per-document attention isolation "
+            "(position_ids resets -> varlen). Install flash-attn, or pass "
+            "--allow-cross-doc-attention to accept the cross-document approximation with sdpa."
+        )
+
+    logger.info(f"Loading teacher model '{teacher_model}' ({attn_implementation}, bf16) on {device}...")
+    model = AutoModelForCausalLM.from_pretrained(
+        teacher_model,
+        torch_dtype=torch.bfloat16,
+        attn_implementation=attn_implementation,
+    )
+    model.to(device)
+    model.eval()
+    return model
+
+
+def _topk_logprobs(logits, top_k: int):
+    """Top-k of log_softmax(logits) computed as topk(logits) - logsumexp(logits).
+
+    topk indices over raw logits equal those over log_softmax (monotone shift);
+    the fp32 normalizer is computed one window at a time to avoid materializing
+    a full fp32 copy of the (bsz, S, V) logits.
+    """
+    import torch
+
+    values, ids = logits.topk(top_k, dim=-1)
+    lse = torch.stack([torch.logsumexp(row.to(torch.float32), dim=-1) for row in logits])
+    logprobs = values.to(torch.float32) - lse.unsqueeze(-1)
+    return logprobs, ids
+
+
+def capture_shard(
+    model,
+    shard_path: str,
+    sidecar_path: str,
+    top_k: int,
+    sequence_len: int,
+    teacher_batch_size: int,
+    teacher_vocab_size: int,
+    tokenize_hash: str,
+    device: str,
+) -> None:
+    import torch
+    from tqdm import tqdm
+
+    tokens, position_ids, n_tokens = _read_shard(shard_path)
+    student_vocab = read_token_shard_header(shard_path).vocab_size
+    max_token_id = int(tokens.max()) if n_tokens > 0 else -1
+    if max_token_id >= teacher_vocab_size:
+        raise ValueError(
+            f"Token shard '{shard_path}' contains token id {max_token_id} but the teacher vocab "
+            f"size is {teacher_vocab_size}. Student and teacher must share a tokenizer. For "
+            "cross-tokenizer distillation, first transplant the teacher's tokenizer onto the "
+            "student: `surogate transplant-tokenizer --student <student> --teacher <teacher> "
+            "--output <dir>`, then re-tokenize and re-capture against the transplanted model."
+        )
+
+    n_windows = n_tokens // sequence_len
+    if n_windows == 0:
+        raise ValueError(
+            f"Token shard '{shard_path}' has only {n_tokens} tokens (< sequence_len={sequence_len}); "
+            "nothing to capture."
+        )
+
+    tmp_path = sidecar_path + ".tmp"
+    with SidecarWriter(
+        tmp_path,
+        n_tokens=n_tokens,
+        k=top_k,
+        vocab_size=teacher_vocab_size,
+        tokenize_hash=tokenize_hash,
+    ) as writer:
+        with torch.inference_mode():
+            for w0 in tqdm(
+                range(0, n_windows, teacher_batch_size),
+                desc=f"Capturing {os.path.basename(shard_path)}",
+                unit="batch",
+            ):
+                w1 = min(w0 + teacher_batch_size, n_windows)
+                span = slice(w0 * sequence_len, w1 * sequence_len)
+                n_flat = (w1 - w0) * sequence_len
+                # Flatten the window batch to a single row and pass explicit
+                # varlen boundaries. Batched [B, S] position_ids do NOT trigger
+                # transformers' padding-free flash-attention path, so without
+                # this the teacher silently attends across packed documents.
+                # Segments start at every window boundary and at every
+                # position-id reset (packed doc starts).
+                flat_ids = torch.from_numpy(np.ascontiguousarray(tokens[span], dtype=np.int64)).to(device)
+                if position_ids is not None:
+                    flat_pos = torch.from_numpy(
+                        np.ascontiguousarray(position_ids[span], dtype=np.int64)
+                    ).to(device)
+                else:
+                    flat_pos = (
+                        torch.arange(sequence_len, dtype=torch.int64, device=device)
+                        .repeat(w1 - w0)
+                    )
+                idx = torch.arange(n_flat, device=device)
+                seg_starts = torch.nonzero((idx % sequence_len == 0) | (flat_pos == 0)).view(-1)
+                cu_seqlens = torch.cat(
+                    [seg_starts.to(torch.int32), torch.tensor([n_flat], dtype=torch.int32, device=device)]
+                )
+                max_len = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
+                logits = model(
+                    input_ids=flat_ids.unsqueeze(0),
+                    position_ids=flat_pos.unsqueeze(0),
+                    cu_seq_lens_q=cu_seqlens,
+                    cu_seq_lens_k=cu_seqlens,
+                    max_length_q=max_len,
+                    max_length_k=max_len,
+                ).logits
+                logprobs, ids = _topk_logprobs(logits, top_k)
+                ids = ids.reshape(-1, top_k).cpu().numpy()
+                logprobs = logprobs.reshape(-1, top_k).cpu().numpy()
+                # Teacher entries outside the student vocab (padded teacher
+                # lm_head rows) carry probability the student cannot express:
+                # mask them so the native q-renormalization drops their mass
+                # (missing-probability = zero semantics).
+                oov = ids >= student_vocab
+                if oov.any():
+                    ids = np.where(oov, 0, ids)
+                    logprobs = np.where(oov, np.float32(-np.inf), logprobs)
+                writer.write_rows(
+                    ids.astype(np.uint32),
+                    logprobs.astype(np.float16),
+                )
+    os.replace(tmp_path, sidecar_path)
+    tail = n_tokens - n_windows * sequence_len
+    logger.info(
+        f"Wrote {sidecar_path}: {n_windows * sequence_len} rows captured, {tail} tail rows zero-filled."
+    )
+
+
+def _api_guidance(api_base: str, top_k: int) -> str:
+    return (
+        f"The server at {api_base} did not return prompt_logprobs. distill-capture requires a "
+        f"vLLM-compatible inference server started with --max-logprobs >= {top_k}, serving a "
+        "teacher that SHARES the student's tokenizer. OpenAI-compatible aggregators/providers "
+        "(e.g. OpenRouter) do not expose per-position prompt logprobs or token-id prompts and "
+        "cannot be used for logit capture."
+    )
+
+
+def _make_api_client(dist):
+    import httpx
+
+    api_key = os.environ.get(dist.teacher_api_key_var or "", "") or "EMPTY"
+    return httpx.Client(
+        base_url=dist.teacher_api_base,
+        timeout=dist.teacher_api_timeout,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+
+def _doc_spans(position_ids: np.ndarray | None, start: int, end: int) -> list[tuple[int, int]]:
+    """Absolute [a, b) document spans within window [start, end).
+
+    pos[i] == 0 marks a document start; the window start always begins a span
+    (a doc continuing across the window boundary loses its earlier context,
+    matching the local backend's window-at-a-time processing).
+    """
+    if position_ids is None:
+        return [(start, end)]
+    starts = [start] + [i for i in range(start + 1, end) if position_ids[i] == 0]
+    return list(zip(starts, starts[1:] + [end]))
+
+
+def _post_prompt_logprobs(client, model: str, prompt: list[int], top_k: int, retry_backoff: float = 1.0):
+    """POST an OpenAI completions request with vLLM's prompt_logprobs extension.
+
+    Returns choices[0].prompt_logprobs (list aligned with the prompt; entry 0 is
+    null, entry i is {token_id_str: {"logprob": float, "rank": int, ...}}).
+    Retries transient failures (transport errors, 429, 5xx) 3 times with backoff.
+    """
+    import httpx
+
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": 1,
+        "temperature": 1.0,
+        "prompt_logprobs": top_k,
+    }
+    attempts = 3
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            response = client.post("/completions", json=body)
+            if response.status_code == 429 or response.status_code >= 500:
+                raise httpx.HTTPStatusError(
+                    f"transient HTTP {response.status_code}", request=response.request, response=response
+                )
+            if 400 <= response.status_code < 500:
+                text = response.text.lower()
+                if "prompt_logprobs" in text or (
+                    "prompt" in text and any(t in text for t in ("unknown", "unexpected", "invalid", "unsupported"))
+                ):
+                    raise RuntimeError(
+                        f"{_api_guidance(str(client.base_url), top_k)} "
+                        f"(HTTP {response.status_code}: {response.text[:300]})"
+                    )
+            response.raise_for_status()
+            data = response.json()
+            return data["choices"][0].get("prompt_logprobs")
+        except (httpx.TransportError, httpx.HTTPStatusError) as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status is not None and status != 429 and status < 500:
+                raise
+            last_error = e
+            if attempt < attempts - 1:
+                time.sleep(retry_backoff * 2**attempt)
+    raise RuntimeError(
+        f"Teacher API request failed after {attempts} attempts ({client.base_url}): {last_error}"
+    )
+
+
+def _row_from_entry(
+    entry: dict, top_k: int, api_base: str, student_vocab: int | None = None
+) -> tuple[np.ndarray, np.ndarray]:
+    """Top-k (ids, logprobs) from one prompt_logprobs entry, sorted by logprob descending.
+
+    vLLM may return top_k + 1 candidates when the actual prompt token falls
+    outside the top-k; truncation keeps the k most probable. Candidates outside
+    the student vocab (padded teacher lm_head rows) are masked to logprob -inf
+    so the native q-renormalization drops their mass.
+    """
+    ranked = sorted(((float(v["logprob"]), int(tid)) for tid, v in entry.items()), reverse=True)
+    if len(ranked) < top_k:
+        raise RuntimeError(
+            f"The server at {api_base} returned only {len(ranked)} prompt_logprobs candidates for a "
+            f"position but distillation.top_k={top_k}; restart the vLLM server with "
+            f"--max-logprobs >= {top_k}."
+        )
+    ranked = ranked[:top_k]
+    ids = np.array([tid for _, tid in ranked], dtype=np.int64)
+    logprobs = np.array([lp for lp, _ in ranked], dtype=np.float32)
+    if student_vocab is not None:
+        oov = ids >= student_vocab
+        if oov.any():
+            ids = np.where(oov, 0, ids)
+            logprobs = np.where(oov, np.float32(-np.inf), logprobs)
+    return ids.astype(np.uint32), logprobs.astype(np.float16)
+
+
+def capture_shard_api(
+    client,
+    teacher_model: str,
+    shard_path: str,
+    sidecar_path: str,
+    top_k: int,
+    sequence_len: int,
+    concurrency: int,
+    tokenize_hash: str,
+    retry_backoff: float = 1.0,
+) -> None:
+    from tqdm import tqdm
+
+    shard_header = read_token_shard_header(shard_path)
+    tokens, position_ids, n_tokens = _read_shard(shard_path)
+
+    n_windows = n_tokens // sequence_len
+    if n_windows == 0:
+        raise ValueError(
+            f"Token shard '{shard_path}' has only {n_tokens} tokens (< sequence_len={sequence_len}); "
+            "nothing to capture."
+        )
+
+    api_base = str(client.base_url)
+    first_response_checked = False
+
+    def fetch(span: tuple[int, int]):
+        a, b = span
+        prompt = np.asarray(tokens[a : min(b + 1, n_tokens)]).tolist()
+        return _post_prompt_logprobs(client, teacher_model, prompt, top_k, retry_backoff=retry_backoff)
+
+    tmp_path = sidecar_path + ".tmp"
+    # Header vocab_size: the teacher config is not available in API mode; the
+    # shared-tokenizer requirement makes the shard's vocab the same vocab.
+    with SidecarWriter(
+        tmp_path,
+        n_tokens=n_tokens,
+        k=top_k,
+        vocab_size=shard_header.vocab_size,
+        tokenize_hash=tokenize_hash,
+    ) as writer:
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            windows_per_flush = max(1, concurrency)
+            for w0 in tqdm(
+                range(0, n_windows, windows_per_flush),
+                desc=f"Capturing {os.path.basename(shard_path)} (API)",
+                unit="chunk",
+            ):
+                start = w0 * sequence_len
+                end = min(w0 + windows_per_flush, n_windows) * sequence_len
+                spans = [
+                    span
+                    for w in range(w0, min(w0 + windows_per_flush, n_windows))
+                    for span in _doc_spans(position_ids, w * sequence_len, (w + 1) * sequence_len)
+                ]
+                buf_ids = np.zeros((end - start, top_k), dtype=np.uint32)
+                buf_logprobs = np.zeros((end - start, top_k), dtype=np.float16)
+                for (a, b), prompt_logprobs in zip(spans, pool.map(fetch, spans)):
+                    if not first_response_checked:
+                        entries = [e for e in (prompt_logprobs or []) if e]
+                        if not entries:
+                            raise RuntimeError(_api_guidance(api_base, top_k))
+                        if len(entries[0]) < top_k:
+                            raise RuntimeError(
+                                f"The server at {api_base} returned only {len(entries[0])} "
+                                f"prompt_logprobs candidates but distillation.top_k={top_k}; restart "
+                                f"the vLLM server with --max-logprobs >= {top_k}."
+                            )
+                        first_response_checked = True
+                    if not prompt_logprobs:
+                        raise RuntimeError(_api_guidance(api_base, top_k))
+                    # Entry i (i >= 1) predicts prompt position i -> sidecar row
+                    # a + i - 1. The one-token lookahead (prompt runs to b) makes
+                    # the doc's last row b-1 predict tokens[b]; when b == n_tokens
+                    # there is no lookahead and the final row stays zero-filled.
+                    for i, entry in enumerate(prompt_logprobs):
+                        if i == 0 or not entry:
+                            continue
+                        row = a + i - 1
+                        buf_ids[row - start], buf_logprobs[row - start] = _row_from_entry(
+                            entry, top_k, api_base, student_vocab=shard_header.vocab_size
+                        )
+                writer.write_rows(buf_ids, buf_logprobs)
+    os.replace(tmp_path, sidecar_path)
+    tail = n_tokens - n_windows * sequence_len
+    logger.info(
+        f"Wrote {sidecar_path}: {n_windows * sequence_len} rows captured via API, "
+        f"{tail} tail rows zero-filled."
+    )
+
+
+def run_capture(
+    config: SFTConfig,
+    shard_paths: list[str],
+    tokenize_hash: str,
+    device: str = "cuda:0",
+    allow_cross_doc_attention: bool = False,
+) -> None:
+    dist = config.distillation
+    logger.warning(
+        "distill-capture assumes the student and teacher share a tokenizer: the sidecar stores "
+        "teacher-vocab token ids against the student's token stream. Cross-tokenizer "
+        "distillation is NOT supported."
+    )
+
+    kd_dir = dist.kd_dir
+    if kd_dir:
+        Path(kd_dir).mkdir(parents=True, exist_ok=True)
+        if any(Path(kd_dir).resolve() != Path(p).parent.resolve() for p in shard_paths):
+            logger.info(
+                f"distillation.kd_dir={kd_dir} differs from the token shard directory; the trainer "
+                "will validate these sidecars and symlink them next to the token shards at "
+                "training start."
+            )
+
+    pending: list[tuple[str, str]] = []
+    for shard in shard_paths:
+        sidecar = sidecar_path_for(shard, kd_dir)
+        try:
+            validate_sidecar(sidecar, shard, expect_k=dist.top_k, expect_hash=tokenize_hash)
+            logger.info(f"Skipping {shard}: valid sidecar exists at {sidecar}.")
+            continue
+        except ValueError as e:
+            if os.path.exists(sidecar):
+                logger.info(f"Recapturing {shard}: {e}")
+        pending.append((shard, sidecar))
+
+    if not pending:
+        logger.info("All shards already have valid sidecars; nothing to capture.")
+        return
+
+    if dist.teacher_api_base:
+        logger.info(
+            f"Using API teacher '{dist.teacher_model}' at {dist.teacher_api_base} "
+            f"(concurrency={dist.teacher_api_concurrency}, timeout={dist.teacher_api_timeout}s)."
+        )
+        client = _make_api_client(dist)
+        try:
+            for shard, sidecar in pending:
+                capture_shard_api(
+                    client,
+                    dist.teacher_model,
+                    shard,
+                    sidecar,
+                    top_k=dist.top_k,
+                    sequence_len=config.sequence_len,
+                    concurrency=dist.teacher_api_concurrency,
+                    tokenize_hash=tokenize_hash,
+                )
+        finally:
+            client.close()
+    else:
+        model = _load_teacher(dist.teacher_model, device, allow_cross_doc_attention)
+        teacher_vocab_size = int(model.config.vocab_size)
+        if dist.top_k > teacher_vocab_size:
+            raise ValueError(
+                f"distillation.top_k={dist.top_k} exceeds the teacher vocab size {teacher_vocab_size}."
+            )
+
+        for shard, sidecar in pending:
+            capture_shard(
+                model,
+                shard,
+                sidecar,
+                top_k=dist.top_k,
+                sequence_len=config.sequence_len,
+                teacher_batch_size=dist.teacher_batch_size,
+                teacher_vocab_size=teacher_vocab_size,
+                tokenize_hash=tokenize_hash,
+                device=device,
+            )
+
+    logger.info(f"Capture complete: {len(pending)} sidecar(s) written.")
+
+
+def distill_capture_main(config: SFTConfig, args: DictDefault) -> None:
+    if config.distillation is None or not config.distillation.teacher_model:
+        raise ValueError(
+            "distill-capture requires a `distillation:` block with `teacher_model` set in the config "
+            "(with teacher_api_base, teacher_model is the served model name)."
+        )
+
+    if args.get("hub_token"):
+        # Covers the teacher download and any gated dataset/tokenizer fetches.
+        os.environ.setdefault("HF_TOKEN", args["hub_token"])
+
+    if args.get("api_base"):
+        config.distillation.teacher_api_base = args["api_base"]
+    if config.distillation.teacher_api_base and (
+        args.get("device") or args.get("allow_cross_doc_attention")
+    ):
+        logger.warning(
+            "--device / --allow-cross-doc-attention are ignored in API mode "
+            "(the teacher runs on the server; per-document requests give exact context isolation)."
+        )
+
+    # Tokenize first if shards are missing/stale — same flow sft.py runs before
+    # globbing (TokenizeDatasets.run() is hash-cached and calls __post_init__).
+    from surogate.train.tokenize import TokenizeDatasets, read_tokenize_hash
+
+    TokenizeDatasets(config, args).run()
+
+    output_path = Path(config.output_dir)
+    train_files = sorted([str(p) for p in output_path.glob("train-*.bin")])
+    if not train_files:
+        raise RuntimeError(
+            f"No training files found matching '{config.output_dir}/train-*.bin'. "
+            "Tokenization produced no usable rows (all dataset rows were dropped)."
+        )
+
+    tokenize_hash = read_tokenize_hash(config.output_dir)
+    if not tokenize_hash:
+        raise RuntimeError(
+            f"No {config.output_dir}/.tokenize_hash found; run `surogate tokenize` (or re-run "
+            "distill-capture) after a successful tokenization."
+        )
+
+    run_capture(
+        config,
+        train_files,
+        tokenize_hash,
+        device=args.get("device") or "cuda:0",
+        allow_cross_doc_attention=bool(args.get("allow_cross_doc_attention", False)),
+    )

--- a/surogate/distill/sidecar.py
+++ b/surogate/distill/sidecar.py
@@ -1,0 +1,294 @@
+"""Reader/writer for the `.kd` teacher-logprob sidecar format.
+
+A sidecar `train-NNN.bin.kd` stores, for every token position of the matching
+`train-NNN.bin` token shard, the teacher's top-K next-token log-probabilities.
+
+File layout::
+
+    [Header 1024 bytes]
+      bytes 0..7   : magic "KD.LOGP\\n"
+      int32 fields (little-endian, int32 index = byte offset / 4):
+        [2] version = 1
+        [3] k                (top-K per token, 1..1024)
+        [4] n_tokens         (must equal the token shard's n_tokens)
+        [5] vocab_size       (teacher vocab)
+        [6] logprob_dtype    (0 = fp16; only fp16 in v1)
+        [7] reserved = 0
+      bytes 64..79 : tokenize hash (16 ASCII hex chars from .tokenize_hash,
+                     zero-padded) — validated by the Python layer before
+                     training (C++ ignores it)
+    [ids      : n_tokens x k uint32]   at byte 1024
+    [logprobs : n_tokens x k fp16]     at byte 1024 + 4*k*n_tokens
+
+Alignment: row i holds the teacher's next-token distribution at input
+position i (predicting tokens[i+1], i.e. aligned with targets[i]). The
+DataLoader reads sidecar rows [chunk_pos, chunk_pos + S) for a chunk at
+chunk_pos — no extra shift. Rows past the last captured window are
+zero-filled.
+
+This module is pure numpy — it must stay importable without torch.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import numpy as np
+
+KD_MAGIC = b"KD.LOGP\n"
+KD_VERSION = 1
+KD_HEADER_BYTES = 1024
+KD_HASH_OFFSET = 64
+KD_HASH_BYTES = 16
+KD_LOGPROB_DTYPE_FP16 = 0
+KD_MAX_TOP_K = 1024
+
+TOKEN_MAGIC = b"BIN.TOK\n"
+TOKEN_HEADER_BYTES = 1024
+
+SIDECAR_SUFFIX = ".kd"
+
+
+def sidecar_path_for(token_shard_path: str, kd_dir: str | None = None) -> str:
+    """Sidecar path for a token shard; `kd_dir` overrides the directory."""
+    if kd_dir:
+        return os.path.join(kd_dir, os.path.basename(token_shard_path) + SIDECAR_SUFFIX)
+    return token_shard_path + SIDECAR_SUFFIX
+
+
+@dataclass
+class SidecarHeader:
+    version: int
+    k: int
+    n_tokens: int
+    vocab_size: int
+    logprob_dtype: int
+    tokenize_hash: str
+
+    @property
+    def ids_offset(self) -> int:
+        return KD_HEADER_BYTES
+
+    @property
+    def logprobs_offset(self) -> int:
+        return KD_HEADER_BYTES + 4 * self.k * self.n_tokens
+
+    @property
+    def file_size(self) -> int:
+        return KD_HEADER_BYTES + 6 * self.k * self.n_tokens
+
+
+@dataclass
+class TokenShardHeader:
+    version: int
+    bytes_per_token: int
+    n_tokens: int
+    vocab_size: int
+    has_masks: bool
+    non_overlapping: bool
+
+    @property
+    def tokens_offset(self) -> int:
+        return TOKEN_HEADER_BYTES
+
+    @property
+    def position_ids_offset(self) -> int:
+        # Version 3 shards store one int32 position id per token right after
+        # the token block.
+        return TOKEN_HEADER_BYTES + 4 * self.n_tokens
+
+
+def read_token_shard_header(path: str) -> TokenShardHeader:
+    """Parse the 1024-byte BIN.TOK header of a token shard."""
+    with open(path, "rb") as f:
+        raw = f.read(TOKEN_HEADER_BYTES)
+    if len(raw) < TOKEN_HEADER_BYTES:
+        raise ValueError(f"Token shard '{path}' is too small to contain a BIN.TOK header.")
+    if raw[:8] != TOKEN_MAGIC:
+        raise ValueError(f"Token shard '{path}' has bad magic {raw[:8]!r}; expected {TOKEN_MAGIC!r}.")
+    fields = np.frombuffer(raw, dtype="<i4")
+    return TokenShardHeader(
+        version=int(fields[2]),
+        bytes_per_token=int(fields[3]),
+        n_tokens=int(fields[4]),
+        vocab_size=int(fields[5]),
+        has_masks=bool(fields[6]),
+        non_overlapping=bool(fields[7]),
+    )
+
+
+def _encode_hash(tokenize_hash: str) -> bytes:
+    encoded = (tokenize_hash or "").encode("ascii")
+    if len(encoded) > KD_HASH_BYTES:
+        raise ValueError(f"tokenize hash '{tokenize_hash}' exceeds {KD_HASH_BYTES} bytes.")
+    return encoded.ljust(KD_HASH_BYTES, b"\x00")
+
+
+def write_sidecar_header(f, header: SidecarHeader) -> None:
+    """Write the 1024-byte KD.LOGP header at the current start of file `f`."""
+    raw = bytearray(KD_HEADER_BYTES)
+    raw[0:8] = KD_MAGIC
+    fields = np.array(
+        [header.version, header.k, header.n_tokens, header.vocab_size, header.logprob_dtype, 0],
+        dtype="<i4",
+    )
+    raw[8 : 8 + fields.nbytes] = fields.tobytes()
+    raw[KD_HASH_OFFSET : KD_HASH_OFFSET + KD_HASH_BYTES] = _encode_hash(header.tokenize_hash)
+    f.seek(0)
+    f.write(bytes(raw))
+
+
+def read_sidecar_header(path: str) -> SidecarHeader:
+    """Parse the 1024-byte KD.LOGP header of a sidecar file."""
+    with open(path, "rb") as f:
+        raw = f.read(KD_HEADER_BYTES)
+    if len(raw) < KD_HEADER_BYTES:
+        raise ValueError(f"KD sidecar '{path}' is too small to contain a header.")
+    if raw[:8] != KD_MAGIC:
+        raise ValueError(
+            f"KD sidecar '{path}' has bad magic {raw[:8]!r}; expected {KD_MAGIC!r}. "
+            "The file is not a KD sidecar — re-run `surogate distill-capture`."
+        )
+    fields = np.frombuffer(raw, dtype="<i4")
+    version = int(fields[2])
+    if version != KD_VERSION:
+        raise ValueError(f"KD sidecar '{path}' has unsupported version {version} (expected {KD_VERSION}).")
+    hash_bytes = raw[KD_HASH_OFFSET : KD_HASH_OFFSET + KD_HASH_BYTES]
+    return SidecarHeader(
+        version=version,
+        k=int(fields[3]),
+        n_tokens=int(fields[4]),
+        vocab_size=int(fields[5]),
+        logprob_dtype=int(fields[6]),
+        tokenize_hash=hash_bytes.rstrip(b"\x00").decode("ascii", errors="replace"),
+    )
+
+
+class SidecarWriter:
+    """Streaming writer for a `.kd` sidecar.
+
+    Preallocates the full file (header + ids block + logprobs block) and
+    memory-maps both blocks, so rows can be appended in order while the ids
+    block physically precedes the logprobs block. Unwritten tail rows stay
+    zero-filled (the preallocation writes zeros).
+    """
+
+    def __init__(self, path: str, n_tokens: int, k: int, vocab_size: int, tokenize_hash: str):
+        if not 1 <= k <= KD_MAX_TOP_K:
+            raise ValueError(f"k must be in [1, {KD_MAX_TOP_K}], got {k}.")
+        if n_tokens <= 0:
+            raise ValueError(f"n_tokens must be positive, got {n_tokens}.")
+        if not 0 < vocab_size < 2**31:
+            raise ValueError(f"vocab_size must be in (0, 2^31), got {vocab_size}.")
+        self.path = path
+        self.header = SidecarHeader(
+            version=KD_VERSION,
+            k=k,
+            n_tokens=n_tokens,
+            vocab_size=vocab_size,
+            logprob_dtype=KD_LOGPROB_DTYPE_FP16,
+            tokenize_hash=tokenize_hash,
+        )
+        with open(path, "wb") as f:
+            write_sidecar_header(f, self.header)
+            f.truncate(self.header.file_size)
+        self._ids = np.memmap(path, dtype="<u4", mode="r+", offset=self.header.ids_offset, shape=(n_tokens, k))
+        self._logprobs = np.memmap(
+            path, dtype="<f2", mode="r+", offset=self.header.logprobs_offset, shape=(n_tokens, k)
+        )
+        self.rows_written = 0
+
+    def write_rows(self, ids: np.ndarray, logprobs: np.ndarray) -> None:
+        """Append `(rows, k)` teacher top-k ids and logprobs at the next row."""
+        ids = np.asarray(ids)
+        logprobs = np.asarray(logprobs)
+        if ids.ndim != 2 or ids.shape[1] != self.header.k:
+            raise ValueError(f"ids must have shape (rows, {self.header.k}), got {ids.shape}.")
+        if logprobs.shape != ids.shape:
+            raise ValueError(f"logprobs shape {logprobs.shape} does not match ids shape {ids.shape}.")
+        end = self.rows_written + ids.shape[0]
+        if end > self.header.n_tokens:
+            raise ValueError(
+                f"write_rows overflows the sidecar: {end} rows > n_tokens={self.header.n_tokens}."
+            )
+        self._ids[self.rows_written : end] = ids.astype(np.uint32, copy=False)
+        self._logprobs[self.rows_written : end] = logprobs.astype(np.float16, copy=False)
+        self.rows_written = end
+
+    def close(self) -> None:
+        if self._ids is None:
+            return
+        self._ids.flush()
+        self._logprobs.flush()
+        self._ids = None
+        self._logprobs = None
+
+    def __enter__(self) -> SidecarWriter:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+
+def read_sidecar(path: str) -> tuple[SidecarHeader, np.ndarray, np.ndarray]:
+    """Read a sidecar; returns (header, ids [n_tokens, k] uint32, logprobs [n_tokens, k] fp16).
+
+    The arrays are read-only memory maps.
+    """
+    header = read_sidecar_header(path)
+    ids = np.memmap(path, dtype="<u4", mode="r", offset=header.ids_offset, shape=(header.n_tokens, header.k))
+    logprobs = np.memmap(
+        path, dtype="<f2", mode="r", offset=header.logprobs_offset, shape=(header.n_tokens, header.k)
+    )
+    return header, ids, logprobs
+
+
+def validate_sidecar(
+    path: str,
+    token_shard_path: str,
+    expect_k: int | None = None,
+    expect_hash: str | None = None,
+) -> SidecarHeader:
+    """Validate a sidecar against its token shard; raises ValueError with an actionable message."""
+    if not os.path.exists(path):
+        raise ValueError(
+            f"KD sidecar '{path}' is missing for token shard '{token_shard_path}'. "
+            "Run `surogate distill-capture <config.yaml>` to capture teacher logprobs."
+        )
+    header = read_sidecar_header(path)
+    token_header = read_token_shard_header(token_shard_path)
+
+    if not 1 <= header.k <= KD_MAX_TOP_K:
+        raise ValueError(f"KD sidecar '{path}' has invalid k={header.k} (expected 1..{KD_MAX_TOP_K}).")
+    if header.logprob_dtype != KD_LOGPROB_DTYPE_FP16:
+        raise ValueError(
+            f"KD sidecar '{path}' has unsupported logprob_dtype={header.logprob_dtype} (only fp16=0 in v1)."
+        )
+    if not 0 < header.vocab_size < 2**31:
+        raise ValueError(f"KD sidecar '{path}' has invalid vocab_size={header.vocab_size}.")
+    if header.n_tokens != token_header.n_tokens:
+        raise ValueError(
+            f"KD sidecar '{path}' has n_tokens={header.n_tokens} but token shard "
+            f"'{token_shard_path}' has n_tokens={token_header.n_tokens}. The token shards were "
+            "re-tokenized after capture — re-run `surogate distill-capture`."
+        )
+    if expect_k is not None and header.k != expect_k:
+        raise ValueError(
+            f"KD sidecar '{path}' was captured with top_k={header.k} but the config requests "
+            f"top_k={expect_k}. Re-run `surogate distill-capture` with the desired distillation.top_k."
+        )
+    if expect_hash is not None and header.tokenize_hash != expect_hash:
+        raise ValueError(
+            f"KD sidecar '{path}' embeds tokenize hash '{header.tokenize_hash}' but the current "
+            f"token shards have hash '{expect_hash}'. The token shards were re-tokenized — "
+            "re-run `surogate distill-capture`."
+        )
+    actual_size = os.path.getsize(path)
+    if actual_size != header.file_size:
+        raise ValueError(
+            f"KD sidecar '{path}' is truncated or oversized: {actual_size} bytes on disk, header "
+            f"implies {header.file_size}. The capture likely did not finish — re-run "
+            "`surogate distill-capture`."
+        )
+    return header

--- a/surogate/train/metrics.py
+++ b/surogate/train/metrics.py
@@ -65,6 +65,7 @@ class StepMetrics:
     phase: str = ""
     lr_overridden: bool = False
     moe: MoEMetrics | None = None
+    kd_loss: float | None = None
 
     # -- derived helpers --
 
@@ -102,4 +103,6 @@ class StepMetrics:
             d["moe_load_cv"] = self.moe.load_cv
             d["moe_router_entropy"] = self.moe.router_entropy
             d["moe_router_confidence"] = self.moe.router_confidence
+        if self.kd_loss is not None:
+            d["kd_loss"] = self.kd_loss
         return d

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -345,6 +345,13 @@ class SurogateTrainerWrapper:
         )
         self.chunk_size = config.per_device_train_batch_size * config.sequence_len * config.gpus
 
+        self._kd_enabled = config.distillation is not None
+        if self._kd_enabled and self._train_vision:
+            raise ValueError(
+                "distillation requires tokenized token shards with .kd sidecars; "
+                "on-the-fly vision training (train_vision) is not supported with KD."
+            )
+
         if self._train_vision:
             if config.sample_packing:
                 logger.warning("train_vision disables sample_packing; forcing sample_packing=False.")
@@ -382,10 +389,15 @@ class SurogateTrainerWrapper:
             )
             self.steps_per_epoch = self.mm_batcher.steps_per_epoch
         else:
+            if self._kd_enabled:
+                self._validate_kd_sidecars(train_files)
             self.train_loader = _surogate.DataLoader(train_files, self.chunk_size, seed=config.train_seed)
             self.eval_loader = (
                 _surogate.DataLoader(eval_files, self.chunk_size, seed=config.eval_seed) if eval_files else None
             )
+            if self._kd_enabled:
+                # Eval stays CE-only; only the train loader serves KD sidecars.
+                self.train_loader.enable_kd(config.distillation.top_k)
 
             # Calculate steps
             self.steps_per_epoch = self.train_loader.num_tokens // self.total_batch_size
@@ -580,6 +592,67 @@ class SurogateTrainerWrapper:
             final_lr=config.learning_rate * config.final_lr_fraction,
             schedule_type=config.lr_scheduler_type,
             wsd_decay_steps_fraction=config.wsd_decay_steps_fraction,
+        )
+
+    def _validate_kd_sidecars(self, train_files: list[str]) -> None:
+        """Validate every train shard's .kd sidecar before the native DataLoader opens them.
+
+        Cross-checks the tokenize hash embedded in each sidecar against
+        `{output_dir}/.tokenize_hash` so stale captures (re-tokenized shards)
+        fail with an actionable message instead of feeding misaligned teacher
+        rows to training.
+        """
+        from surogate.distill.sidecar import (
+            read_sidecar_header,
+            read_token_shard_header,
+            sidecar_path_for,
+            validate_sidecar,
+        )
+        from surogate.train.tokenize import read_tokenize_hash
+
+        expected_hash = read_tokenize_hash(self.config.output_dir)
+        if not expected_hash:
+            raise ValueError(
+                f"distillation is enabled but no {self.config.output_dir}/.tokenize_hash was found; "
+                "cannot verify that the .kd sidecars match the token shards. Re-run tokenization "
+                "and `surogate distill-capture`."
+            )
+        kd_dir = self.config.distillation.kd_dir
+        vocab_warned = False
+        for shard in train_files:
+            sidecar = sidecar_path_for(shard, kd_dir)
+            validate_sidecar(
+                sidecar,
+                shard,
+                expect_k=self.config.distillation.top_k,
+                expect_hash=expected_hash,
+            )
+            # The native DataLoader always opens `<shard>.kd`; bridge kd_dir
+            # captures with a symlink so both layers read the validated file.
+            default_path = shard + ".kd"
+            if os.path.abspath(sidecar) != os.path.abspath(default_path):
+                if os.path.islink(default_path) or not os.path.exists(default_path):
+                    if os.path.islink(default_path):
+                        os.unlink(default_path)
+                    os.symlink(os.path.abspath(sidecar), default_path)
+                else:
+                    raise ValueError(
+                        f"distillation.kd_dir points at {sidecar} but a different sidecar already "
+                        f"exists at {default_path}; remove one of them."
+                    )
+            if not vocab_warned:
+                kd_vocab = read_sidecar_header(sidecar).vocab_size
+                student_vocab = read_token_shard_header(shard).vocab_size
+                if kd_vocab > student_vocab:
+                    logger.warning(
+                        f"KD sidecars were captured with teacher vocab {kd_vocab} > student vocab "
+                        f"{student_vocab}; teacher entries outside the student vocab are "
+                        "renormalized away (missing-probability = zero)."
+                    )
+                vocab_warned = True
+        logger.info(
+            f"Validated {len(train_files)} KD sidecar(s) "
+            f"(top_k={self.config.distillation.top_k}, hash={expected_hash})."
         )
 
     def _detect_pos_planes(self) -> int:
@@ -1124,6 +1197,18 @@ class SurogateTrainerWrapper:
         # Pass those IDs through and let C++ expand planes as needed.
         pos_ids = np.empty((total_rows, self.config.sequence_len), dtype=np.int32)
 
+        # KD host staging buffers: one gpus*B chunk per micro-step (KD steps run
+        # eagerly, one micro-step at a time).
+        kd_ids = kd_logprobs = None
+        if self._kd_enabled:
+            kd_chunk_rows = self.config.gpus * self.config.per_device_train_batch_size
+            kd_ids = np.empty(
+                (kd_chunk_rows, self.config.sequence_len, self.config.distillation.top_k), dtype=np.int32
+            )
+            kd_logprobs = np.empty(
+                (kd_chunk_rows, self.config.sequence_len, self.config.distillation.top_k), dtype=np.float32
+            )
+
         # Dispatch-PP: partition the transformer blocks into contiguous stages over
         # the GPU pool (stage i -> GPU i % gpus). The fused training step dispatches
         # each stage round-robin, hands activations/grads GPU->host->GPU, optimizes
@@ -1284,7 +1369,29 @@ class SurogateTrainerWrapper:
             # Training step
             step_start = time.time()
 
-            if self._dispatch_pp:
+            if self._kd_enabled:
+                # KD micro-steps: load one gpus*B chunk plus its teacher top-k rows,
+                # run the forward/backward per micro-step; the optimizer update
+                # happens once below via update_with_config.
+                chunk = self.config.gpus * self.config.per_device_train_batch_size
+                for micro_step in range(self.config.gradient_accumulation_steps):
+                    if not self.train_loader.has_next():
+                        self.train_loader.advance_epoch()
+                    self.train_loader.load_batch(
+                        in_tokens[:chunk], out_tokens[:chunk], pos_ids[:chunk], kd_ids, kd_logprobs
+                    )
+                    self.trainer.step_with_kd(
+                        in_tokens[:chunk],
+                        out_tokens[:chunk],
+                        kd_ids,
+                        kd_logprobs,
+                        position_ids=pos_ids[:chunk],
+                        top_k=self.config.distillation.top_k,
+                        temperature=self.config.distillation.temperature,
+                        kd_weight=self.config.distillation.kd_weight,
+                        ce_weight=self.config.distillation.ce_weight,
+                    )
+            elif self._dispatch_pp:
                 # Fill all gpus*bsz*_dpp_chunks rows = M microbatches. The loader yields one
                 # gpus*bsz chunk per call, so load _dpp_chunks of them into the buffer.
                 chunk = self.config.gpus * self.config.per_device_train_batch_size
@@ -1331,7 +1438,13 @@ class SurogateTrainerWrapper:
                 normuon_lr=lr,  # Use same LR for NorMuon
                 normuon_cautious_wd=self.config.normuon_cautious_wd,
             )
-            if self._dispatch_pp:
+            kd_loss = None
+            if self._kd_enabled:
+                # Optional LoRA gradient debug (before optimizer update)
+                self._maybe_log_lora_grad_stats(step)
+                result = self.trainer.update_with_config(opt_config, step + 1)
+                kd_loss = self.trainer.get_kd_loss()
+            elif self._dispatch_pp:
                 # Stage-level dispatch: forward+backward across the GPU pool, collect grads
                 # to the master, optimize, broadcast. One fused call. Each small stage runs
                 # on GPU s%N with its weights held resident across all M microbatches
@@ -1402,6 +1515,7 @@ class SurogateTrainerWrapper:
                 phase=phase.value,
                 lr_overridden=self.lr_schedule.has_override,
                 moe=MoEMetrics.from_dict(self.trainer.get_moe_stats()),
+                kd_loss=kd_loss,
             )
             moe_monitor.step(metrics.moe, step)
             advisor.step(metrics, step)
@@ -1431,6 +1545,17 @@ class SurogateTrainerWrapper:
                         metrics.moe.load_cv,
                         metrics.moe.router_entropy,
                         metrics.moe.router_confidence,
+                    )
+                elif metrics.kd_loss is not None:
+                    train_logger.log_step_kd(
+                        metrics.step,
+                        metrics.epoch,
+                        metrics.tokens,
+                        metrics.elapsed_ms,
+                        metrics.grad_norm,
+                        metrics.loss,
+                        metrics.lr,
+                        metrics.kd_loss,
                     )
                 else:
                     train_logger.log_step(

--- a/surogate/transplant/__init__.py
+++ b/surogate/transplant/__init__.py
@@ -1,0 +1,7 @@
+from surogate.transplant.transplant import (
+    TRANSPLANT_MANIFEST,
+    run_transplant,
+    run_transplant_back,
+)
+
+__all__ = ["TRANSPLANT_MANIFEST", "run_transplant", "run_transplant_back"]

--- a/surogate/transplant/transplant.py
+++ b/surogate/transplant/transplant.py
@@ -1,0 +1,232 @@
+"""Vocabulary transplantation for cross-tokenizer knowledge distillation.
+
+Wraps `mergekit-tokensurgeon` (Arcee's tokenizer-transplant tool) as a
+subprocess: the student model's embedding and LM-head rows are reconstructed
+for the teacher's vocabulary (shared tokens copied exactly, new tokens
+approximated — default method OMP with k=64, per arXiv:2506.06607). After the
+transplant the student uses the teacher's tokenizer, so the existing
+same-tokenizer KD pipeline (tokenize → distill-capture → sft) runs unchanged.
+
+mergekit is an OPTIONAL dependency, invoked strictly as an external command:
+it is LGPL-3.0-licensed and must not be vendored or imported into surogate.
+Install it with `pip install mergekit` (or run via `uvx --from mergekit ...`
+in a separate environment to avoid its pydantic/click pins).
+
+A `transplant_manifest.json` is written next to the output model so the
+reverse transplant (back to the student's native tokenizer after KD training)
+can be driven by `surogate transplant-tokenizer --restore`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+TRANSPLANT_MANIFEST = "transplant_manifest.json"
+
+_APPROXIMATION_METHODS = (
+    "omp",
+    "common_interpolation",
+    "subword",
+    "mean",
+    "zero",
+    "randn",
+    "john_hewitt",
+    "landmark_pca",
+    "sparse_token_basis",
+    "mp_rope",
+)
+
+_INSTALL_GUIDANCE = (
+    "mergekit-tokensurgeon was not found on PATH. Vocabulary transplantation uses "
+    "mergekit (LGPL-3.0) as an external tool; install it with `pip install mergekit` "
+    "or run surogate transplant-tokenizer inside an environment where "
+    "`uvx --from mergekit mergekit-tokensurgeon` works. mergekit is intentionally NOT "
+    "a surogate dependency (license + pinned-dependency isolation)."
+)
+
+
+def _find_tokensurgeon() -> list[str]:
+    exe = shutil.which("mergekit-tokensurgeon")
+    if exe:
+        return [exe]
+    raise RuntimeError(_INSTALL_GUIDANCE)
+
+
+def _resolve_model_dir(model: str) -> str:
+    """Local directory as-is; otherwise download the HF snapshot (merge.py idiom)."""
+    if os.path.isdir(model):
+        return model
+    from huggingface_hub import snapshot_download
+
+    logger.info(f"Downloading model from HuggingFace: {model}")
+    return snapshot_download(model)
+
+
+def _validate_output_model(out_dir: str) -> dict:
+    config_path = os.path.join(out_dir, "config.json")
+    if not os.path.exists(config_path):
+        raise RuntimeError(
+            f"tokensurgeon produced no config.json in {out_dir}; the transplant did not complete."
+        )
+    with open(config_path) as f:
+        config = json.load(f)
+
+    has_tokenizer = any(
+        os.path.exists(os.path.join(out_dir, name)) for name in ("tokenizer.json", "tokenizer.model")
+    )
+    if not has_tokenizer:
+        raise RuntimeError(
+            f"tokensurgeon output {out_dir} has no tokenizer.json/tokenizer.model — the donor "
+            "tokenizer was not written; re-run with --trust-remote-code if the donor needs it."
+        )
+    has_weights = any(name.endswith(".safetensors") for name in os.listdir(out_dir))
+    if not has_weights:
+        raise RuntimeError(f"tokensurgeon output {out_dir} contains no safetensors weight files.")
+
+    if config.get("tie_word_embeddings"):
+        logger.warning(
+            "Transplanted model has tie_word_embeddings=true: input embeddings and LM head share "
+            "one matrix, so the transplant solves a compromise between the two approximations. "
+            "Small tied-embedding students heal, but expect a few hundred million KD tokens "
+            "before quality recovers."
+        )
+    return config
+
+
+def _run_tokensurgeon(
+    base_model: str,
+    donor_model: str,
+    out_dir: str,
+    method: str,
+    k: int,
+    device: str | None,
+    trust_remote_code: bool,
+    extra_args: list[str] | None,
+) -> None:
+    if method not in _APPROXIMATION_METHODS:
+        raise ValueError(
+            f"Unknown approximation method '{method}'. Supported: {', '.join(_APPROXIMATION_METHODS)}."
+        )
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k}.")
+
+    cmd = _find_tokensurgeon() + [
+        base_model,
+        donor_model,
+        out_dir,
+        "--approximation-method",
+        method,
+        "--k",
+        str(k),
+    ]
+    if device:
+        cmd += ["--device", device]
+    if trust_remote_code:
+        cmd += ["--trust-remote-code"]
+    if extra_args:
+        cmd += list(extra_args)
+
+    logger.info(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()[-15:]
+        raise RuntimeError(
+            f"mergekit-tokensurgeon failed (exit {result.returncode}):\n" + "\n".join(tail)
+        )
+
+
+def run_transplant(
+    student_model: str,
+    teacher_model: str,
+    out_dir: str,
+    method: str = "omp",
+    k: int = 64,
+    device: str | None = None,
+    trust_remote_code: bool = False,
+    extra_args: list[str] | None = None,
+) -> str:
+    """Transplant the teacher's tokenizer onto the student model.
+
+    Returns the output model directory. The output carries the student's
+    weights with embedding/LM-head rows rebuilt for the teacher vocabulary,
+    plus the teacher's tokenizer files — ready for the same-tokenizer KD
+    pipeline (`surogate tokenize` / `distill-capture` / `sft` against it).
+    """
+    student_dir = _resolve_model_dir(student_model)
+    teacher_dir = _resolve_model_dir(teacher_model)
+
+    _run_tokensurgeon(
+        student_dir, teacher_dir, out_dir, method, k, device, trust_remote_code, extra_args
+    )
+    _validate_output_model(out_dir)
+
+    manifest = {
+        "version": 1,
+        "student_model": student_model,
+        "student_dir": os.path.abspath(student_dir),
+        "teacher_model": teacher_model,
+        "teacher_dir": os.path.abspath(teacher_dir),
+        "method": method,
+        "k": k,
+        "created_unix": int(time.time()),
+    }
+    with open(os.path.join(out_dir, TRANSPLANT_MANIFEST), "w") as f:
+        json.dump(manifest, f, indent=2)
+    logger.info(
+        f"Transplant complete: {out_dir} now uses the tokenizer of {teacher_model}. "
+        f"Next: point your KD config's `model:` at it, then run `surogate distill-capture` "
+        f"and `surogate sft`. Restore the native tokenizer afterwards with "
+        f"`surogate transplant-tokenizer --restore {out_dir}/{TRANSPLANT_MANIFEST} ...`."
+    )
+    return out_dir
+
+
+def run_transplant_back(
+    distilled_model: str,
+    manifest_path: str,
+    out_dir: str,
+    device: str | None = None,
+    trust_remote_code: bool = False,
+    extra_args: list[str] | None = None,
+) -> str:
+    """Transplant a distilled model back to the original student tokenizer.
+
+    `distilled_model` is the KD-trained model (teacher vocabulary);
+    `manifest_path` is the transplant_manifest.json written by run_transplant.
+    The original student model acts as the tokenizer donor. A short SFT on
+    native-template data afterwards is recommended (chat-template semantics
+    shift back with the tokenizer).
+    """
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    donor = manifest.get("student_dir") or manifest.get("student_model")
+    if not donor:
+        raise ValueError(f"Manifest {manifest_path} has no student_model/student_dir entry.")
+    if not os.path.isdir(donor):
+        donor = _resolve_model_dir(manifest["student_model"])
+
+    distilled_dir = _resolve_model_dir(distilled_model)
+    _run_tokensurgeon(
+        distilled_dir,
+        donor,
+        out_dir,
+        manifest.get("method", "omp"),
+        int(manifest.get("k", 64)),
+        device,
+        trust_remote_code,
+        extra_args,
+    )
+    _validate_output_model(out_dir)
+    logger.info(
+        f"Restored native tokenizer: {out_dir}. A short healing SFT on native-template data "
+        "is recommended before release."
+    )
+    return out_dir

--- a/tests/distill/test_capture.py
+++ b/tests/distill/test_capture.py
@@ -1,0 +1,155 @@
+"""Local HF capture correctness: per-document attention isolation and alignment.
+
+Builds a tiny packed token shard (multiple docs with position-id resets), runs
+`capture_shard` with a cached small teacher, and compares each captured row
+against a reference computed by feeding EVERY DOCUMENT AS ITS OWN SEQUENCE.
+The per-doc reference makes this test sensitive to cross-document attention
+leaks: if the capture forward did not isolate packed documents (flash-attention
+varlen), rows after the first doc boundary diverge.
+
+Requirements: 1 GPU, flash-attn installed, cached Qwen3 weights
+(QWEN3_MODEL_PATH or HF cache for Qwen/Qwen3-0.6B / Qwen/Qwen3-1.7B /
+Qwen/Qwen3.5-0.8B).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+transformers = pytest.importorskip("transformers")
+pytest.importorskip("flash_attn", reason="capture's document isolation requires flash-attention-2")
+
+from surogate.distill.capture import capture_shard, _load_teacher
+from surogate.distill.sidecar import read_sidecar, read_token_shard_header
+
+pytestmark = [pytest.mark.gpu, pytest.mark.slow]
+
+CANDIDATE_MODELS = ["Qwen/Qwen3-0.6B", "Qwen/Qwen3-1.7B", "Qwen/Qwen3.5-0.8B"]
+ENV_VAR = "QWEN3_MODEL_PATH"
+SEQ_LEN = 96
+TOP_K = 8
+HASH = "fedcba9876543210"
+# Docs per window chosen so windows contain internal doc boundaries AND one
+# doc crosses a window boundary (truncated at the window edge like tokenize
+# packing does not allow, but position ids simply keep counting — the capture
+# splits at window starts regardless, matching DataLoader chunk semantics).
+DOC_LENS = [40, 56, 33, 63, 30]  # = 222 tokens -> 2 full windows + 30 tail
+
+
+def resolve_model_path() -> Path | None:
+    env = os.environ.get(ENV_VAR)
+    if env and Path(env).exists():
+        return Path(env)
+    cache_root = Path("~/.cache/huggingface/hub").expanduser()
+    for model_id in CANDIDATE_MODELS:
+        snaps = cache_root / f"models--{model_id.replace('/', '--')}" / "snapshots"
+        if snaps.exists():
+            for snap in sorted(snaps.iterdir(), reverse=True):
+                if (snap / "config.json").exists():
+                    return snap
+    return None
+
+
+def write_token_shard(path, tokens: np.ndarray, position_ids: np.ndarray, vocab_size: int) -> None:
+    header = np.zeros(256, dtype=np.int32)
+    header[0:2] = np.frombuffer(b"BIN.TOK\n", dtype=np.int32)
+    header[2] = 3
+    header[3] = 4
+    header[4] = len(tokens)
+    header[5] = vocab_size
+    with open(path, "wb") as f:
+        header.tofile(f)
+        tokens.astype(np.int32).tofile(f)
+        position_ids.astype(np.int32).tofile(f)
+
+
+@pytest.fixture(scope="module")
+def teacher():
+    snapshot = resolve_model_path()
+    if snapshot is None:
+        pytest.skip(f"No cached teacher. Set {ENV_VAR} or cache one of {CANDIDATE_MODELS}")
+    model = _load_teacher(str(snapshot), "cuda", allow_cross_doc_attention=False)
+    yield snapshot, model
+    del model
+    torch.cuda.empty_cache()
+
+
+def test_capture_matches_per_document_reference(tmp_path, teacher):
+    snapshot, model = teacher
+    vocab_size = model.config.vocab_size
+
+    rng = np.random.default_rng(99)
+    tokens = rng.integers(0, min(vocab_size, 50000), size=sum(DOC_LENS), dtype=np.int32)
+    position_ids = np.concatenate([np.arange(n, dtype=np.int32) for n in DOC_LENS])
+    n_tokens = len(tokens)
+
+    shard = tmp_path / "train-000.bin"
+    write_token_shard(shard, tokens, position_ids, vocab_size)
+
+    capture_shard(
+        model,
+        str(shard),
+        str(shard) + ".kd",
+        top_k=TOP_K,
+        sequence_len=SEQ_LEN,
+        teacher_batch_size=2,
+        teacher_vocab_size=vocab_size,
+        tokenize_hash=HASH,
+        device="cuda",
+    )
+    header, cap_ids, cap_lps = read_sidecar(str(shard) + ".kd")
+    assert header.k == TOP_K and header.n_tokens == n_tokens
+
+    # Reference: independent forward per (window-truncated) document segment.
+    # Segments are what the student attends over: doc boundaries reset at
+    # position-id drops AND at every window boundary.
+    n_windows = n_tokens // SEQ_LEN
+    boundaries = sorted(
+        {i for i in range(n_windows * SEQ_LEN) if i % SEQ_LEN == 0 or position_ids[i] == 0}
+    ) + [n_windows * SEQ_LEN]
+    top1_match = 0
+    checked = 0
+    with torch.inference_mode():
+        for a, b in zip(boundaries[:-1], boundaries[1:]):
+            seg = torch.tensor(tokens[a:b].astype(np.int64), device="cuda").unsqueeze(0)
+            logits = model(input_ids=seg).logits[0].float()
+            ref_lp = torch.log_softmax(logits, dim=-1).cpu()
+            # Row a+i predicts tokens[a+i+1]; the segment's last row predicts
+            # the next segment's first token — captured, and comparable, since
+            # both use only the segment's context.
+            for i in range(b - a):
+                row = a + i
+                if row >= n_windows * SEQ_LEN:
+                    break
+                ref_row = ref_lp[i]
+                ref_vals, ref_ids = torch.topk(ref_row, TOP_K)
+                cap_row_ids = cap_ids[row].astype(np.int64)
+                cap_row_lps = cap_lps[row].astype(np.float32)
+                checked += 1
+                if int(ref_ids[0]) == int(cap_row_ids[0]):
+                    top1_match += 1
+                # Mass agreement over the union of both top-k sets: tight when
+                # attention contexts match, badly off when the capture leaked
+                # attention across documents.
+                union = sorted(set(cap_row_ids.tolist()) | set(int(x) for x in ref_ids))
+                ref_p = {int(t): float(np.exp(ref_row[t])) for t in union}
+                cap_p = {int(t): 0.0 for t in union}
+                for t, lp in zip(cap_row_ids, cap_row_lps):
+                    cap_p[int(t)] = float(np.exp(lp))
+                l1 = sum(abs(ref_p[t] - cap_p.get(t, 0.0)) for t in union)
+                assert l1 < 0.15, (
+                    f"row {row}: captured top-k distribution diverges from the per-document "
+                    f"reference (L1 over union = {l1:.3f}) — cross-document attention leak?"
+                )
+
+    assert checked == n_windows * SEQ_LEN
+    assert top1_match / checked > 0.98, f"top-1 agreement only {top1_match}/{checked}"
+
+    # Tail rows past the last full window stay zero-filled.
+    tail = cap_lps[n_windows * SEQ_LEN :]
+    assert np.all(tail == 0)

--- a/tests/distill/test_capture_api.py
+++ b/tests/distill/test_capture_api.py
@@ -1,0 +1,245 @@
+"""CPU tests for the OpenAI-compatible API capture backend (mocked vLLM server).
+
+Uses httpx.MockTransport, so no network or GPU is involved; the fake teacher is
+deterministic: at every position the top candidates predicting the next token
+are (prev_token + 1 + r) % VOCAB with logprob -0.5 - r for rank r.
+"""
+
+import json
+import threading
+
+import numpy as np
+import pytest
+
+httpx = pytest.importorskip("httpx")
+capture = pytest.importorskip("surogate.distill.capture", reason="requires the built _surogate native module")
+
+from surogate.distill.capture import _doc_spans, _make_api_client, capture_shard_api  # noqa: E402
+from surogate.distill.sidecar import read_sidecar, validate_sidecar  # noqa: E402
+
+VOCAB = 50
+HASH = "0123456789abcdef"
+API_BASE = "http://fake-teacher:8000/v1"
+
+
+def _write_token_shard(path, tokens, position_ids, vocab_size=VOCAB):
+    tokens = np.asarray(tokens, dtype="<i4")
+    position_ids = np.asarray(position_ids, dtype="<i4")
+    assert len(tokens) == len(position_ids)
+    header = bytearray(1024)
+    header[0:8] = b"BIN.TOK\n"
+    header[8:32] = np.array([3, 4, len(tokens), vocab_size, 0, 0], dtype="<i4").tobytes()
+    with open(path, "wb") as f:
+        f.write(bytes(header))
+        f.write(tokens.tobytes())
+        f.write(position_ids.tobytes())
+
+
+def _packed_shard(tmp_path, doc_lengths, n_tokens=None):
+    """Shard with per-doc position resets (0..len-1 per doc), like sample packing."""
+    pos = np.concatenate([np.arange(l, dtype=np.int32) for l in doc_lengths])
+    if n_tokens is not None:
+        assert len(pos) == n_tokens
+    tokens = ((np.arange(len(pos)) * 3 + 1) % VOCAB).astype(np.int32)
+    shard = str(tmp_path / "train-000.bin")
+    _write_token_shard(shard, tokens, pos)
+    return shard, tokens, pos
+
+
+class FakeVLLM:
+    """MockTransport handler mimicking vLLM's /completions prompt_logprobs response."""
+
+    def __init__(self, extra_candidates=0, max_candidates=None, fail_first=0, omit_prompt_logprobs=False,
+                 error_response=None):
+        self.extra_candidates = extra_candidates
+        self.max_candidates = max_candidates
+        self.fail_first = fail_first
+        self.omit_prompt_logprobs = omit_prompt_logprobs
+        self.error_response = error_response
+        self.calls = 0
+        self.requests = []
+        self._lock = threading.Lock()
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        with self._lock:
+            self.calls += 1
+            call_index = self.calls
+            self.requests.append(
+                {"path": request.url.path, "body": body, "auth": request.headers.get("authorization")}
+            )
+        if self.error_response is not None:
+            return httpx.Response(self.error_response[0], json=self.error_response[1])
+        if call_index <= self.fail_first:
+            return httpx.Response(500, json={"error": "transient boom"})
+        if self.omit_prompt_logprobs:
+            # Plain OpenAI completions response (e.g. an aggregator like OpenRouter).
+            return httpx.Response(200, json={"choices": [{"index": 0, "text": "x"}]})
+        k = int(body["prompt_logprobs"])
+        n_cands = self.max_candidates if self.max_candidates is not None else k + self.extra_candidates
+        prompt = body["prompt"]
+        plp = [None]
+        for i in range(1, len(prompt)):
+            prev = int(prompt[i - 1])
+            plp.append(
+                {str((prev + 1 + r) % VOCAB): {"logprob": -0.5 - r, "rank": r + 1} for r in range(n_cands)}
+            )
+        return httpx.Response(200, json={"choices": [{"index": 0, "text": "", "prompt_logprobs": plp}]})
+
+
+def _client(handler):
+    # Mirrors _make_api_client's construction (unset key env -> "EMPTY") with a
+    # mock transport; _make_api_client itself is covered by test_api_key_from_env_var.
+    return httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url=API_BASE,
+        headers={"Authorization": "Bearer EMPTY"},
+    )
+
+
+def _run(handler, shard, top_k=2, sequence_len=8, concurrency=2):
+    with _client(handler) as client:
+        capture_shard_api(
+            client,
+            "teacher-x",
+            shard,
+            shard + ".kd",
+            top_k=top_k,
+            sequence_len=sequence_len,
+            concurrency=concurrency,
+            tokenize_hash=HASH,
+            retry_backoff=0.0,
+        )
+
+
+def test_doc_spans():
+    pos = np.concatenate([np.arange(5), np.arange(6), np.arange(9)]).astype(np.int32)  # docs at 0, 5, 11
+    assert _doc_spans(pos, 0, 8) == [(0, 5), (5, 8)]
+    # Window start is always a span start even mid-document.
+    assert _doc_spans(pos, 8, 16) == [(8, 11), (11, 16)]
+    assert _doc_spans(None, 8, 16) == [(8, 16)]
+
+
+def test_request_shape_doc_split_and_alignment(tmp_path):
+    shard, tokens, _ = _packed_shard(tmp_path, [5, 6, 9], n_tokens=20)  # S=8 -> 2 windows, tail 4
+    handler = FakeVLLM()
+    _run(handler, shard)
+
+    # (a) request shape: token-id prompt, prompt_logprobs=K, served model name.
+    for req in handler.requests:
+        assert req["path"] == "/v1/completions"
+        body = req["body"]
+        assert body["model"] == "teacher-x"
+        assert isinstance(body["prompt"], list) and all(isinstance(t, int) for t in body["prompt"])
+        assert body["prompt_logprobs"] == 2
+        assert body["max_tokens"] == 1
+        assert body["temperature"] == 1.0
+        assert req["auth"] == "Bearer EMPTY"
+
+    # (b) per-doc splitting at position resets, with one-token lookahead. The doc
+    # spanning the window boundary [8,16) restarts at the window start.
+    expected_prompts = {
+        tuple(tokens[0:6].tolist()),   # doc [0,5) + lookahead
+        tuple(tokens[5:9].tolist()),   # doc [5,8) (cut at window end) + lookahead across the boundary
+        tuple(tokens[8:12].tolist()),  # doc fragment [8,11) + lookahead
+        tuple(tokens[11:17].tolist()),  # doc [11,16) (cut at window end) + lookahead
+    }
+    assert {tuple(r["body"]["prompt"]) for r in handler.requests} == expected_prompts
+
+    # (c) row alignment: prompt_logprobs[i] predicts prompt position i, stored at
+    # sidecar row a+i-1; with the fake teacher, row r's top-1 is (tokens[r]+1)%V.
+    validate_sidecar(shard + ".kd", shard, expect_k=2, expect_hash=HASH)
+    _, ids, lps = read_sidecar(shard + ".kd")
+    captured = 16  # 2 full windows; rows 16..19 are tail
+    np.testing.assert_array_equal(np.asarray(ids[:captured, 0]), (tokens[:captured] + 1) % VOCAB)
+    np.testing.assert_array_equal(np.asarray(ids[:captured, 1]), (tokens[:captured] + 2) % VOCAB)
+    # fp16 roundtrip is exact for -0.5 / -1.5.
+    np.testing.assert_array_equal(np.asarray(lps[:captured, 0], dtype=np.float32), -0.5)
+    np.testing.assert_array_equal(np.asarray(lps[:captured, 1], dtype=np.float32), -1.5)
+    np.testing.assert_array_equal(np.asarray(ids[captured:]), 0)
+
+
+def test_no_lookahead_at_shard_end(tmp_path):
+    # Single doc ending exactly at n_tokens == n_windows*S: the final row has no
+    # next token, so it stays zero-filled (existing local-backend semantics).
+    shard, tokens, _ = _packed_shard(tmp_path, [16], n_tokens=16)
+    handler = FakeVLLM()
+    _run(handler, shard, sequence_len=8)
+    prompts = sorted(tuple(r["body"]["prompt"]) for r in handler.requests)
+    assert prompts == sorted([tuple(tokens[0:9].tolist()), tuple(tokens[8:16].tolist())])
+    _, ids, _ = read_sidecar(shard + ".kd")
+    np.testing.assert_array_equal(np.asarray(ids[:15, 0]), (tokens[:15] + 1) % VOCAB)
+    np.testing.assert_array_equal(np.asarray(ids[15]), 0)
+
+
+def test_k_plus_one_candidates_truncated_by_logprob(tmp_path):
+    # vLLM may return K+1 entries when the actual token is outside the top-K;
+    # capture keeps the top K by logprob.
+    shard, tokens, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(extra_candidates=1)
+    _run(handler, shard, top_k=2)
+    _, ids, lps = read_sidecar(shard + ".kd")
+    np.testing.assert_array_equal(np.asarray(ids[:7, 0]), (tokens[:7] + 1) % VOCAB)
+    np.testing.assert_array_equal(np.asarray(ids[:7, 1]), (tokens[:7] + 2) % VOCAB)
+    assert float(np.asarray(lps[:7]).min()) >= -1.5  # rank-3 candidate (-2.5) was dropped
+
+
+def test_abort_when_server_max_logprobs_below_k(tmp_path):
+    shard, _, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(max_candidates=1)
+    with pytest.raises(RuntimeError, match=r"--max-logprobs >= 2"):
+        _run(handler, shard, top_k=2)
+
+
+def test_abort_when_prompt_logprobs_missing(tmp_path):
+    # A plain OpenAI-compatible provider (e.g. OpenRouter) that ignores the
+    # prompt_logprobs extension must abort with actionable guidance.
+    shard, _, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(omit_prompt_logprobs=True)
+    with pytest.raises(RuntimeError, match="OpenRouter"):
+        _run(handler, shard)
+    assert not (tmp_path / "train-000.bin.kd").exists()
+
+
+def test_4xx_unknown_field_surfaces_guidance(tmp_path):
+    shard, _, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(error_response=(400, {"error": {"message": "unknown field 'prompt_logprobs'"}}))
+    with pytest.raises(RuntimeError, match="vLLM-compatible"):
+        _run(handler, shard)
+
+
+def test_unrelated_4xx_is_not_rewritten(tmp_path):
+    shard, _, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(error_response=(404, {"error": {"message": "model not found"}}))
+    with pytest.raises(httpx.HTTPStatusError):
+        _run(handler, shard)
+    assert handler.calls == 1  # non-transient 4xx is not retried
+
+
+def test_retry_recovers_from_transient_failures(tmp_path):
+    shard, tokens, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(fail_first=2)
+    _run(handler, shard, concurrency=1)
+    assert handler.calls == 3  # 2 transient 500s + 1 success for the single doc
+    _, ids, _ = read_sidecar(shard + ".kd")
+    np.testing.assert_array_equal(np.asarray(ids[:7, 0]), (tokens[:7] + 1) % VOCAB)
+
+
+def test_retry_gives_up_after_three_attempts(tmp_path):
+    shard, _, _ = _packed_shard(tmp_path, [8], n_tokens=8)
+    handler = FakeVLLM(error_response=(500, {"error": "down"}))
+    with pytest.raises(RuntimeError, match="after 3 attempts"):
+        _run(handler, shard, concurrency=1)
+    assert handler.calls == 3
+
+
+def test_api_key_from_env_var(tmp_path, monkeypatch):
+    from surogate.core.config.sft_config import DistillationConfig
+
+    dist = DistillationConfig(teacher_model="t", teacher_api_base=API_BASE, teacher_api_key_var="MY_TEACHER_KEY")
+    monkeypatch.delenv("MY_TEACHER_KEY", raising=False)
+    with _make_api_client(dist) as client:
+        assert client.headers["authorization"] == "Bearer EMPTY"
+    monkeypatch.setenv("MY_TEACHER_KEY", "sekrit")
+    with _make_api_client(dist) as client:
+        assert client.headers["authorization"] == "Bearer sekrit"

--- a/tests/distill/test_config.py
+++ b/tests/distill/test_config.py
@@ -1,0 +1,172 @@
+"""CPU tests for DistillationConfig parsing, defaults, and validation.
+
+SFTConfig.__post_init__ resolves the model over the network, so these tests
+exercise SFTConfig.__init__ (pure field parsing) plus the validation helper
+`_validate_distillation_config` and the `create_runtime_config` CUDA-graph
+disable block directly, with a stubbed model_info.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+sft_config = pytest.importorskip(
+    "surogate.core.config.sft_config", reason="requires the built _surogate native module"
+)
+
+from surogate.core.config.sft_config import DistillationConfig, DistributedConfig, SFTConfig  # noqa: E402
+from surogate.utils.dict import DictDefault  # noqa: E402
+
+
+def _make_config(**extra) -> SFTConfig:
+    return SFTConfig(DictDefault({"model": "dummy/model", **extra}))
+
+
+def test_defaults():
+    d = DistillationConfig()
+    assert d.teacher_model is None
+    assert d.top_k == 32
+    assert d.temperature == 1.0
+    assert d.kd_weight == 0.5
+    assert d.ce_weight is None
+    assert d.teacher_batch_size == 4
+    assert d.kd_dir is None
+    assert d.teacher_api_base is None
+    assert d.teacher_api_key_var == "VLLM_API_KEY"
+    assert d.teacher_api_concurrency == 8
+    assert d.teacher_api_timeout == 1200
+
+
+def test_api_fields_dict_parsing():
+    c = _make_config(
+        distillation={
+            "teacher_model": "served-name",
+            "teacher_api_base": "http://localhost:8000/v1",
+            "teacher_api_key_var": "MY_KEY",
+            "teacher_api_concurrency": 16,
+            "teacher_api_timeout": 60,
+        }
+    )
+    d = c.distillation
+    assert d.teacher_api_base == "http://localhost:8000/v1"
+    assert d.teacher_api_key_var == "MY_KEY"
+    assert d.teacher_api_concurrency == 16
+    assert d.teacher_api_timeout == 60
+    c._validate_distillation_config()
+
+
+def test_absent_block_parses_to_none():
+    assert _make_config().distillation is None
+
+
+def test_dict_block_parsing():
+    c = _make_config(
+        distillation={
+            "teacher_model": "org/teacher",
+            "top_k": 64,
+            "temperature": 2.0,
+            "kd_weight": 0.7,
+            "ce_weight": 0.4,
+            "teacher_batch_size": 8,
+            "kd_dir": "/tmp/kd",
+        }
+    )
+    d = c.distillation
+    assert isinstance(d, DistillationConfig)
+    assert d.teacher_model == "org/teacher"
+    assert d.top_k == 64
+    assert d.temperature == 2.0
+    assert d.kd_weight == 0.7
+    assert d.ce_weight == 0.4
+    assert d.teacher_batch_size == 8
+    assert d.kd_dir == "/tmp/kd"
+
+
+def test_partial_dict_block_uses_defaults():
+    c = _make_config(distillation={"teacher_model": "org/teacher"})
+    d = c.distillation
+    assert d.top_k == 32
+    assert d.temperature == 1.0
+    assert d.kd_weight == 0.5
+    assert d.ce_weight is None
+
+
+def test_instance_passthrough():
+    inst = DistillationConfig(teacher_model="org/teacher", top_k=16)
+    c = _make_config(distillation=inst)
+    assert c.distillation is inst
+
+
+def test_ce_weight_defaults_to_one_minus_kd_weight():
+    c = _make_config(distillation={"kd_weight": 0.3})
+    c._validate_distillation_config()
+    assert c.distillation.ce_weight == pytest.approx(0.7)
+
+
+def test_ce_weight_explicit_is_kept():
+    c = _make_config(distillation={"kd_weight": 0.3, "ce_weight": 1.0})
+    c._validate_distillation_config()
+    assert c.distillation.ce_weight == 1.0
+
+
+def test_none_distillation_validation_is_noop():
+    c = _make_config()
+    c._validate_distillation_config()
+    assert c.distillation is None
+
+
+@pytest.mark.parametrize(
+    "block, match",
+    [
+        ({"top_k": 0}, "top_k"),
+        ({"top_k": 2048}, "top_k"),
+        ({"temperature": 0.0}, "temperature"),
+        ({"temperature": -1.0}, "temperature"),
+        ({"kd_weight": -0.1}, "kd_weight"),
+        ({"kd_weight": 0.5, "ce_weight": -0.5}, "ce_weight"),
+        ({"kd_weight": 1.5}, "ce_weight"),  # implied ce_weight = 1 - 1.5 < 0
+        ({"teacher_batch_size": 0}, "teacher_batch_size"),
+        ({"teacher_api_concurrency": 0}, "teacher_api_concurrency"),
+        ({"teacher_api_timeout": 0}, "teacher_api_timeout"),
+    ],
+)
+def test_validation_errors(block, match):
+    c = _make_config(distillation=block)
+    with pytest.raises(ValueError, match=match):
+        c._validate_distillation_config()
+
+
+def test_distributed_rejected_with_distillation():
+    c = _make_config(distillation={"kd_weight": 0.5})
+    c.distributed = DistributedConfig(num_nodes=2)
+    with pytest.raises(ValueError, match="distributed"):
+        c._validate_distillation_config()
+
+
+def test_dispatch_pp_rejected_with_distillation():
+    c = _make_config(distillation={"kd_weight": 0.5})
+    c.parallelism = "dispatch_pp"
+    with pytest.raises(ValueError, match="dispatch_pp"):
+        c._validate_distillation_config()
+
+
+def test_lmhead_drop_ignored_rows_forced_off():
+    c = _make_config(distillation={"kd_weight": 0.5}, lmhead_drop_ignored_rows=True)
+    assert c.lmhead_drop_ignored_rows is True
+    c._validate_distillation_config()
+    assert c.lmhead_drop_ignored_rows is False
+
+
+def test_cuda_graphs_auto_disabled_in_runtime_config():
+    c = _make_config(distillation={"kd_weight": 0.5}, use_cuda_graphs=True)
+    c.model_info = SimpleNamespace(quant_info=None)
+    assert c.use_cuda_graphs is True
+    c.create_runtime_config()
+    assert c.use_cuda_graphs is False
+
+
+def test_cuda_graphs_untouched_without_distillation():
+    c = _make_config(use_cuda_graphs=True)
+    c.model_info = SimpleNamespace(quant_info=None)
+    c.create_runtime_config()
+    assert c.use_cuda_graphs is True

--- a/tests/distill/test_dataloader_kd.py
+++ b/tests/distill/test_dataloader_kd.py
@@ -1,0 +1,148 @@
+"""Native DataLoader KD sidecar tests.
+
+Builds a synthetic BIN.TOK token shard plus a matching `.kd` sidecar with a
+per-position pattern that makes misalignment detectable, then checks that
+`load_batch(..., kd_ids, kd_logprobs)` serves teacher rows exactly aligned
+with `targets` (sidecar row i = distribution predicting tokens[i+1]).
+
+Runs on CPU; only needs the built `_surogate` extension.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:
+    import surogate._surogate as _surogate
+except ImportError:
+    pytest.skip("surogate._surogate C++ extension not built", allow_module_level=True)
+
+from surogate.distill.sidecar import SidecarWriter
+
+SEQ_LEN = 64
+N_TOKENS = 8 * SEQ_LEN + 5  # deliberately not a multiple of SEQ_LEN
+VOCAB = 50000
+TOP_K = 4
+HASH = "0123456789abcdef"
+
+
+def write_token_shard(path, tokens: np.ndarray, vocab_size: int) -> None:
+    """Minimal BIN.TOK version-3 writer (no masks): header + tokens + position_ids."""
+    header = np.zeros(256, dtype=np.int32)
+    header[0:2] = np.frombuffer(b"BIN.TOK\n", dtype=np.int32)
+    header[2] = 3  # version
+    header[3] = 4  # bytes per token
+    header[4] = len(tokens)
+    header[5] = vocab_size
+    header[6] = 0  # has_masks
+    header[7] = 0  # non_overlapping
+    with open(path, "wb") as f:
+        header.tofile(f)
+        tokens.astype(np.int32).tofile(f)
+        np.arange(len(tokens), dtype=np.int32).tofile(f)  # position ids
+
+
+def expected_logprob(row: int, k: int) -> np.ndarray:
+    # Row-dependent pattern, distinct per (row, k), representable in fp16.
+    return np.float16(-0.125 * ((row % 97) + 1) - 0.5 * np.arange(k))
+
+
+@pytest.fixture()
+def kd_shard(tmp_path):
+    rng = np.random.default_rng(7)
+    tokens = rng.integers(0, VOCAB, size=N_TOKENS, dtype=np.int32)
+    shard = tmp_path / "train-000.bin"
+    write_token_shard(shard, tokens, VOCAB)
+
+    # Sidecar row i predicts tokens[i+1]: encode that token as the top-1 id so
+    # alignment with `targets` is directly checkable. Remaining ids are
+    # (tokens[i+1] + j) % VOCAB.
+    with SidecarWriter(str(shard) + ".kd", N_TOKENS, TOP_K, VOCAB, HASH) as writer:
+        ids = np.zeros((N_TOKENS, TOP_K), dtype=np.uint32)
+        lps = np.zeros((N_TOKENS, TOP_K), dtype=np.float16)
+        for i in range(N_TOKENS - 1):
+            ids[i] = (int(tokens[i + 1]) + np.arange(TOP_K)) % VOCAB
+            lps[i] = expected_logprob(i, TOP_K)
+        writer.write_rows(ids, lps)
+    return shard, tokens
+
+
+class TestDataLoaderKd:
+    def test_kd_rows_align_with_targets(self, kd_shard):
+        shard, tokens = kd_shard
+        loader = _surogate.DataLoader([str(shard)], SEQ_LEN, seed=3)
+        loader.enable_kd(TOP_K)
+        assert loader.has_kd
+
+        inputs = np.empty((1, SEQ_LEN), dtype=np.int32)
+        targets = np.empty((1, SEQ_LEN), dtype=np.int32)
+        pos = np.empty((1, SEQ_LEN), dtype=np.int32)
+        kd_ids = np.empty((1, SEQ_LEN, TOP_K), dtype=np.int32)
+        kd_lps = np.empty((1, SEQ_LEN, TOP_K), dtype=np.float32)
+
+        checked = 0
+        while loader.has_next():
+            loader.load_batch(inputs, targets, pos, kd_ids, kd_lps)
+            # Recover the chunk's absolute position from the token content:
+            # inputs[0, 0] == tokens[chunk_pos] and the shard has unique-enough
+            # random content — recover via the position ids instead (arange).
+            chunk_pos = int(pos[0, 0])
+            for j in range(SEQ_LEN):
+                row = chunk_pos + j
+                assert targets[0, j] == tokens[row + 1]
+                # top-1 teacher id was written as the true next token
+                assert kd_ids[0, j, 0] == targets[0, j], (
+                    f"KD row misaligned at chunk_pos={chunk_pos} j={j}: "
+                    f"kd top-1 {kd_ids[0, j, 0]} != target {targets[0, j]}"
+                )
+                np.testing.assert_allclose(
+                    kd_lps[0, j],
+                    expected_logprob(row, TOP_K).astype(np.float32),
+                    rtol=0,
+                    atol=0,
+                    err_msg=f"KD logprobs mismatch at row {row}",
+                )
+            checked += 1
+        # has_next(1) is conservative on the last file (strict `+ world_size`
+        # bound): the epoch's final chunk is withheld. Pre-existing loader
+        # behavior, independent of KD; with world_size=1 that is one chunk.
+        total_chunks = (N_TOKENS - 1) // SEQ_LEN
+        assert checked == total_chunks - 1
+        assert checked > 0
+
+    def test_enable_kd_rejects_wrong_k(self, kd_shard):
+        shard, _ = kd_shard
+        loader = _surogate.DataLoader([str(shard)], SEQ_LEN, seed=3)
+        with pytest.raises(RuntimeError, match="top_k"):
+            loader.enable_kd(TOP_K + 1)
+
+    def test_enable_kd_rejects_missing_sidecar(self, tmp_path):
+        rng = np.random.default_rng(11)
+        tokens = rng.integers(0, VOCAB, size=N_TOKENS, dtype=np.int32)
+        shard = tmp_path / "train-001.bin"
+        write_token_shard(shard, tokens, VOCAB)
+        loader = _surogate.DataLoader([str(shard)], SEQ_LEN, seed=3)
+        with pytest.raises(RuntimeError, match="distill-capture"):
+            loader.enable_kd(TOP_K)
+
+    def test_kd_buffers_without_enable_raise(self, kd_shard):
+        shard, _ = kd_shard
+        loader = _surogate.DataLoader([str(shard)], SEQ_LEN, seed=3)
+        inputs = np.empty((1, SEQ_LEN), dtype=np.int32)
+        targets = np.empty((1, SEQ_LEN), dtype=np.int32)
+        pos = np.empty((1, SEQ_LEN), dtype=np.int32)
+        kd_ids = np.empty((1, SEQ_LEN, TOP_K), dtype=np.int32)
+        kd_lps = np.empty((1, SEQ_LEN, TOP_K), dtype=np.float32)
+        with pytest.raises(RuntimeError, match="enable_kd"):
+            loader.load_batch(inputs, targets, pos, kd_ids, kd_lps)
+
+    def test_plain_load_batch_still_works(self, kd_shard):
+        shard, tokens = kd_shard
+        loader = _surogate.DataLoader([str(shard)], SEQ_LEN, seed=3)
+        loader.enable_kd(TOP_K)
+        inputs = np.empty((1, SEQ_LEN), dtype=np.int32)
+        targets = np.empty((1, SEQ_LEN), dtype=np.int32)
+        loader.load_batch(inputs, targets)
+        pos0 = np.where(tokens[:-SEQ_LEN] == inputs[0, 0])[0]
+        assert len(pos0) >= 1

--- a/tests/distill/test_kd_gradient.py
+++ b/tests/distill/test_kd_gradient.py
@@ -1,0 +1,334 @@
+"""Numerical validation of the native KD loss/gradient against a torch reference.
+
+Uses a truncated (4-layer) Qwen3 model. The teacher signal is derived from the
+HuggingFace forward of the *same* model, which gives closed-form expectations:
+
+- With kd_weight=1, ce_weight=0, tau=1 and teacher == student, the reported
+  kd_loss is KL(renorm(topk(p)) || p) = -log(topk_mass) per token.
+- With tau != 1, kd_loss = tau^2 * KL(q_tau || p_tau), computable in torch.
+- With kd_weight=0, ce_weight=1 the step must reproduce the plain CE step.
+- Training against a fixed teacher must reduce kd_loss (gradient direction).
+
+Requirements: 1 GPU, cached Qwen3 weights (QWEN3_MODEL_PATH or HF cache for
+Qwen/Qwen3-0.6B or Qwen/Qwen3-1.7B).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+transformers = pytest.importorskip("transformers")
+
+try:
+    import surogate._surogate as _surogate
+except ImportError:
+    pytest.skip("surogate._surogate C++ extension not built", allow_module_level=True)
+
+from surogate.dsl.ir_builder import build_dsl_ir_for_model
+from surogate.utils.hf import get_model_weights_path
+
+pytestmark = [pytest.mark.gpu, pytest.mark.slow]
+
+CANDIDATE_MODELS = ["Qwen/Qwen3-0.6B", "Qwen/Qwen3-1.7B"]
+ENV_VAR = "QWEN3_MODEL_PATH"
+NUM_LAYERS = 4
+SEED = 1234
+BATCH = 1
+SEQ_LEN = 64
+TOP_K = 8
+MINI_MODEL_DIR = Path("tmp/distill_kd_mini")
+
+
+def resolve_model_path() -> Path | None:
+    env = os.environ.get(ENV_VAR)
+    if env and Path(env).exists():
+        return Path(env)
+    cache_root = Path("~/.cache/huggingface/hub").expanduser()
+    for model_id in CANDIDATE_MODELS:
+        model_cache = cache_root / f"models--{model_id.replace('/', '--')}"
+        snaps = model_cache / "snapshots"
+        if snaps.exists():
+            for snap in sorted(snaps.iterdir(), reverse=True):
+                if (snap / "config.json").exists():
+                    return snap
+    return None
+
+
+def prepare_mini_model(snapshot_dir: Path) -> Path:
+    if MINI_MODEL_DIR.exists():
+        shutil.rmtree(MINI_MODEL_DIR)
+    MINI_MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+    config = json.loads((snapshot_dir / "config.json").read_text())
+    config["num_hidden_layers"] = NUM_LAYERS
+    (MINI_MODEL_DIR / "config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+    for tok_file in ["tokenizer.json", "tokenizer_config.json", "special_tokens_map.json"]:
+        src = snapshot_dir / tok_file
+        if src.exists():
+            shutil.copy2(src, MINI_MODEL_DIR / tok_file)
+
+    index_path = snapshot_dir / "model.safetensors.index.json"
+    single_path = snapshot_dir / "model.safetensors"
+    if index_path.exists():
+        base_index = json.loads(index_path.read_text())
+        weight_map = base_index.get("weight_map", {})
+        prefixes = [f"model.layers.{i}." for i in range(NUM_LAYERS)]
+        extra = {"model.embed_tokens.weight", "model.norm.weight", "lm_head.weight"}
+        mini_map = {
+            k: v for k, v in weight_map.items() if k in extra or any(k.startswith(p) for p in prefixes)
+        }
+        mini_index = {"metadata": base_index.get("metadata", {}), "weight_map": mini_map}
+        (MINI_MODEL_DIR / "model.safetensors.index.json").write_text(
+            json.dumps(mini_index, indent=2, sort_keys=True) + "\n"
+        )
+        for fname in sorted(set(mini_map.values())):
+            link = MINI_MODEL_DIR / fname
+            if not link.exists():
+                link.symlink_to((snapshot_dir / fname).resolve())
+    elif single_path.exists():
+        (MINI_MODEL_DIR / "model.safetensors").symlink_to(single_path.resolve())
+    else:
+        raise FileNotFoundError(f"No weights found in {snapshot_dir}")
+    return MINI_MODEL_DIR
+
+
+def build_trainer(model_dir: Path) -> "_surogate.SurogateTrainer":
+    cfg = _surogate.PretrainedConfig.from_pretrained(str(model_dir), "bf16")
+    opts = _surogate.RuntimeOptions(
+        offload_residual=False,
+        use_cuda_graphs=False,
+        offload_master=False,
+        offload_grads=False,
+        offload_optimizer=False,
+        shard_gradients=True,
+        use_zero_copy=False,
+    )
+    opts.dsl_ir_json = build_dsl_ir_for_model(str(model_dir))
+    trainer = _surogate.SurogateTrainer(
+        ngpu=1,
+        config=cfg,
+        options=opts,
+        batch_size=BATCH,
+        seq_len=SEQ_LEN,
+        grad_accum=1,
+        memcpy_all_gather=True,
+        memcpy_send_recv=True,
+        lora_config=None,
+        qlora_config=None,
+    )
+    trainer.import_weights(get_model_weights_path(str(model_dir)))
+    return trainer
+
+
+def opt_config(lr: float) -> "_surogate.OptimizerConfig":
+    return _surogate.OptimizerConfig(
+        optimizer="adamw",
+        learning_rate=lr,
+        weight_decay=0.0,
+        grad_clip=1.0,
+        adamw_beta1=0.9,
+        adamw_beta2=0.999,
+        adamw_epsilon=1e-8,
+    )
+
+
+@pytest.fixture(scope="module")
+def model_dir():
+    snapshot = resolve_model_path()
+    if snapshot is None:
+        pytest.skip(f"Qwen3 weights not found. Set {ENV_VAR} or cache one of {CANDIDATE_MODELS}")
+    return prepare_mini_model(snapshot)
+
+
+@pytest.fixture(scope="module")
+def batch(model_dir):
+    config = json.loads((model_dir / "config.json").read_text())
+    rng = np.random.default_rng(SEED)
+    inputs = rng.integers(0, config["vocab_size"], size=(BATCH, SEQ_LEN), dtype=np.int32)
+    targets = inputs.copy()
+    targets[:, :-1] = inputs[:, 1:]
+    targets[:, -1] = -100
+    return {"inputs": inputs, "targets": targets, "vocab_size": config["vocab_size"]}
+
+
+@pytest.fixture(scope="module")
+def hf_logprobs(model_dir, batch):
+    """Float32 log-softmax of the HF forward on the same mini model/batch."""
+    from transformers import AutoModelForCausalLM
+
+    model = AutoModelForCausalLM.from_pretrained(
+        str(model_dir), torch_dtype=torch.bfloat16, device_map="cuda", trust_remote_code=True
+    )
+    model.eval()
+    with torch.no_grad():
+        input_ids = torch.tensor(batch["inputs"], device="cuda", dtype=torch.long)
+        logits = model(input_ids=input_ids, use_cache=False).logits.float()
+        logprobs = torch.log_softmax(logits, dim=-1).cpu()
+    del model
+    torch.cuda.empty_cache()
+    return logprobs  # [BATCH, SEQ_LEN, V] fp32
+
+
+def teacher_topk(hf_logprobs: "torch.Tensor") -> tuple[np.ndarray, np.ndarray]:
+    values, indices = torch.topk(hf_logprobs, TOP_K, dim=-1)
+    return (
+        indices.numpy().astype(np.int32),
+        values.numpy().astype(np.float32),
+    )
+
+
+def torch_kd_reference(
+    hf_logprobs: "torch.Tensor", kd_ids: np.ndarray, kd_lps: np.ndarray, targets: np.ndarray, tau: float
+) -> float:
+    """Mean over valid tokens of tau^2 * KL(q_tau || p_tau), matching the kernel math."""
+    logits = hf_logprobs  # already log-probs; softmax(logprobs/tau) == softmax-with-temperature
+    total = 0.0
+    count = 0
+    for b in range(targets.shape[0]):
+        for t in range(targets.shape[1]):
+            if targets[b, t] == -100:
+                continue
+            q = torch.softmax(torch.tensor(kd_lps[b, t]) / tau, dim=-1)
+            p_tau = torch.log_softmax(logits[b, t] / tau, dim=-1)
+            s = p_tau[torch.tensor(kd_ids[b, t], dtype=torch.long)]
+            total += float(tau * tau * torch.sum(q * (torch.log(q.clamp_min(1e-30)) - s)))
+            count += 1
+    return total / max(1, count)
+
+
+class TestKdGradient:
+    def test_kd_loss_identity_and_reference_band(self, model_dir, batch, hf_logprobs):
+        """Exact + sanity validation of the native kd_loss value.
+
+        Exact: with K=1 and the teacher set to the target token (q = 1), the
+        KD loss collapses to -logprob(target) = cross-entropy, computed by the
+        SAME engine — so kd_loss must equal the reported CE loss regardless of
+        any surogate-vs-HF forward drift. This pins the metric's math
+        (normalization, tau^2, valid-token divisor, scatter/gather indexing).
+
+        Sanity band: the torch reference from HF logits only bounds kd_loss
+        loosely — the truncated 4-layer model has degenerate distributions and
+        the two engines drift ~0.7 nats/token on it (measured), so tight
+        agreement is not expected; the band still catches gross factor bugs
+        (missing tau^2, wrong divisor, unnormalized q).
+        """
+        trainer = build_trainer(model_dir)
+        try:
+            # --- exact identity: teacher = target token, K=1 ---
+            kd_ids1 = np.where(batch["targets"] >= 0, batch["targets"], 0)[..., None].astype(np.int32)
+            kd_lps1 = np.zeros_like(kd_ids1, dtype=np.float32)
+            trainer.step_with_kd(
+                batch["inputs"],
+                batch["targets"],
+                kd_ids1,
+                kd_lps1,
+                top_k=1,
+                temperature=1.0,
+                kd_weight=1.0,
+                ce_weight=0.0,
+            )
+            result = trainer.update_with_config(opt_config(1e-9), 1)
+            kd_loss1 = trainer.get_kd_loss()
+            assert np.isfinite(result["loss"]) and np.isfinite(result["norm"])
+            assert abs(kd_loss1 - result["loss"]) < 2e-2 * max(1.0, result["loss"]), (
+                f"K=1 identity broken: kd_loss={kd_loss1} vs CE={result['loss']}"
+            )
+
+            # --- sanity band vs the HF-logit reference, tau=1 and tau=2 ---
+            kd_ids, kd_lps = teacher_topk(hf_logprobs)
+            for tau in (1.0, 2.0):
+                trainer.step_with_kd(
+                    batch["inputs"],
+                    batch["targets"],
+                    kd_ids,
+                    kd_lps,
+                    top_k=TOP_K,
+                    temperature=tau,
+                    kd_weight=1.0,
+                    ce_weight=0.0,
+                )
+                trainer.update_with_config(opt_config(1e-9), 2)
+                kd_loss = trainer.get_kd_loss()
+                ref = torch_kd_reference(hf_logprobs, kd_ids, kd_lps, batch["targets"], tau=tau)
+                assert kd_loss > 0
+                assert 0.2 * ref < kd_loss < 5.0 * ref, (
+                    f"kd_loss(tau={tau})={kd_loss} outside sanity band of torch ref={ref}"
+                )
+
+            # tau=1 closed form and torch reference agree with each other tightly
+            # (both computed from the same HF logits) — validates the reference itself.
+            valid = batch["targets"] != -100
+            topk_mass = np.exp(kd_lps.astype(np.float64)).sum(axis=-1)
+            expected = float(-np.log(topk_mass[valid]).mean())
+            ref1 = torch_kd_reference(hf_logprobs, kd_ids, kd_lps, batch["targets"], tau=1.0)
+            assert abs(ref1 - expected) < 5e-3
+        finally:
+            del trainer
+
+    def test_ce_only_kd_step_matches_plain_step(self, model_dir, batch, hf_logprobs):
+        kd_ids, kd_lps = teacher_topk(hf_logprobs)
+
+        trainer = build_trainer(model_dir)
+        try:
+            trainer.step(batch["inputs"], batch["targets"])
+            plain = trainer.update_with_config(opt_config(1e-9), 1)
+        finally:
+            del trainer
+
+        trainer = build_trainer(model_dir)
+        try:
+            trainer.step_with_kd(
+                batch["inputs"],
+                batch["targets"],
+                kd_ids,
+                kd_lps,
+                top_k=TOP_K,
+                temperature=1.0,
+                kd_weight=0.0,
+                ce_weight=1.0,
+            )
+            kd = trainer.update_with_config(opt_config(1e-9), 1)
+        finally:
+            del trainer
+
+        # Same weights, same batch, KD contribution zeroed: CE loss and grad
+        # norm must match the plain step closely (identical kernels modulo the
+        # KD-variant backward with kd_scale=0).
+        assert abs(kd["loss"] - plain["loss"]) < 5e-3 * max(1.0, abs(plain["loss"]))
+        assert abs(kd["norm"] - plain["norm"]) < 5e-2 * max(1.0, abs(plain["norm"]))
+
+    def test_kd_gradient_reduces_kd_loss(self, model_dir, batch, hf_logprobs):
+        # Fixed synthetic teacher that differs from the student: shift the
+        # top-k ids by one position so the student must move probability mass.
+        kd_ids, kd_lps = teacher_topk(hf_logprobs)
+        rng = np.random.default_rng(SEED + 1)
+        kd_ids = ((kd_ids.astype(np.int64) + 7919) % batch["vocab_size"]).astype(np.int32)
+        kd_lps = np.sort(rng.uniform(-3.0, -0.5, size=kd_lps.shape).astype(np.float32), axis=-1)[..., ::-1].copy()
+
+        trainer = build_trainer(model_dir)
+        try:
+            losses = []
+            for step in range(12):
+                trainer.step_with_kd(
+                    batch["inputs"],
+                    batch["targets"],
+                    kd_ids,
+                    kd_lps,
+                    top_k=TOP_K,
+                    temperature=1.0,
+                    kd_weight=1.0,
+                    ce_weight=0.0,
+                )
+                trainer.update_with_config(opt_config(2e-4), step + 1)
+                losses.append(trainer.get_kd_loss())
+            assert all(np.isfinite(losses))
+            assert losses[-1] < losses[0] * 0.9, f"kd_loss did not decrease: {losses}"
+        finally:
+            del trainer

--- a/tests/distill/test_sidecar.py
+++ b/tests/distill/test_sidecar.py
@@ -1,0 +1,211 @@
+"""CPU tests for the .kd sidecar reader/writer (pure numpy, no torch)."""
+
+import numpy as np
+import pytest
+
+from surogate.distill.sidecar import (
+    KD_LOGPROB_DTYPE_FP16,
+    KD_MAGIC,
+    KD_VERSION,
+    SidecarWriter,
+    read_sidecar,
+    read_sidecar_header,
+    read_token_shard_header,
+    sidecar_path_for,
+    validate_sidecar,
+)
+
+TOKEN_MAGIC = b"BIN.TOK\n"
+HASH = "0123456789abcdef"
+
+
+def _write_token_shard(path, tokens, vocab_size, version=3):
+    """Minimal BIN.TOK writer mirroring TokenizedDataFileWriter's layout:
+    [1024-byte header][tokens int32][position_ids int32 (version 3)].
+    """
+    tokens = np.asarray(tokens, dtype="<i4")
+    position_ids = np.arange(len(tokens), dtype="<i4")
+    header = bytearray(1024)
+    header[0:8] = TOKEN_MAGIC
+    fields = np.array([version, 4, len(tokens), vocab_size, 0, 0], dtype="<i4")
+    header[8 : 8 + fields.nbytes] = fields.tobytes()
+    with open(path, "wb") as f:
+        f.write(bytes(header))
+        f.write(tokens.tobytes())
+        if version >= 3:
+            f.write(position_ids.tobytes())
+
+
+def _make_pair(tmp_path, n_tokens=64, k=4, vocab_size=100, tokenize_hash=HASH):
+    shard = str(tmp_path / "train-000.bin")
+    tokens = np.arange(n_tokens, dtype=np.int32) % vocab_size
+    _write_token_shard(shard, tokens, vocab_size)
+    sidecar = shard + ".kd"
+    ids = (np.arange(n_tokens * k, dtype=np.uint32) % vocab_size).reshape(n_tokens, k)
+    logprobs = (-0.25 * (1 + np.arange(n_tokens * k, dtype=np.float32) % 16)).reshape(n_tokens, k)
+    with SidecarWriter(sidecar, n_tokens=n_tokens, k=k, vocab_size=vocab_size, tokenize_hash=tokenize_hash) as w:
+        w.write_rows(ids[: n_tokens // 2], logprobs[: n_tokens // 2])
+        w.write_rows(ids[n_tokens // 2 :], logprobs[n_tokens // 2 :])
+    return shard, sidecar, tokens, ids, logprobs
+
+
+def test_token_shard_header_roundtrip(tmp_path):
+    shard = str(tmp_path / "train-000.bin")
+    _write_token_shard(shard, np.arange(10), vocab_size=50)
+    h = read_token_shard_header(shard)
+    assert h.version == 3
+    assert h.bytes_per_token == 4
+    assert h.n_tokens == 10
+    assert h.vocab_size == 50
+    assert not h.has_masks
+    assert not h.non_overlapping
+    assert h.tokens_offset == 1024
+    assert h.position_ids_offset == 1024 + 4 * 10
+
+
+def test_sidecar_roundtrip(tmp_path):
+    shard, sidecar, _, ids, logprobs = _make_pair(tmp_path)
+    header = read_sidecar_header(sidecar)
+    assert header.version == KD_VERSION
+    assert header.k == 4
+    assert header.n_tokens == 64
+    assert header.vocab_size == 100
+    assert header.logprob_dtype == KD_LOGPROB_DTYPE_FP16
+    assert header.tokenize_hash == HASH
+
+    read_header, read_ids, read_logprobs = read_sidecar(sidecar)
+    assert read_header == header
+    np.testing.assert_array_equal(np.asarray(read_ids), ids)
+    # Values chosen fp16-representable, so the roundtrip is exact.
+    np.testing.assert_array_equal(np.asarray(read_logprobs, dtype=np.float32), logprobs)
+
+
+def test_sidecar_block_layout(tmp_path):
+    # ids block (uint32) precedes the logprobs block (fp16): byte offsets are
+    # 1024 and 1024 + 4*k*n_tokens.
+    _, sidecar, _, ids, logprobs = _make_pair(tmp_path, n_tokens=8, k=2)
+    with open(sidecar, "rb") as f:
+        raw = f.read()
+    assert raw[:8] == KD_MAGIC
+    assert len(raw) == 1024 + 6 * 2 * 8
+    ids_block = np.frombuffer(raw, dtype="<u4", count=8 * 2, offset=1024).reshape(8, 2)
+    lp_block = np.frombuffer(raw, dtype="<f2", count=8 * 2, offset=1024 + 4 * 2 * 8).reshape(8, 2)
+    np.testing.assert_array_equal(ids_block, ids)
+    np.testing.assert_array_equal(lp_block.astype(np.float32), logprobs)
+
+
+def test_tail_rows_zero_filled(tmp_path):
+    shard = str(tmp_path / "train-000.bin")
+    _write_token_shard(shard, np.arange(64), vocab_size=100)
+    sidecar = shard + ".kd"
+    with SidecarWriter(sidecar, n_tokens=64, k=4, vocab_size=100, tokenize_hash=HASH) as w:
+        w.write_rows(np.ones((40, 4), np.uint32), np.full((40, 4), -1.0, np.float16))
+        assert w.rows_written == 40
+    _, ids, logprobs = read_sidecar(sidecar)
+    np.testing.assert_array_equal(np.asarray(ids[40:]), 0)
+    np.testing.assert_array_equal(np.asarray(logprobs[40:], dtype=np.float32), 0.0)
+    np.testing.assert_array_equal(np.asarray(ids[:40]), 1)
+
+
+def test_alignment_row_i_predicts_token_i_plus_1(tmp_path):
+    # Contract: sidecar row i holds the teacher distribution predicting
+    # tokens[i+1], i.e. aligned with targets[i]. The DataLoader serves a chunk
+    # at chunk_pos as inputs=tokens[chunk_pos:chunk_pos+S] and
+    # targets=tokens[chunk_pos+1:chunk_pos+S+1], reading sidecar rows
+    # [chunk_pos, chunk_pos+S) with NO extra shift — including the last row of
+    # each capture window, whose target is the first token of the next window.
+    n_tokens, k, vocab, S = 64, 2, 100, 16
+    shard = str(tmp_path / "train-000.bin")
+    tokens = ((np.arange(n_tokens) * 7 + 3) % vocab).astype(np.int32)
+    _write_token_shard(shard, tokens, vocab)
+    sidecar = shard + ".kd"
+    ids = np.zeros((n_tokens, k), np.uint32)
+    ids[: n_tokens - 1, 0] = tokens[1:]  # perfect teacher: top-1 = the true next token
+    with SidecarWriter(sidecar, n_tokens=n_tokens, k=k, vocab_size=vocab, tokenize_hash=HASH) as w:
+        w.write_rows(ids, np.zeros((n_tokens, k), np.float16))
+
+    _, read_ids, _ = read_sidecar(sidecar)
+    for chunk_pos in (0, S, 2 * S):
+        targets = tokens[chunk_pos + 1 : chunk_pos + S + 1]
+        np.testing.assert_array_equal(np.asarray(read_ids[chunk_pos : chunk_pos + S, 0]), targets)
+
+
+def test_validate_ok(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path)
+    header = validate_sidecar(sidecar, shard, expect_k=4, expect_hash=HASH)
+    assert header.k == 4
+
+
+def test_validate_missing_sidecar(tmp_path):
+    shard = str(tmp_path / "train-000.bin")
+    _write_token_shard(shard, np.arange(16), vocab_size=100)
+    with pytest.raises(ValueError, match="distill-capture"):
+        validate_sidecar(shard + ".kd", shard)
+
+
+def test_validate_bad_magic(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path)
+    with open(sidecar, "r+b") as f:
+        f.write(b"XXXXXXXX")
+    with pytest.raises(ValueError, match="bad magic"):
+        validate_sidecar(sidecar, shard)
+
+
+def test_validate_unsupported_version(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path)
+    with open(sidecar, "r+b") as f:
+        f.seek(8)
+        f.write(np.array([99], dtype="<i4").tobytes())
+    with pytest.raises(ValueError, match="version"):
+        validate_sidecar(sidecar, shard)
+
+
+def test_validate_n_tokens_mismatch(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path, n_tokens=64)
+    other_shard = str(tmp_path / "train-001.bin")
+    _write_token_shard(other_shard, np.arange(32), vocab_size=100)
+    with pytest.raises(ValueError, match="re-tokenized"):
+        validate_sidecar(sidecar, other_shard)
+
+
+def test_validate_k_mismatch(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path, k=4)
+    with pytest.raises(ValueError, match="top_k"):
+        validate_sidecar(sidecar, shard, expect_k=8)
+
+
+def test_validate_hash_mismatch(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path, tokenize_hash="deadbeefdeadbeef")
+    with pytest.raises(ValueError, match="re-tokenized"):
+        validate_sidecar(sidecar, shard, expect_hash=HASH)
+
+
+def test_validate_truncated_file(tmp_path):
+    shard, sidecar, _, _, _ = _make_pair(tmp_path)
+    size = (tmp_path / "train-000.bin.kd").stat().st_size
+    with open(sidecar, "r+b") as f:
+        f.truncate(size - 8)
+    with pytest.raises(ValueError, match="truncated"):
+        validate_sidecar(sidecar, shard)
+
+
+def test_writer_rejects_bad_shapes_and_overflow(tmp_path):
+    shard = str(tmp_path / "train-000.bin")
+    _write_token_shard(shard, np.arange(8), vocab_size=100)
+    with pytest.raises(ValueError, match="k must be"):
+        SidecarWriter(shard + ".kd", n_tokens=8, k=0, vocab_size=100, tokenize_hash=HASH)
+    with pytest.raises(ValueError, match="k must be"):
+        SidecarWriter(shard + ".kd", n_tokens=8, k=2048, vocab_size=100, tokenize_hash=HASH)
+    with SidecarWriter(shard + ".kd", n_tokens=8, k=2, vocab_size=100, tokenize_hash=HASH) as w:
+        with pytest.raises(ValueError, match="shape"):
+            w.write_rows(np.zeros((4, 3), np.uint32), np.zeros((4, 3), np.float16))
+        with pytest.raises(ValueError, match="does not match"):
+            w.write_rows(np.zeros((4, 2), np.uint32), np.zeros((3, 2), np.float16))
+        w.write_rows(np.zeros((8, 2), np.uint32), np.zeros((8, 2), np.float16))
+        with pytest.raises(ValueError, match="overflows"):
+            w.write_rows(np.zeros((1, 2), np.uint32), np.zeros((1, 2), np.float16))
+
+
+def test_sidecar_path_for(tmp_path):
+    assert sidecar_path_for("/data/train-000.bin") == "/data/train-000.bin.kd"
+    assert sidecar_path_for("/data/train-000.bin", kd_dir="/kd") == "/kd/train-000.bin.kd"

--- a/tests/distill/test_transplant.py
+++ b/tests/distill/test_transplant.py
@@ -1,0 +1,190 @@
+"""Tests for the mergekit-tokensurgeon transplant wrapper (subprocess mocked)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from unittest import mock
+
+import pytest
+
+from surogate.transplant import TRANSPLANT_MANIFEST, run_transplant, run_transplant_back
+from surogate.transplant import transplant as transplant_mod
+
+
+def _fake_output_model(out_dir: str, tie_word_embeddings: bool = False) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, "config.json"), "w") as f:
+        json.dump({"vocab_size": 129280, "tie_word_embeddings": tie_word_embeddings}, f)
+    open(os.path.join(out_dir, "tokenizer.json"), "w").write("{}")
+    open(os.path.join(out_dir, "model.safetensors"), "wb").write(b"\0")
+
+
+def _completed(returncode=0, stderr=""):
+    return mock.Mock(returncode=returncode, stdout="", stderr=stderr)
+
+
+@pytest.fixture()
+def student_teacher(tmp_path):
+    student = tmp_path / "student"
+    teacher = tmp_path / "teacher"
+    student.mkdir()
+    teacher.mkdir()
+    (student / "config.json").write_text("{}")
+    (teacher / "config.json").write_text("{}")
+    return str(student), str(teacher)
+
+
+class TestRunTransplant:
+    def test_invocation_and_manifest(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        out = str(tmp_path / "out")
+
+        def fake_run(cmd, capture_output, text):
+            _fake_output_model(out)
+            return _completed()
+
+        with (
+            mock.patch.object(shutil, "which", return_value="/usr/bin/mergekit-tokensurgeon"),
+            mock.patch.object(transplant_mod.subprocess, "run", side_effect=fake_run) as run_mock,
+        ):
+            result = run_transplant(student, teacher, out, method="omp", k=64, device="cuda")
+
+        assert result == out
+        cmd = run_mock.call_args.args[0]
+        assert cmd[0] == "/usr/bin/mergekit-tokensurgeon"
+        assert cmd[1:4] == [student, teacher, out]
+        assert cmd[cmd.index("--approximation-method") + 1] == "omp"
+        assert cmd[cmd.index("--k") + 1] == "64"
+        assert cmd[cmd.index("--device") + 1] == "cuda"
+        assert "--trust-remote-code" not in cmd
+
+        manifest = json.load(open(os.path.join(out, TRANSPLANT_MANIFEST)))
+        assert manifest["student_model"] == student
+        assert manifest["teacher_model"] == teacher
+        assert manifest["method"] == "omp"
+        assert manifest["k"] == 64
+
+    def test_trust_remote_code_and_extra_args(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        out = str(tmp_path / "out")
+
+        def fake_run(cmd, capture_output, text):
+            _fake_output_model(out)
+            return _completed()
+
+        with (
+            mock.patch.object(shutil, "which", return_value="mergekit-tokensurgeon"),
+            mock.patch.object(transplant_mod.subprocess, "run", side_effect=fake_run) as run_mock,
+        ):
+            run_transplant(
+                student, teacher, out, trust_remote_code=True, extra_args=["--byte-match", "yes"]
+            )
+        cmd = run_mock.call_args.args[0]
+        assert "--trust-remote-code" in cmd
+        assert cmd[cmd.index("--byte-match") + 1] == "yes"
+
+    def test_missing_mergekit_is_actionable(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        with mock.patch.object(shutil, "which", return_value=None):
+            with pytest.raises(RuntimeError, match="pip install mergekit"):
+                run_transplant(student, teacher, str(tmp_path / "out"))
+
+    def test_subprocess_failure_surfaces_stderr(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        with (
+            mock.patch.object(shutil, "which", return_value="mergekit-tokensurgeon"),
+            mock.patch.object(
+                transplant_mod.subprocess,
+                "run",
+                return_value=_completed(returncode=1, stderr="boom: donor vocab unreadable"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="donor vocab unreadable"):
+                run_transplant(student, teacher, str(tmp_path / "out"))
+
+    def test_incomplete_output_rejected(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        out = str(tmp_path / "out")
+
+        def fake_run(cmd, capture_output, text):
+            os.makedirs(out, exist_ok=True)  # no config.json / tokenizer / weights
+            return _completed()
+
+        with (
+            mock.patch.object(shutil, "which", return_value="mergekit-tokensurgeon"),
+            mock.patch.object(transplant_mod.subprocess, "run", side_effect=fake_run),
+        ):
+            with pytest.raises(RuntimeError, match="config.json"):
+                run_transplant(student, teacher, out)
+
+    def test_unknown_method_rejected(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        with mock.patch.object(shutil, "which", return_value="mergekit-tokensurgeon"):
+            with pytest.raises(ValueError, match="approximation method"):
+                run_transplant(student, teacher, str(tmp_path / "out"), method="magic")
+            with pytest.raises(ValueError, match="k must be"):
+                run_transplant(student, teacher, str(tmp_path / "out"), k=0)
+
+
+class TestRunTransplantBack:
+    def test_reverse_uses_manifest_donor_and_method(self, tmp_path, student_teacher):
+        student, teacher = student_teacher
+        transplanted = str(tmp_path / "transplanted")
+        _fake_output_model(transplanted)
+        manifest_path = os.path.join(transplanted, TRANSPLANT_MANIFEST)
+        json.dump(
+            {
+                "version": 1,
+                "student_model": student,
+                "student_dir": student,
+                "teacher_model": teacher,
+                "method": "common_interpolation",
+                "k": 8,
+            },
+            open(manifest_path, "w"),
+        )
+        distilled = str(tmp_path / "distilled")
+        _fake_output_model(distilled)
+        out = str(tmp_path / "restored")
+
+        def fake_run(cmd, capture_output, text):
+            _fake_output_model(out)
+            return _completed()
+
+        with (
+            mock.patch.object(shutil, "which", return_value="mergekit-tokensurgeon"),
+            mock.patch.object(transplant_mod.subprocess, "run", side_effect=fake_run) as run_mock,
+        ):
+            run_transplant_back(distilled, manifest_path, out)
+
+        cmd = run_mock.call_args.args[0]
+        # distilled model is the base; the ORIGINAL STUDENT is the tokenizer donor
+        assert cmd[1:4] == [distilled, student, out]
+        assert cmd[cmd.index("--approximation-method") + 1] == "common_interpolation"
+        assert cmd[cmd.index("--k") + 1] == "8"
+
+    def test_manifest_without_student_rejected(self, tmp_path):
+        manifest_path = str(tmp_path / "m.json")
+        json.dump({"version": 1}, open(manifest_path, "w"))
+        with pytest.raises(ValueError, match="student"):
+            run_transplant_back(str(tmp_path), manifest_path, str(tmp_path / "out"))
+
+
+def test_cli_parser_roundtrip():
+    from surogate.cli.transplant import prepare_command_parser
+
+    parser = prepare_command_parser()
+    args = parser.parse_args(
+        ["--student", "s", "--teacher", "t", "--output", "o", "--method", "omp", "--k", "32"]
+    )
+    assert (args.student, args.teacher, args.output, args.method, args.k) == ("s", "t", "o", "omp", 32)
+    args = parser.parse_args(["--student", "d", "--output", "o", "--restore", "m.json"])
+    assert args.restore == "m.json"
+
+
+def test_cli_registered():
+    from surogate.cli.main import COMMAND_MAPPING
+
+    assert COMMAND_MAPPING["transplant-tokenizer"] == "surogate.cli.transplant"


### PR DESCRIPTION
## Summary

Adds knowledge-distillation support to surogate: offline top-K logit distillation with a native
CUDA loss path, teacher capture (local HF or remote vLLM), and cross-tokenizer distillation via
vocabulary transplant.

### Native KD training path
- Fused KD gradient inside the LM-head cross-entropy backward (both fused and vocab-chunked CUDA
  kernels): `dlogit = dloss·(ce_w·(p − onehot) + kd_w·τ·(p_τ − q_topk))` with renormalized top-K
  teacher distributions at temperature τ; out-of-vocab teacher entries are excluded from the
  normalization. KD loss metric (τ²·KL) accumulates on-device.
- `SurogateTrainer.step_with_kd(...)` / `get_kd_loss()`: standard SFT loss semantics (CE and
  ValidTokenCount accumulation, 1/valid-token gradient scaling), GRPO-style pinned staging for the
  teacher arrays. LM-head row compaction and CUDA graphs are auto-disabled for KD runs.
- `.kd` sidecar format (per token shard): top-K teacher ids (uint32) + logprobs (fp16), row i
  aligned with `targets[i]`; native `DataLoader.enable_kd()` + `load_batch(..., kd_ids,
  kd_logprobs)` with strict header validation. `DataLoader.set_state` now reopens files and
  reshuffles (pre-existing restore bug).
- `distillation:` YAML block (`top_k`, `temperature`, `kd_weight`, `ce_weight`, teacher/capture
  settings) with validation; `kd_loss` in step metrics and the training log (`log_step_kd`).

### Teacher capture — `surogate distill-capture`
- Local HF backend: teacher forward over the exact tokenized shards in training-chunk windows,
  with explicit flash-attention varlen boundaries so packed documents are isolated exactly as the
  student sees them; tokenize-hash embedded in sidecars to detect stale captures.
- Remote backend (`distillation.teacher_api_base`): token-id prompts per packed document against a
  vLLM-compatible server via `prompt_logprobs` (requires `--max-logprobs >= top_k`); exact
  document isolation without flash-attn; actionable errors for non-vLLM servers/aggregators.

### Cross-tokenizer distillation — `surogate transplant-tokenizer`
- Thin subprocess wrapper around `mergekit-tokensurgeon` (optional external dependency; LGPL-3.0,
  never imported or vendored): transplants the teacher's tokenizer onto the student (OMP k=64
  default), writes a `transplant_manifest.json`, and supports `--restore` to convert back after
  KD training.

### Docs & examples
- New guide `docs/guides/distillation.md` (workflow, config reference, sidecar spec,
  cross-tokenizer section, troubleshooting) + updates across 11 reference/guide pages;
  `examples/distillation/` with a runnable Qwen3 config.

## Test plan
- 75 CPU tests (`tests/distill/`): sidecar format/alignment roundtrips, native DataLoader KD
  alignment against synthetic shards, config validation, API-capture mock-server suite
  (request shape, doc splitting, retries, abort paths), transplant wrapper invocation/manifest.
- GPU (1× RTX 5090): exact K=1 identity (kd_loss ≡ engine CE, matches to 5 decimals), CE-parity
  of `step_with_kd` vs plain step at `kd_weight=0`, KD-loss descent against a fixed teacher.
- Adversarial multi-agent review of the full diff: 12 confirmed findings, all fixed (incl. a
  critical capture-side attention-isolation bug).
- `tests/distill/test_capture.py` (capture vs per-document reference) auto-skips until flash-attn
  is installed for the current torch stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
