### PR TITLE
feat(dpo): add native offline DPO trainer

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -702,6 +702,7 @@ if (BUILD_TESTS OR BUILD_TESTS_INTEGRATION)
     add_executable(integration-tests
         src/testing/utilities/test_main.cpp
         src/testing/distributed/test-nccl.cpp
+        src/testing/kernels/test-dpo-dloss.cu
         src/testing/tokenizer/test-chat-template.cpp
     )
     target_link_libraries(integration-tests PRIVATE

--- a/csrc/src/binding/binding.cpp
+++ b/csrc/src/binding/binding.cpp
@@ -1105,7 +1105,8 @@ NB_MODULE(_surogate, m) {
             nb::arg("delay_us") = 0,
             "Queue one AdamW update (FP32 grad). delay_us stalls the worker so the "
             "caller can observe the in-flight stale state.")
-        .def("applied_count", &optimizers::AsyncStaleAdamW::applied_count,
+        .def("applied_count",
+             &optimizers::AsyncStaleAdamW::applied_count,
              "Number of updates the worker has finished applying (lock-free probe).")
         .def("drain", &optimizers::AsyncStaleAdamW::drain, "Block until all queued updates complete.")
         .def("master", &optimizers::AsyncStaleAdamW::master, "Drain, then return the FP32 master params.")
@@ -1411,8 +1412,10 @@ NB_MODULE(_surogate, m) {
             [](MultiGPUPyTrainer* trainer, TokenArray inputs, TokenArray targets, int split_after_block) {
                 CHECK_SHAPE(inputs, trainer->batch_size(), trainer->seq_length());
                 CHECK_SHAPE(targets, trainer->batch_size(), trainer->seq_length());
-                return dsl::dispatch_pp_phase0::grad_norms_subranges(
-                    *trainer, inputs.data(), targets.data(), split_after_block);
+                return dsl::dispatch_pp_phase0::grad_norms_subranges(*trainer,
+                                                                     inputs.data(),
+                                                                     targets.data(),
+                                                                     split_after_block);
             },
             nb::arg("inputs"),
             nb::arg("targets"),
@@ -1433,7 +1436,10 @@ NB_MODULE(_surogate, m) {
             "returns the final hidden state as a flat f32 list.")
         .def(
             "dispatch_pp_grad_norms_multigpu",
-            [](MultiGPUPyTrainer* trainer, TokenArray inputs, TokenArray targets, std::vector<int> los,
+            [](MultiGPUPyTrainer* trainer,
+               TokenArray inputs,
+               TokenArray targets,
+               std::vector<int> los,
                std::vector<int> his) {
                 CHECK_SHAPE(inputs, trainer->batch_size(), trainer->seq_length());
                 CHECK_SHAPE(targets, trainer->batch_size(), trainer->seq_length());
@@ -1453,8 +1459,11 @@ NB_MODULE(_surogate, m) {
             "bounded by the streaming slot count, not the layer count.")
         .def(
             "dispatch_pp_train_step",
-            [](MultiGPUPyTrainer* trainer, TokenArray inputs, TokenArray targets,
-               const optimizers::OptimizerConfig& opt_config, int step_idx) {
+            [](MultiGPUPyTrainer* trainer,
+               TokenArray inputs,
+               TokenArray targets,
+               const optimizers::OptimizerConfig& opt_config,
+               int step_idx) {
                 CHECK_SHAPE(inputs, trainer->batch_size(), trainer->seq_length());
                 CHECK_SHAPE(targets, trainer->batch_size(), trainer->seq_length());
                 return trainer->dispatch_pp_train_step(inputs.data(), targets.data(), opt_config, step_idx);
@@ -1467,14 +1476,26 @@ NB_MODULE(_surogate, m) {
             "grads, optimizer update) through the sub-range executor; returns the step loss.")
         .def(
             "dispatch_pp_train_step_multigpu",
-            [](MultiGPUPyTrainer* trainer, TokenArray inputs, TokenArray targets, std::vector<int> los,
-               std::vector<int> his, const optimizers::OptimizerConfig& opt_config, int step_idx, bool stale,
+            [](MultiGPUPyTrainer* trainer,
+               TokenArray inputs,
+               TokenArray targets,
+               std::vector<int> los,
+               std::vector<int> his,
+               const optimizers::OptimizerConfig& opt_config,
+               int step_idx,
+               bool stale,
                int num_microbatches) {
                 // inputs/targets carry num_microbatches microbatches of [batch_size, seq] each.
                 CHECK_SHAPE(inputs, num_microbatches * trainer->batch_size(), trainer->seq_length());
                 CHECK_SHAPE(targets, num_microbatches * trainer->batch_size(), trainer->seq_length());
-                return trainer->dispatch_pp_train_step_multigpu(
-                    inputs.data(), targets.data(), los, his, opt_config, step_idx, stale, num_microbatches);
+                return trainer->dispatch_pp_train_step_multigpu(inputs.data(),
+                                                                targets.data(),
+                                                                los,
+                                                                his,
+                                                                opt_config,
+                                                                step_idx,
+                                                                stale,
+                                                                num_microbatches);
             },
             nb::arg("inputs"),
             nb::arg("targets"),
@@ -2105,6 +2126,143 @@ NB_MODULE(_surogate, m) {
             "get_kd_loss",
             [](MultiGPUPyTrainer* trainer) { return trainer->get_kd_loss(); },
             "Mean KD loss per valid token accumulated since the last call (rank-0 local).")
+        .def(
+            "step_dpo_native",
+            [](MultiGPUPyTrainer* trainer,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> input_ids,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> targets,
+               nb::ndarray<float, nb::c_contig> ref_logprobs,
+               nb::ndarray<std::uint8_t, nb::c_contig> loss_mask,
+               nb::ndarray<std::int32_t, nb::c_contig> sample_starts,
+               nb::ndarray<std::int32_t, nb::c_contig> sample_ends,
+               nb::ndarray<std::int32_t, nb::c_contig> pair_chosen,
+               nb::ndarray<std::int32_t, nb::c_contig> pair_rejected,
+               nb::object position_ids_obj,
+               float loss_scale,
+               float beta,
+               int length_norm) {
+                // Per-token (ref_logprobs/loss_mask) and sample/pair arrays are
+                // either 1-D (shared by every GPU) or 2-D (one row per host batch
+                // row; sample/pair rows padded with -1). Pairs shard with samples.
+                auto check_ndim = [](const char* name, std::size_t ndim) {
+                    if (ndim != 1 && ndim != 2) {
+                        throw std::invalid_argument(std::string(name) +
+                                                    " must be 1-D (shared) or 2-D (one row per GPU)");
+                    }
+                };
+                auto rows_of = [](const auto& arr) {
+                    return arr.ndim() == 2 ? static_cast<int>(arr.shape(0)) : 1;
+                };
+                auto len_of = [](const auto& arr) {
+                    return static_cast<std::size_t>(arr.ndim() == 2 ? arr.shape(1) : arr.shape(0));
+                };
+                check_ndim("ref_logprobs", ref_logprobs.ndim());
+                check_ndim("loss_mask", loss_mask.ndim());
+                check_ndim("sample_starts", sample_starts.ndim());
+                check_ndim("sample_ends", sample_ends.ndim());
+                check_ndim("pair_chosen", pair_chosen.ndim());
+                check_ndim("pair_rejected", pair_rejected.ndim());
+
+                MultiGPUPyTrainer::GrpoHostLayout layout;
+                layout.token_rows = rows_of(ref_logprobs);
+                layout.sample_rows = rows_of(sample_starts);
+                layout.token_len = static_cast<long>(len_of(ref_logprobs));
+                layout.input_rows = static_cast<long>(input_ids.shape(0));
+                layout.input_cols = static_cast<long>(input_ids.shape(1));
+                if (rows_of(loss_mask) != layout.token_rows || len_of(loss_mask) != len_of(ref_logprobs)) {
+                    throw std::invalid_argument("ref_logprobs and loss_mask must share the same shape");
+                }
+                if (rows_of(sample_ends) != layout.sample_rows || len_of(sample_ends) != len_of(sample_starts)) {
+                    throw std::invalid_argument("sample_starts and sample_ends must have the same shape");
+                }
+                if (rows_of(pair_chosen) != layout.sample_rows || rows_of(pair_rejected) != layout.sample_rows ||
+                    len_of(pair_rejected) != len_of(pair_chosen)) {
+                    throw std::invalid_argument(
+                        "pair_chosen/pair_rejected must share a shape and row count with the sample arrays");
+                }
+                if (targets.shape(0) != input_ids.shape(0) || targets.shape(1) != input_ids.shape(1)) {
+                    throw std::invalid_argument("targets must match input_ids' shape");
+                }
+                const std::int32_t* position_ids_ptr = nullptr;
+                if (!position_ids_obj.is_none()) {
+                    auto position_ids = nb::cast<nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig>>(position_ids_obj);
+                    if (position_ids.shape(0) != input_ids.shape(0) || position_ids.shape(1) != input_ids.shape(1)) {
+                        throw std::invalid_argument("position_ids must match input_ids' shape");
+                    }
+                    position_ids_ptr = position_ids.data();
+                }
+                trainer->step_dpo_native(input_ids.data(),
+                                         targets.data(),
+                                         ref_logprobs.data(),
+                                         loss_mask.data(),
+                                         sample_starts.data(),
+                                         sample_ends.data(),
+                                         static_cast<int>(len_of(sample_starts)),
+                                         pair_chosen.data(),
+                                         pair_rejected.data(),
+                                         static_cast<int>(len_of(pair_chosen)),
+                                         position_ids_ptr,
+                                         loss_scale,
+                                         beta,
+                                         length_norm,
+                                         layout);
+            },
+            nb::arg("input_ids"),
+            nb::arg("targets"),
+            nb::arg("ref_logprobs"),
+            nb::arg("loss_mask"),
+            nb::arg("sample_starts"),
+            nb::arg("sample_ends"),
+            nb::arg("pair_chosen"),
+            nb::arg("pair_rejected"),
+            nb::arg("position_ids") = nb::none(),
+            nb::arg("loss_scale") = 1.0f,
+            nb::arg("beta") = 0.1f,
+            nb::arg("length_norm") = 0,
+            "Run one offline DPO training micro-step with native CUDA per-pair gradient generation.")
+        .def(
+            "get_dpo_native_metrics",
+            [](MultiGPUPyTrainer* trainer) {
+                nb::dict out;
+                for (const auto& [key, value] : trainer->get_dpo_native_metrics()) {
+                    out[key.c_str()] = value;
+                }
+                return out;
+            },
+            "Return native DPO metrics accumulated since the current grad-accum step started.")
+        .def(
+            "compute_ref_logprobs_dpo",
+            [](MultiGPUPyTrainer* trainer,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> input_ids,
+               nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig> targets,
+               nb::object position_ids_obj) {
+                if (targets.shape(0) != input_ids.shape(0) || targets.shape(1) != input_ids.shape(1)) {
+                    throw std::invalid_argument("targets must match input_ids' shape");
+                }
+                const std::int32_t* position_ids_ptr = nullptr;
+                if (!position_ids_obj.is_none()) {
+                    auto position_ids = nb::cast<nb::ndarray<int32_t, nb::ndim<2>, nb::c_contig>>(position_ids_obj);
+                    if (position_ids.shape(0) != input_ids.shape(0) || position_ids.shape(1) != input_ids.shape(1)) {
+                        throw std::invalid_argument("position_ids must match input_ids' shape");
+                    }
+                    position_ids_ptr = position_ids.data();
+                }
+                const int input_rows = static_cast<int>(input_ids.shape(0));
+                auto logprobs =
+                    trainer->compute_ref_logprobs_dpo(input_ids.data(), targets.data(), position_ids_ptr, input_rows);
+                const std::size_t n = logprobs.size();
+                float* data = new float[n];
+                std::copy(logprobs.begin(), logprobs.end(), data);
+                nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<float*>(p); });
+                return nb::ndarray<nb::numpy, float, nb::ndim<2>>(
+                    data,
+                    {static_cast<std::size_t>(input_ids.shape(0)), static_cast<std::size_t>(input_ids.shape(1))},
+                    owner);
+            },
+            nb::arg("input_ids"),
+            nb::arg("targets"),
+            nb::arg("position_ids") = nb::none(),
+            "DPO reference per-token log-probs via the fused-loss forward (fp8/multi-GPU-safe).")
         .def("set_grad_accumulation",
              &MultiGPUPyTrainer::set_grad_accumulation,
              nb::arg("n"),

--- a/csrc/src/binding/binding.cpp
+++ b/csrc/src/binding/binding.cpp
@@ -2163,7 +2163,7 @@ NB_MODULE(_surogate, m) {
                 check_ndim("pair_chosen", pair_chosen.ndim());
                 check_ndim("pair_rejected", pair_rejected.ndim());
 
-                MultiGPUPyTrainer::GrpoHostLayout layout;
+                MultiGPUPyTrainer::DpoHostLayout layout;
                 layout.token_rows = rows_of(ref_logprobs);
                 layout.sample_rows = rows_of(sample_starts);
                 layout.token_len = static_cast<long>(len_of(ref_logprobs));
@@ -3420,11 +3420,16 @@ NB_MODULE(_surogate, m) {
                     strategy = tokenizer::LossStrategy::DEFAULT;
                 else if (strategy_str == "last_round")
                     strategy = tokenizer::LossStrategy::LAST_ROUND;
+                else if (strategy_str == "thinking_only")
+                    strategy = tokenizer::LossStrategy::THINKING_ONLY;
+                else if (strategy_str == "final_only")
+                    strategy = tokenizer::LossStrategy::FINAL_ONLY;
                 else if (strategy_str == "all")
                     strategy = tokenizer::LossStrategy::ALL;
                 else
-                    throw std::invalid_argument("strategy must be 'default', 'last_round', or 'all', got: " +
-                                                strategy_str);
+                    throw std::invalid_argument(
+                        "strategy must be 'default', 'last_round', 'thinking_only', 'final_only', or 'all', got: " +
+                        strategy_str);
 
                 // Convert messages, skipping entries with null content
                 std::vector<tokenizer::ChatMessage> msgs;
@@ -3451,7 +3456,9 @@ NB_MODULE(_surogate, m) {
             "Parameters:\n"
             "- messages: List of dicts with 'role' and 'content' keys.\n"
             "- strategy: 'default' (train on all assistant turns), 'last_round'\n"
-            "            (train only on last assistant turn), or 'all' (train on everything).")
+            "            (train only on last assistant turn), 'thinking_only'\n"
+            "            (train reasoning through </think>), 'final_only'\n"
+            "            (train only after </think>), or 'all' (train on everything).")
         .def(
             "encode_for_training_batch",
             [](const tokenizer::Tokenizer& self, nb::list batch, const std::string& strategy_str) {
@@ -3460,11 +3467,16 @@ NB_MODULE(_surogate, m) {
                     strategy = tokenizer::LossStrategy::DEFAULT;
                 else if (strategy_str == "last_round")
                     strategy = tokenizer::LossStrategy::LAST_ROUND;
+                else if (strategy_str == "thinking_only")
+                    strategy = tokenizer::LossStrategy::THINKING_ONLY;
+                else if (strategy_str == "final_only")
+                    strategy = tokenizer::LossStrategy::FINAL_ONLY;
                 else if (strategy_str == "all")
                     strategy = tokenizer::LossStrategy::ALL;
                 else
-                    throw std::invalid_argument("strategy must be 'default', 'last_round', or 'all', got: " +
-                                                strategy_str);
+                    throw std::invalid_argument(
+                        "strategy must be 'default', 'last_round', 'thinking_only', 'final_only', or 'all', got: " +
+                        strategy_str);
 
                 // Convert batch of conversations, skipping entries with null content
                 std::vector<std::vector<tokenizer::ChatMessage>> cpp_batch;
@@ -3501,7 +3513,7 @@ NB_MODULE(_surogate, m) {
             "Batch encode conversations for training (multi-threaded).\n\n"
             "Parameters:\n"
             "- batch: List of conversations, each a list of message dicts.\n"
-            "- strategy: 'default', 'last_round', or 'all'.");
+            "- strategy: 'default', 'last_round', 'thinking_only', 'final_only', or 'all'.");
 
     // ----------------------------------------------------------------------
     // mem-efficient attention (Phase 4 attempt 1 port, see

--- a/csrc/src/binding/py_train.cpp
+++ b/csrc/src/binding/py_train.cpp
@@ -3057,7 +3057,7 @@ void MultiGPUPyTrainer::step_dpo_native(const std::int32_t* inputs,
                                         float loss_scale,
                                         float beta,
                                         int length_norm,
-                                        GrpoHostLayout layout) {
+                                        DpoHostLayout layout) {
     const int ep_size = std::max(1, mOptions.EPSize);
     const int host_rows = std::max(1, (int)mContexts.size() / ep_size);
     if (layout.token_rows != 1 && layout.token_rows != host_rows) {
@@ -3093,7 +3093,7 @@ void MultiGPUPyTrainer::step_dpo_native(const std::int32_t* inputs,
                         host_rows,
                         static_cast<long>(host_rows) * static_cast<long>(B)));
     }
-    mGrpoShardedRows = (layout.token_rows > 1);
+    mDpoShardedRows = (layout.token_rows > 1);
     for (int i = 0; i < (int)mContexts.size(); ++i) {
         auto& ctx = mContexts.at(i);
         if (!ctx.Model) {
@@ -3223,7 +3223,7 @@ std::unordered_map<std::string, float> MultiGPUPyTrainer::get_dpo_native_metrics
     // rank is identical, take rank 0.
     const int ep_size = std::max(1, mOptions.EPSize);
     dsl::DpoNativeMetrics agg;
-    if (mGrpoShardedRows) {
+    if (mDpoShardedRows) {
         float total_pairs = 0.0f;
         for (int r = 0; r < (int)per_rank.size(); r += ep_size) {
             const auto& m = per_rank[static_cast<std::size_t>(r)];

--- a/csrc/src/binding/py_train.cpp
+++ b/csrc/src/binding/py_train.cpp
@@ -1931,18 +1931,18 @@ std::vector<std::pair<std::string, Tensor>> MultiGPUPyTrainer::get_gradients(int
 // ---- Debug-only dispatch-PP sub-range parity ------------------------------
 // Stage host token ids into GPU 0's device input buffer and fill sequential
 // position ids, mirroring step()'s single-GPU staging.
-#define DISPATCH_PP_DBG_STAGE(ctx, inputs_ptr, targets_ptr)                                            \
-    do {                                                                                               \
-        auto* _ib = (ctx).Model->get_input_buffer().get<std::int32_t>();                               \
-        std::memcpy(_ib, (inputs_ptr), static_cast<std::size_t>(B) * T * sizeof(std::int32_t));        \
-        if ((targets_ptr) != nullptr) {                                                                \
-            auto* _tb = (ctx).Model->get_target_buffer().get<std::int32_t>();                          \
-            std::memcpy(_tb, (targets_ptr), static_cast<std::size_t>(B) * T * sizeof(std::int32_t));   \
-        }                                                                                              \
-        Tensor _pos = (ctx).Model->get_position_ids_buffer();                                          \
-        auto* _pb = _pos.get<std::int32_t>();                                                          \
-        const int _planes = (_pos.Rank == 3) ? static_cast<int>(_pos.Sizes[0]) : 1;                    \
-        fill_sequential_position_ids(_pb, _planes, B, T);                                              \
+#define DISPATCH_PP_DBG_STAGE(ctx, inputs_ptr, targets_ptr)                                          \
+    do {                                                                                             \
+        auto* _ib = (ctx).Model->get_input_buffer().get<std::int32_t>();                             \
+        std::memcpy(_ib, (inputs_ptr), static_cast<std::size_t>(B) * T * sizeof(std::int32_t));      \
+        if ((targets_ptr) != nullptr) {                                                              \
+            auto* _tb = (ctx).Model->get_target_buffer().get<std::int32_t>();                        \
+            std::memcpy(_tb, (targets_ptr), static_cast<std::size_t>(B) * T * sizeof(std::int32_t)); \
+        }                                                                                            \
+        Tensor _pos = (ctx).Model->get_position_ids_buffer();                                        \
+        auto* _pb = _pos.get<std::int32_t>();                                                        \
+        const int _planes = (_pos.Rank == 3) ? static_cast<int>(_pos.Sizes[0]) : 1;                  \
+        fill_sequential_position_ids(_pb, _planes, B, T);                                            \
     } while (0)
 
 std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden(const std::int32_t* inputs) {
@@ -1952,16 +1952,16 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden(const std::int3
             auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
             if (!model) throw std::runtime_error("dispatch_pp_forward_hidden: DSL model required");
             DISPATCH_PP_DBG_STAGE(ctx, inputs, nullptr);
-            auto out = model->dispatch_pp_forward_hidden(
-                ctx.Model->get_input_buffer(), ctx.Model->get_position_ids_buffer(), *ctx.Communicator);
+            auto out = model->dispatch_pp_forward_hidden(ctx.Model->get_input_buffer(),
+                                                         ctx.Model->get_position_ids_buffer(),
+                                                         *ctx.Communicator);
             if (ctx.Communicator->local_rank() == 0) result = std::move(out);
         },
         0);
     return result;
 }
 
-std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_subranges(const std::int32_t* inputs,
-                                                                         int split_after_block) {
+std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_subranges(const std::int32_t* inputs, int split_after_block) {
     std::vector<float> result;
     run_work(
         [&](sThreadContext& ctx) {
@@ -1969,9 +1969,9 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_subranges(const std::i
             if (!model) throw std::runtime_error("dispatch_pp_forward_subranges: DSL model required");
             DISPATCH_PP_DBG_STAGE(ctx, inputs, nullptr);
             auto out = model->dispatch_pp_forward_subranges(ctx.Model->get_input_buffer(),
-                                                                  ctx.Model->get_position_ids_buffer(),
-                                                                  *ctx.Communicator,
-                                                                  split_after_block);
+                                                            ctx.Model->get_position_ids_buffer(),
+                                                            *ctx.Communicator,
+                                                            split_after_block);
             if (ctx.Communicator->local_rank() == 0) result = std::move(out);
         },
         0);
@@ -1979,7 +1979,7 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_subranges(const std::i
 }
 
 std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_whole(const std::int32_t* inputs,
-                                                                        const std::int32_t* targets) {
+                                                                   const std::int32_t* targets) {
     std::vector<float> result;
     run_work(
         [&](sThreadContext& ctx) {
@@ -1987,9 +1987,9 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_whole(const std::in
             if (!model) throw std::runtime_error("dispatch_pp_grad_norms_whole: DSL model required");
             DISPATCH_PP_DBG_STAGE(ctx, inputs, targets);
             auto out = model->dispatch_pp_grad_norms_whole(ctx.Model->get_input_buffer(),
-                                                                 ctx.Model->get_target_buffer(),
-                                                                 ctx.Model->get_position_ids_buffer(),
-                                                                 *ctx.Communicator);
+                                                           ctx.Model->get_target_buffer(),
+                                                           ctx.Model->get_position_ids_buffer(),
+                                                           *ctx.Communicator);
             if (ctx.Communicator->local_rank() == 0) result = std::move(out);
         },
         0);
@@ -1997,8 +1997,8 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_whole(const std::in
 }
 
 std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_subranges(const std::int32_t* inputs,
-                                                                            const std::int32_t* targets,
-                                                                            int split_after_block) {
+                                                                       const std::int32_t* targets,
+                                                                       int split_after_block) {
     std::vector<float> result;
     run_work(
         [&](sThreadContext& ctx) {
@@ -2006,18 +2006,19 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_subranges(const std
             if (!model) throw std::runtime_error("dispatch_pp_grad_norms_subranges: DSL model required");
             DISPATCH_PP_DBG_STAGE(ctx, inputs, targets);
             auto out = model->dispatch_pp_grad_norms_subranges(ctx.Model->get_input_buffer(),
-                                                                     ctx.Model->get_target_buffer(),
-                                                                     ctx.Model->get_position_ids_buffer(),
-                                                                     *ctx.Communicator,
-                                                                     split_after_block);
+                                                               ctx.Model->get_target_buffer(),
+                                                               ctx.Model->get_position_ids_buffer(),
+                                                               *ctx.Communicator,
+                                                               split_after_block);
             if (ctx.Communicator->local_rank() == 0) result = std::move(out);
         },
         0);
     return result;
 }
 
-std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden_multigpu(
-    const std::int32_t* inputs, const std::vector<int>& los, const std::vector<int>& his) {
+std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden_multigpu(const std::int32_t* inputs,
+                                                                          const std::vector<int>& los,
+                                                                          const std::vector<int>& his) {
     if (los.size() != his.size() || los.empty()) {
         throw std::runtime_error("dispatch_pp_forward_hidden_multigpu: bad stage ranges");
     }
@@ -2042,16 +2043,15 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden_multigpu(
         run_work(
             [&](sThreadContext& ctx) {
                 auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-                if (!model)
-                    throw std::runtime_error("dispatch_pp_forward_hidden_multigpu: DSL model required");
+                if (!model) throw std::runtime_error("dispatch_pp_forward_hidden_multigpu: DSL model required");
                 DISPATCH_PP_DBG_STAGE(ctx, inputs, nullptr);
                 model->dispatch_pp_forward_stage(ctx.Model->get_input_buffer(),
-                                                       ctx.Model->get_position_ids_buffer(),
-                                                       *ctx.Communicator,
-                                                       lo,
-                                                       hi,
-                                                       std::move(inject_named),
-                                                       /*preserve_output=*/!is_last);
+                                                 ctx.Model->get_position_ids_buffer(),
+                                                 *ctx.Communicator,
+                                                 lo,
+                                                 hi,
+                                                 std::move(inject_named),
+                                                 /*preserve_output=*/!is_last);
                 auto* ge = model->graph_executor();
                 if (is_last) {
                     final_hidden = ge->last_block_hidden_f32();
@@ -2076,9 +2076,10 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_forward_hidden_multigpu(
     return result;
 }
 
-std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_multigpu(
-    const std::int32_t* inputs, const std::int32_t* targets, const std::vector<int>& los,
-    const std::vector<int>& his) {
+std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_multigpu(const std::int32_t* inputs,
+                                                                      const std::int32_t* targets,
+                                                                      const std::vector<int>& los,
+                                                                      const std::vector<int>& his) {
     if (los.size() != his.size() || los.empty()) {
         throw std::runtime_error("dispatch_pp_grad_norms_multigpu: bad stage ranges");
     }
@@ -2104,18 +2105,17 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_multigpu(
         run_work(
             [&](sThreadContext& ctx) {
                 auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-                if (!model)
-                    throw std::runtime_error("dispatch_pp_grad_norms_multigpu: DSL model required");
+                if (!model) throw std::runtime_error("dispatch_pp_grad_norms_multigpu: DSL model required");
                 DISPATCH_PP_DBG_STAGE(ctx, inputs, targets);
                 model->dispatch_pp_backward_stage(ctx.Model->get_input_buffer(),
-                                                        ctx.Model->get_target_buffer(),
-                                                        ctx.Model->get_position_ids_buffer(),
-                                                        *ctx.Communicator,
-                                                        lo,
-                                                        hi,
-                                                        is_loss_stage,
-                                                        /*fwd_inject=*/{},  // harness: whole-from-start forward fallback
-                                                        std::move(inject_named));
+                                                  ctx.Model->get_target_buffer(),
+                                                  ctx.Model->get_position_ids_buffer(),
+                                                  *ctx.Communicator,
+                                                  lo,
+                                                  hi,
+                                                  is_loss_stage,
+                                                  /*fwd_inject=*/{},  // harness: whole-from-start forward fallback
+                                                  std::move(inject_named));
                 auto* ge = model->graph_executor();
                 stage_norms = ge->block_grad_norms();
                 if (lo > 0) {
@@ -2136,22 +2136,21 @@ std::vector<float> MultiGPUPyTrainer::dispatch_pp_grad_norms_multigpu(
 }
 
 float MultiGPUPyTrainer::dispatch_pp_train_step(const std::int32_t* inputs,
-                                                      const std::int32_t* targets,
-                                                      const optimizers::OptimizerConfig& opt_config,
-                                                      int step_idx) {
+                                                const std::int32_t* targets,
+                                                const optimizers::OptimizerConfig& opt_config,
+                                                int step_idx) {
     float loss = 0.0f;
     run_work(
         [&](sThreadContext& ctx) {
             auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-            if (!model)
-                throw std::runtime_error("dispatch_pp_train_step: DSL model required");
+            if (!model) throw std::runtime_error("dispatch_pp_train_step: DSL model required");
             DISPATCH_PP_DBG_STAGE(ctx, inputs, targets);
             const float l = model->dispatch_pp_train_step(ctx.Model->get_input_buffer(),
-                                                                ctx.Model->get_target_buffer(),
-                                                                ctx.Model->get_position_ids_buffer(),
-                                                                *ctx.Communicator,
-                                                                opt_config,
-                                                                step_idx);
+                                                          ctx.Model->get_target_buffer(),
+                                                          ctx.Model->get_position_ids_buffer(),
+                                                          *ctx.Communicator,
+                                                          opt_config,
+                                                          step_idx);
             if (ctx.Communicator->local_rank() == 0) loss = l;
         },
         0);
@@ -2159,13 +2158,13 @@ float MultiGPUPyTrainer::dispatch_pp_train_step(const std::int32_t* inputs,
 }
 
 float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inputs,
-                                                              const std::int32_t* targets,
-                                                              const std::vector<int>& los,
-                                                              const std::vector<int>& his,
-                                                              const optimizers::OptimizerConfig& opt_config,
-                                                              int step_idx,
-                                                              bool stale,
-                                                              int num_microbatches) {
+                                                         const std::int32_t* targets,
+                                                         const std::vector<int>& los,
+                                                         const std::vector<int>& his,
+                                                         const optimizers::OptimizerConfig& opt_config,
+                                                         int step_idx,
+                                                         bool stale,
+                                                         int num_microbatches) {
     if (los.size() != his.size() || los.empty()) {
         throw std::runtime_error("dispatch_pp_train_step_multigpu: bad stage ranges");
     }
@@ -2214,7 +2213,8 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                                                    std::vector<Boundary>(static_cast<std::size_t>(M)));
         const int nflags = std::max(1, num_stages * M);
         std::unique_ptr<std::atomic<int>[]> ready(new std::atomic<int>[nflags]);
-        for (int i = 0; i < nflags; ++i) ready[i].store(0, std::memory_order_relaxed);
+        for (int i = 0; i < nflags; ++i)
+            ready[i].store(0, std::memory_order_relaxed);
         std::atomic<int>* readyp = ready.get();
         for (int s = 0; s <= last_fwd; ++s) {
             const int lo = los[static_cast<std::size_t>(s)];
@@ -2225,8 +2225,7 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
             dispatch_async(
                 [this, inputs, mb_stride, M, s, lo, hi, my_out, up_out, sin, readyp](sThreadContext& ctx) {
                     auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-                    if (!model)
-                        throw std::runtime_error("dispatch_pp_train_step_multigpu: DSL model required");
+                    if (!model) throw std::runtime_error("dispatch_pp_train_step_multigpu: DSL model required");
                     auto* ge = model->graph_executor();
                     const std::string rn = "blocks[" + std::to_string(hi) + "].res_att";
                     const std::string xn = "blocks[" + std::to_string(hi) + "].mlp_down";
@@ -2240,12 +2239,12 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                         (*sin)[static_cast<std::size_t>(m)] = inj;
                         DISPATCH_PP_DBG_STAGE(ctx, inputs + static_cast<std::size_t>(m) * mb_stride, nullptr);
                         model->dispatch_pp_forward_stage(ctx.Model->get_input_buffer(),
-                                                               ctx.Model->get_position_ids_buffer(),
-                                                               *ctx.Communicator,
-                                                               lo,
-                                                               hi,
-                                                               std::move(inj),
-                                                               /*preserve_output=*/true);
+                                                         ctx.Model->get_position_ids_buffer(),
+                                                         *ctx.Communicator,
+                                                         lo,
+                                                         hi,
+                                                         std::move(inj),
+                                                         /*preserve_output=*/true);
                         Boundary o;
                         o.emplace_back(rn, ge->read_named_bytes(rn));
                         o.emplace_back(xn, ge->read_named_bytes(xn));
@@ -2256,7 +2255,8 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                 },
                 s % ngpu);
         }
-        for (int g = 0; g < ngpu; ++g) wait_gpu(g);
+        for (int g = 0; g < ngpu; ++g)
+            wait_gpu(g);
         for (int m = 0; m < M; ++m)
             stage_inputs[static_cast<std::size_t>(num_stages - 1)][static_cast<std::size_t>(m)] =
                 (last_fwd >= 0) ? fwd_out[static_cast<std::size_t>(last_fwd)][static_cast<std::size_t>(m)] : Boundary{};
@@ -2289,7 +2289,8 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                                                     std::vector<Boundary>(static_cast<std::size_t>(M)));
         const int nflags = std::max(1, num_stages * M);
         std::unique_ptr<std::atomic<int>[]> ready(new std::atomic<int>[nflags]);
-        for (int i = 0; i < nflags; ++i) ready[i].store(0, std::memory_order_relaxed);
+        for (int i = 0; i < nflags; ++i)
+            ready[i].store(0, std::memory_order_relaxed);
         std::atomic<int>* readyp = ready.get();
         std::vector<double>* lpm = &loss_per_mb;
         std::vector<int>* vtpm = &valid_per_mb;
@@ -2304,8 +2305,7 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                 [this, inputs, targets, mb_stride, M, s, lo, hi, is_loss, my_g, up_g, sin, readyp, lpm, vtpm](
                     sThreadContext& ctx) {
                     auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-                    if (!model)
-                        throw std::runtime_error("dispatch_pp_train_step_multigpu: DSL model required");
+                    if (!model) throw std::runtime_error("dispatch_pp_train_step_multigpu: DSL model required");
                     auto* ge = model->graph_executor();
                     const std::string rn = "d_blocks[" + std::to_string(lo - 1) + "].res_att";
                     const std::string xn = "d_blocks[" + std::to_string(lo - 1) + "].mlp_down";
@@ -2317,19 +2317,20 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                             ginj = (*up_g)[static_cast<std::size_t>(m)];
                         }
                         Boundary finj = (*sin)[static_cast<std::size_t>(m)];
-                        DISPATCH_PP_DBG_STAGE(ctx, inputs + static_cast<std::size_t>(m) * mb_stride,
+                        DISPATCH_PP_DBG_STAGE(ctx,
+                                              inputs + static_cast<std::size_t>(m) * mb_stride,
                                               targets + static_cast<std::size_t>(m) * mb_stride);
                         model->dispatch_pp_backward_stage(ctx.Model->get_input_buffer(),
-                                                                ctx.Model->get_target_buffer(),
-                                                                ctx.Model->get_position_ids_buffer(),
-                                                                *ctx.Communicator,
-                                                                lo,
-                                                                hi,
-                                                                is_loss,
-                                                                std::move(finj),
-                                                                std::move(ginj),
-                                                                /*micro_step=*/1,  // pre-zeroed -> always accumulate
-                                                                /*total_micro=*/M);
+                                                          ctx.Model->get_target_buffer(),
+                                                          ctx.Model->get_position_ids_buffer(),
+                                                          *ctx.Communicator,
+                                                          lo,
+                                                          hi,
+                                                          is_loss,
+                                                          std::move(finj),
+                                                          std::move(ginj),
+                                                          /*micro_step=*/1,  // pre-zeroed -> always accumulate
+                                                          /*total_micro=*/M);
                         if (is_loss) {
                             (*lpm)[static_cast<std::size_t>(m)] = static_cast<double>(model->dispatch_pp_raw_loss());
                             (*vtpm)[static_cast<std::size_t>(m)] = model->dispatch_pp_loss_valid_tokens();
@@ -2352,15 +2353,18 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
                 },
                 s % ngpu);
         }
-        for (int g = 0; g < ngpu; ++g) wait_gpu(g);
+        for (int g = 0; g < ngpu; ++g)
+            wait_gpu(g);
     }
     {
         double ls = 0.0;
-        for (double x : loss_per_mb) ls += x;
+        for (double x : loss_per_mb)
+            ls += x;
         loss = static_cast<float>(ls / static_cast<double>(M));
     }
     int step_valid_tokens = 0;
-    for (int v : valid_per_mb) step_valid_tokens += v;
+    for (int v : valid_per_mb)
+        step_valid_tokens += v;
 
     // Collect each stage's accumulated grads from its GPU (grads stay resident on the
     // stage's GPU until read here, after the whole backward wavefront).
@@ -2375,11 +2379,14 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
             [&, lo, hi, is_loss](sThreadContext& ctx) {
                 auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
                 if (model)
-                    stage_grads = model->dispatch_pp_read_block_grads(lo, hi, /*include_head=*/is_loss,
+                    stage_grads = model->dispatch_pp_read_block_grads(lo,
+                                                                      hi,
+                                                                      /*include_head=*/is_loss,
                                                                       /*include_embed=*/lo == 0);
             },
             gpu);
-        for (auto& g : stage_grads) collected.push_back(std::move(g));
+        for (auto& g : stage_grads)
+            collected.push_back(std::move(g));
     }
 
     // 2. Optimizer + broadcast. In synchronous mode, apply this step's grads now.
@@ -2389,7 +2396,9 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
     if (stale) {
         if (!mDispatchPpPendingGrads.empty()) {
             // The deferred grads belong to the previous step — scale by its valid-token count.
-            dispatch_pp_apply_grads_(mDispatchPpPendingGrads, opt_config, ++mDispatchPpAppliedStep,
+            dispatch_pp_apply_grads_(mDispatchPpPendingGrads,
+                                     opt_config,
+                                     ++mDispatchPpAppliedStep,
                                      mDispatchPpPendingValidTokens);
         }
         mDispatchPpPendingGrads = std::move(collected);
@@ -2402,26 +2411,30 @@ float MultiGPUPyTrainer::dispatch_pp_train_step_multigpu(const std::int32_t* inp
 
 void MultiGPUPyTrainer::dispatch_pp_flush_pending(const optimizers::OptimizerConfig& opt_config) {
     if (mDispatchPpPendingGrads.empty()) return;
-    dispatch_pp_apply_grads_(mDispatchPpPendingGrads, opt_config, ++mDispatchPpAppliedStep,
+    dispatch_pp_apply_grads_(mDispatchPpPendingGrads,
+                             opt_config,
+                             ++mDispatchPpAppliedStep,
                              mDispatchPpPendingValidTokens);
     mDispatchPpPendingGrads.clear();
 }
 
 void MultiGPUPyTrainer::dispatch_pp_apply_grads_(
     const std::vector<std::pair<std::string, std::vector<std::byte>>>& collected,
-    const optimizers::OptimizerConfig& opt_config, int opt_step_1based, int valid_tokens) {
+    const optimizers::OptimizerConfig& opt_config,
+    int opt_step_1based,
+    int valid_tokens) {
     // GPU 0 holds the master replica: write the collected grads into its store and
     // run the optimizer there.
     run_work(
         [&](sThreadContext& ctx) {
             auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-            if (!model)
-                throw std::runtime_error("dispatch_pp_apply_grads_: DSL model required");
+            if (!model) throw std::runtime_error("dispatch_pp_apply_grads_: DSL model required");
             // The loss GPU counted valid tokens; publish the step total here so the optimizer
             // (on this master GPU) scales the grad norm per valid token, not per padded token.
             model->set_dispatch_pp_valid_tokens(valid_tokens);
             model->dispatch_pp_write_grads(collected);
-            mDispatchPpLastGradNorm = model->dispatch_pp_apply_optimizer(*ctx.Communicator, opt_config, opt_step_1based);
+            mDispatchPpLastGradNorm =
+                model->dispatch_pp_apply_optimizer(*ctx.Communicator, opt_config, opt_step_1based);
         },
         0);
     // Broadcast GPU 0's updated weights to every replica so the pool is consistent
@@ -2447,8 +2460,7 @@ std::unordered_map<std::string, std::size_t> MultiGPUPyTrainer::dispatch_pp_weig
     run_work(
         [&](sThreadContext& ctx) {
             auto* model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
-            if (!model)
-                throw std::runtime_error("dispatch_pp_weight_residency: DSL model required");
+            if (!model) throw std::runtime_error("dispatch_pp_weight_residency: DSL model required");
             auto* wm = model->weight_manager();
             if (!wm) {
                 // No weight manager => weights are fully resident (not streamed);
@@ -3027,6 +3039,282 @@ std::unordered_map<std::string, float> MultiGPUPyTrainer::get_grpo_native_metric
             {"keep_tokens", metrics.keep_tokens},
             {"total_tokens", metrics.total_tokens},
         };
+    });
+    return result;
+}
+
+void MultiGPUPyTrainer::step_dpo_native(const std::int32_t* inputs,
+                                        const std::int32_t* targets,
+                                        const float* ref_logprobs,
+                                        const std::uint8_t* loss_mask,
+                                        const std::int32_t* sample_starts,
+                                        const std::int32_t* sample_ends,
+                                        int sample_count,
+                                        const std::int32_t* pair_chosen,
+                                        const std::int32_t* pair_rejected,
+                                        int pair_count,
+                                        const std::int32_t* position_ids,
+                                        float loss_scale,
+                                        float beta,
+                                        int length_norm,
+                                        GrpoHostLayout layout) {
+    const int ep_size = std::max(1, mOptions.EPSize);
+    const int host_rows = std::max(1, (int)mContexts.size() / ep_size);
+    if (layout.token_rows != 1 && layout.token_rows != host_rows) {
+        throw std::invalid_argument(fmt::format(
+            "step_dpo_native: per-token arrays have {} rows; expected 1 (shared) or {} (one per host batch row)",
+            layout.token_rows,
+            host_rows));
+    }
+    if (layout.sample_rows != 1 && layout.sample_rows != host_rows) {
+        throw std::invalid_argument(fmt::format(
+            "step_dpo_native: sample/pair arrays have {} rows; expected 1 (shared) or {} (one per host batch row)",
+            layout.sample_rows,
+            host_rows));
+    }
+    if (layout.token_len != 0 && layout.token_len != static_cast<long>(B) * static_cast<long>(T)) {
+        throw std::invalid_argument(
+            fmt::format("step_dpo_native: per-token arrays have {} elements per row; engine expects B*T = {}x{} = {}",
+                        layout.token_len,
+                        B,
+                        T,
+                        static_cast<long>(B) * static_cast<long>(T)));
+    }
+    if (layout.input_cols != 0 && layout.input_cols != static_cast<long>(T)) {
+        throw std::invalid_argument(
+            fmt::format("step_dpo_native: input_ids/targets have {} columns; engine expects T = {}",
+                        layout.input_cols,
+                        T));
+    }
+    if (layout.input_rows != 0 && layout.input_rows < static_cast<long>(host_rows) * static_cast<long>(B)) {
+        throw std::invalid_argument(
+            fmt::format("step_dpo_native: input_ids/targets have {} rows; engine consumes {} host rows x B = {}",
+                        layout.input_rows,
+                        host_rows,
+                        static_cast<long>(host_rows) * static_cast<long>(B)));
+    }
+    mGrpoShardedRows = (layout.token_rows > 1);
+    for (int i = 0; i < (int)mContexts.size(); ++i) {
+        auto& ctx = mContexts.at(i);
+        if (!ctx.Model) {
+            throw std::runtime_error(fmt::format("step_dpo_native: ctx[{}].Model is null", i));
+        }
+        auto* ib = ctx.Model->get_input_buffer().get<std::int32_t>();
+        auto* tb = ctx.Model->get_target_buffer().get<std::int32_t>();
+        Tensor pos_buf = ctx.Model->get_position_ids_buffer();
+        auto* pb = pos_buf.get<std::int32_t>();
+        const int pos_planes = (pos_buf.Rank == 3) ? static_cast<int>(pos_buf.Sizes[0]) : 1;
+        const std::size_t bt = static_cast<std::size_t>(B) * static_cast<std::size_t>(T);
+        const int src_row = host_batch_row_for_local_rank(i, ep_size);
+
+        std::memcpy(ib, inputs + src_row * B * T, B * T * sizeof(std::int32_t));
+        std::memcpy(tb, targets + src_row * B * T, B * T * sizeof(std::int32_t));
+        if (position_ids) {
+            const auto* src = position_ids + static_cast<std::ptrdiff_t>(src_row) * static_cast<std::ptrdiff_t>(bt);
+            for (int p = 0; p < pos_planes; ++p) {
+                std::memcpy(pb + p * bt, src, bt * sizeof(std::int32_t));
+            }
+        } else {
+            fill_sequential_position_ids(pb, pos_planes, B, T);
+        }
+    }
+
+    if (mTrainMicroStep >= mGradAccumulation) {
+        throw std::runtime_error(
+            fmt::format("step_dpo_native: micro_step {} >= grad_accumulation {}", mTrainMicroStep, mGradAccumulation));
+    }
+
+    const dsl::DpoNativeLossConfig loss_config{
+        .loss_scale = loss_scale,
+        .beta = beta,
+        .length_norm = (length_norm != 0),
+    };
+
+    run_work([micro_idx = mTrainMicroStep,
+              micro_batches = mGradAccumulation,
+              ref_logprobs,
+              loss_mask,
+              sample_starts,
+              sample_ends,
+              sample_count,
+              pair_chosen,
+              pair_rejected,
+              pair_count,
+              loss_config,
+              layout,
+              B = this->B,
+              T = this->T](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("step_dpo_native: model is not a DslModel");
+        }
+
+        Tensor inputs_tensor = ctx.Model->get_input_buffer();
+        Tensor position_ids_tensor = ctx.Model->get_position_ids_buffer();
+        Tensor targets_tensor = ctx.Model->get_target_buffer();
+
+        const int gpu_rank = ctx.Communicator->local_rank();
+        const int gpu_ep_size = ctx.Communicator->ep_size();
+        const int src_row = host_batch_row_for_local_rank(gpu_rank, gpu_ep_size);
+        const std::ptrdiff_t token_offset = static_cast<std::ptrdiff_t>(src_row) * B * T;
+
+        const float* ref_row = ref_logprobs;
+        const std::uint8_t* loss_mask_row = loss_mask;
+        if (layout.token_rows > 1) {
+            ref_row += token_offset;
+            loss_mask_row += token_offset;
+        }
+        const std::int32_t* starts_row = sample_starts;
+        const std::int32_t* ends_row = sample_ends;
+        const std::int32_t* pair_chosen_row = pair_chosen;
+        const std::int32_t* pair_rejected_row = pair_rejected;
+        int row_sample_count = sample_count;
+        int row_pair_count = pair_count;
+        if (layout.sample_rows > 1) {
+            starts_row += static_cast<std::ptrdiff_t>(src_row) * sample_count;
+            ends_row += static_cast<std::ptrdiff_t>(src_row) * sample_count;
+            int n = 0;
+            while (n < sample_count && starts_row[n] >= 0 && ends_row[n] >= 0) {
+                ++n;
+            }
+            row_sample_count = n;
+            // Pair rows share the sample-row stride; entries are padded with -1.
+            pair_chosen_row += static_cast<std::ptrdiff_t>(src_row) * pair_count;
+            pair_rejected_row += static_cast<std::ptrdiff_t>(src_row) * pair_count;
+            int p = 0;
+            while (p < pair_count && pair_chosen_row[p] >= 0 && pair_rejected_row[p] >= 0) {
+                ++p;
+            }
+            row_pair_count = p;
+        }
+
+        dsl_model->step_dpo_native(inputs_tensor,
+                                   position_ids_tensor,
+                                   targets_tensor,
+                                   ref_row,
+                                   loss_mask_row,
+                                   starts_row,
+                                   ends_row,
+                                   row_sample_count,
+                                   pair_chosen_row,
+                                   pair_rejected_row,
+                                   row_pair_count,
+                                   micro_batches,
+                                   micro_idx,
+                                   *ctx.Communicator,
+                                   loss_config);
+    });
+
+    ++mTrainMicroStep;
+}
+
+std::unordered_map<std::string, float> MultiGPUPyTrainer::get_dpo_native_metrics() {
+    std::vector<dsl::DpoNativeMetrics> per_rank(mContexts.size());
+    run_work([&per_rank](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("get_dpo_native_metrics: model is not a DslModel");
+        }
+        per_rank.at(static_cast<std::size_t>(ctx.Communicator->local_rank())) = dsl_model->consume_dpo_native_metrics();
+    });
+
+    // Sharded layout: each data-parallel rank saw a distinct slice of pairs, so
+    // combine means weighted by each rank's pair count. Replicated layout: every
+    // rank is identical, take rank 0.
+    const int ep_size = std::max(1, mOptions.EPSize);
+    dsl::DpoNativeMetrics agg;
+    if (mGrpoShardedRows) {
+        float total_pairs = 0.0f;
+        for (int r = 0; r < (int)per_rank.size(); r += ep_size) {
+            const auto& m = per_rank[static_cast<std::size_t>(r)];
+            const float w = std::max(m.pair_count, 0.0f);
+            agg.loss += m.loss * w;
+            agg.accuracy += m.accuracy * w;
+            agg.margin += m.margin * w;
+            total_pairs += m.pair_count;
+        }
+        const float denom = std::max(total_pairs, 1.0f);
+        agg.loss /= denom;
+        agg.accuracy /= denom;
+        agg.margin /= denom;
+        agg.pair_count = total_pairs;
+    } else {
+        agg = per_rank.at(0);
+    }
+
+    return {
+        {"dpo_loss", agg.loss},
+        {"dpo_accuracy", agg.accuracy},
+        {"dpo_margin", agg.margin},
+        {"dpo_pairs", agg.pair_count},
+    };
+}
+std::vector<float> MultiGPUPyTrainer::compute_ref_logprobs_dpo(const std::int32_t* inputs,
+                                                               const std::int32_t* targets,
+                                                               const std::int32_t* position_ids,
+                                                               int input_rows) {
+    const int ep_size = std::max(1, mOptions.EPSize);
+    const int engine_host_rows = std::max(1, (int)mContexts.size() / ep_size);
+    if (input_rows % B != 0) {
+        throw std::invalid_argument(
+            fmt::format("compute_ref_logprobs_dpo: input_rows {} not a multiple of B {}", input_rows, B));
+    }
+    const int host_rows = input_rows / B;
+    if (host_rows != engine_host_rows) {
+        throw std::invalid_argument(fmt::format("compute_ref_logprobs_dpo: inputs have {} host rows; engine consumes "
+                                                "{} (one B-block per data-parallel rank)",
+                                                host_rows,
+                                                engine_host_rows));
+    }
+    const std::size_t bt = static_cast<std::size_t>(B) * static_cast<std::size_t>(T);
+
+    for (int i = 0; i < (int)mContexts.size(); ++i) {
+        auto& ctx = mContexts.at(i);
+        if (!ctx.Model) {
+            throw std::runtime_error(fmt::format("compute_ref_logprobs_dpo: ctx[{}].Model is null", i));
+        }
+        auto* ib = ctx.Model->get_input_buffer().get<std::int32_t>();
+        auto* tb = ctx.Model->get_target_buffer().get<std::int32_t>();
+        Tensor pos_buf = ctx.Model->get_position_ids_buffer();
+        auto* pb = pos_buf.get<std::int32_t>();
+        const int pos_planes = (pos_buf.Rank == 3) ? static_cast<int>(pos_buf.Sizes[0]) : 1;
+        const int src_row = host_batch_row_for_local_rank(i, ep_size);
+
+        std::memcpy(ib, inputs + static_cast<std::ptrdiff_t>(src_row) * B * T, B * T * sizeof(std::int32_t));
+        std::memcpy(tb, targets + static_cast<std::ptrdiff_t>(src_row) * B * T, B * T * sizeof(std::int32_t));
+        if (position_ids) {
+            const auto* src = position_ids + static_cast<std::ptrdiff_t>(src_row) * static_cast<std::ptrdiff_t>(bt);
+            for (int p = 0; p < pos_planes; ++p) {
+                std::memcpy(pb + p * bt, src, bt * sizeof(std::int32_t));
+            }
+        } else {
+            fill_sequential_position_ids(pb, pos_planes, B, T);
+        }
+    }
+
+    std::vector<float> result(static_cast<std::size_t>(host_rows) * bt, 0.0f);
+    run_work([&result, ep_size, bt, B = this->B, T = this->T](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("compute_ref_logprobs_dpo: model is not a DslModel");
+        }
+        const int gpu_rank = ctx.Communicator->local_rank();
+        const int gpu_ep_size = ctx.Communicator->ep_size();
+        // Within an EP group every rank holds the same host row; only the group's
+        // first rank writes it back so distinct rows don't race or duplicate.
+        if (gpu_ep_size > 1 && (gpu_rank % gpu_ep_size) != 0) {
+            (void)dsl_model->compute_ref_logprobs(ctx.Model->get_input_buffer(),
+                                                  ctx.Model->get_position_ids_buffer(),
+                                                  ctx.Model->get_target_buffer(),
+                                                  *ctx.Communicator);
+            return;
+        }
+        const int src_row = host_batch_row_for_local_rank(gpu_rank, gpu_ep_size);
+        auto logprobs = dsl_model->compute_ref_logprobs(ctx.Model->get_input_buffer(),
+                                                        ctx.Model->get_position_ids_buffer(),
+                                                        ctx.Model->get_target_buffer(),
+                                                        *ctx.Communicator);
+        std::copy(logprobs.begin(), logprobs.end(), result.begin() + static_cast<std::ptrdiff_t>(src_row) * bt);
     });
     return result;
 }

--- a/csrc/src/binding/py_train.h
+++ b/csrc/src/binding/py_train.h
@@ -308,10 +308,19 @@ public:
     // local, mirroring get_grpo_native_metrics). Consumes the accumulator on
     // every rank.
     float get_kd_loss();
-    // Offline DPO micro-step. Per-token arrays (ref_logprobs / loss_mask) and the
-    // sample/pair arrays follow the same GrpoHostLayout sharding as
-    // step_grpo_native; pair arrays shard together with the sample arrays
-    // (sample_rows). Each pair row holds `pair_count` entries padded with -1.
+    // Host-array layout for step_dpo_native. Per-token arrays and sample/pair
+    // arrays are either shared by every GPU row (rows == 1) or carry one row
+    // per host batch row. When sample_rows > 1, each sample/pair row is padded
+    // with -1 to its configured capacity.
+    struct DpoHostLayout {
+        int token_rows = 1;
+        int sample_rows = 1;
+        long token_len = 0;
+        long input_rows = 0;
+        long input_cols = 0;
+    };
+
+    // Offline DPO micro-step. Pair arrays shard together with sample arrays.
     void step_dpo_native(const std::int32_t* inputs,
                          const std::int32_t* targets,
                          const float* ref_logprobs,
@@ -326,7 +335,7 @@ public:
                          float loss_scale,
                          float beta,
                          int length_norm,
-                         GrpoHostLayout layout);
+                         DpoHostLayout layout);
     std::unordered_map<std::string, float> get_dpo_native_metrics();
 
     // DPO reference log-probs via the fused-loss forward (fp8/multi-GPU-safe).
@@ -348,6 +357,8 @@ private:
     int mTrainMicroStep = 0;
     int mEvalStep = 0;
     int mGradAccumulation = 1;
+    // Controls metric aggregation after a DPO step with distinct host rows.
+    bool mDpoShardedRows = false;
 
     std::unique_ptr<CommunicatorThreadsPack> mThreads;
     struct sFullStepGraphState {

--- a/csrc/src/binding/py_train.h
+++ b/csrc/src/binding/py_train.h
@@ -185,22 +185,21 @@ public:
     std::vector<float> dispatch_pp_forward_hidden(const std::int32_t* inputs);
     std::vector<float> dispatch_pp_forward_subranges(const std::int32_t* inputs, int split_after_block);
     std::vector<float> dispatch_pp_grad_norms_whole(const std::int32_t* inputs, const std::int32_t* targets);
-    std::vector<float> dispatch_pp_grad_norms_subranges(const std::int32_t* inputs,
-                                                              const std::int32_t* targets,
-                                                              int split_after_block);
+    std::vector<float>
+    dispatch_pp_grad_norms_subranges(const std::int32_t* inputs, const std::int32_t* targets, int split_after_block);
     // Round-robin forward dispatch of contiguous block stages [los[i]..his[i]]
     // across the GPU pool (stage i -> GPU i % ngpu), handing the boundary residual
     // GPU->host->GPU between stages. Returns the final hidden state as flat f32.
     std::vector<float> dispatch_pp_forward_hidden_multigpu(const std::int32_t* inputs,
-                                                                 const std::vector<int>& los,
-                                                                 const std::vector<int>& his);
+                                                           const std::vector<int>& los,
+                                                           const std::vector<int>& his);
     // Round-robin backward dispatch (reverse stage order) across the GPU pool,
     // handing the boundary gradients GPU->host->GPU. Returns per-block weight-grad
     // L2 norms collected from whichever GPU computed each block.
     std::vector<float> dispatch_pp_grad_norms_multigpu(const std::int32_t* inputs,
-                                                             const std::int32_t* targets,
-                                                             const std::vector<int>& los,
-                                                             const std::vector<int>& his);
+                                                       const std::int32_t* targets,
+                                                       const std::vector<int>& los,
+                                                       const std::vector<int>& his);
     // Per-GPU weight-residency snapshot (GPU 0; the pool is homogeneous): total
     // device-resident weight bytes, the streaming block double-buffer footprint,
     // and the slot count. Proves the dispatch-PP memory invariant — GPU weight
@@ -209,9 +208,9 @@ public:
     // One full single-GPU dispatch-PP training step (forward -> loss, backward ->
     // grads, optimizer update) through the sub-range executor. Returns the loss.
     float dispatch_pp_train_step(const std::int32_t* inputs,
-                                       const std::int32_t* targets,
-                                       const optimizers::OptimizerConfig& opt_config,
-                                       int step_idx);
+                                 const std::int32_t* targets,
+                                 const optimizers::OptimizerConfig& opt_config,
+                                 int step_idx);
     // One full multi-GPU dispatch-PP training step: round-robin backward dispatch
     // with cross-GPU boundary handoff -> collect per-stage grads -> optimizer on the
     // master replica -> broadcast updated weights to every GPU. Returns the loss.
@@ -220,13 +219,13 @@ public:
     // RoundPipe one-step staleness. Call dispatch_pp_flush_pending at the end to
     // apply the last deferred grads.
     float dispatch_pp_train_step_multigpu(const std::int32_t* inputs,
-                                                const std::int32_t* targets,
-                                                const std::vector<int>& los,
-                                                const std::vector<int>& his,
-                                                const optimizers::OptimizerConfig& opt_config,
-                                                int step_idx,
-                                                bool stale,
-                                                int num_microbatches = 1);
+                                          const std::int32_t* targets,
+                                          const std::vector<int>& los,
+                                          const std::vector<int>& his,
+                                          const optimizers::OptimizerConfig& opt_config,
+                                          int step_idx,
+                                          bool stale,
+                                          int num_microbatches = 1);
     // Grad norm computed by the last dispatch_pp optimizer apply (for the loss display).
     float dispatch_pp_last_grad_norm() const {
         return mDispatchPpLastGradNorm;
@@ -309,6 +308,34 @@ public:
     // local, mirroring get_grpo_native_metrics). Consumes the accumulator on
     // every rank.
     float get_kd_loss();
+    // Offline DPO micro-step. Per-token arrays (ref_logprobs / loss_mask) and the
+    // sample/pair arrays follow the same GrpoHostLayout sharding as
+    // step_grpo_native; pair arrays shard together with the sample arrays
+    // (sample_rows). Each pair row holds `pair_count` entries padded with -1.
+    void step_dpo_native(const std::int32_t* inputs,
+                         const std::int32_t* targets,
+                         const float* ref_logprobs,
+                         const std::uint8_t* loss_mask,
+                         const std::int32_t* sample_starts,
+                         const std::int32_t* sample_ends,
+                         int sample_count,
+                         const std::int32_t* pair_chosen,
+                         const std::int32_t* pair_rejected,
+                         int pair_count,
+                         const std::int32_t* position_ids,
+                         float loss_scale,
+                         float beta,
+                         int length_norm,
+                         GrpoHostLayout layout);
+    std::unordered_map<std::string, float> get_dpo_native_metrics();
+
+    // DPO reference log-probs via the fused-loss forward (fp8/multi-GPU-safe).
+    // `inputs`/`targets`/`position_ids` are [host_rows*B, T] (one B-block per host
+    // batch row). Returns logprobs for ALL host rows, [host_rows*B*T] in row order.
+    std::vector<float> compute_ref_logprobs_dpo(const std::int32_t* inputs,
+                                                const std::int32_t* targets,
+                                                const std::int32_t* position_ids,
+                                                int input_rows);
 
 private:
     std::unique_ptr<PretrainedConfig> mConfig;  // unique_ptr to preserve polymorphism
@@ -390,7 +417,8 @@ private:
     // the updated weights to every replica. opt_step_1based is the Adam step index.
     void dispatch_pp_apply_grads_(const std::vector<std::pair<std::string, std::vector<std::byte>>>& collected,
                                   const optimizers::OptimizerConfig& opt_config,
-                                  int opt_step_1based, int valid_tokens);
+                                  int opt_step_1based,
+                                  int valid_tokens);
     // dispatch-PP one-step-stale state: gradients deferred from the previous step,
     // and the count of optimizer updates applied so far (1-based Adam step).
     std::vector<std::pair<std::string, std::vector<std::byte>>> mDispatchPpPendingGrads;

--- a/csrc/src/kernels/fused_classifier.cu
+++ b/csrc/src/kernels/fused_classifier.cu
@@ -1824,8 +1824,9 @@ void compute_dpo_custom_dloss(float* custom_dloss,
     }
     // Zero the full dloss buffer so backward never consumes stale values for the
     // prompt / padding / final-no-next-token slots the kernel does not write.
+    // metrics is NOT reset here: the kernel atomicAdds across micro-steps and the
+    // caller resets it once per optimizer step (step_dpo_native, micro_step 0).
     CUDA_CHECK(cudaMemsetAsync(custom_dloss, 0, static_cast<std::size_t>(BT) * sizeof(float), stream));
-    CUDA_CHECK(cudaMemsetAsync(metrics, 0, 4 * sizeof(float), stream));
     if (pair_count <= 0) {
         return;
     }

--- a/csrc/src/kernels/fused_classifier.cu
+++ b/csrc/src/kernels/fused_classifier.cu
@@ -1031,8 +1031,7 @@ __global__ void kd_normalize_teacher_topk_kernel(float* q_out,
     const float inv_sum = 1.0f / block_sum;
     for (int k = threadIdx.x; k < K; k += blockDim.x) {
         int id = ids[base + k];
-        q_out[base + k] =
-            (id >= 0 && id < V) ? expf(teacher_logprobs[base + k] * inv_tau - block_max) * inv_sum : 0.0f;
+        q_out[base + k] = (id >= 0 && id < V) ? expf(teacher_logprobs[base + k] * inv_tau - block_max) * inv_sum : 0.0f;
     }
 }
 
@@ -1693,6 +1692,158 @@ void compute_grpo_custom_dloss(float* custom_dloss,
                                                                adv_tau,
                                                                teacher_tau,
                                                                kl_tau);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+// --- DPO custom dloss -------------------------------------------------------
+// Reduce one sample's response-token log-prob sums (policy and reference) plus
+// the response-token count. All 256 block threads must call this in lock-step;
+// it is invoked twice per block (chosen then rejected) and reuses the same
+// shared buffers, so a trailing __syncthreads() guards the next invocation.
+__device__ void dpo_reduce_sample(const float* losses,
+                                  const float* ref_logprobs,
+                                  const std::uint8_t* loss_mask,
+                                  int start,
+                                  int end,
+                                  double& s_pol,
+                                  double& s_ref,
+                                  int& len) {
+    __shared__ double sh_pol[256];
+    __shared__ double sh_ref[256];
+    __shared__ int sh_len[256];
+
+    double lp = 0.0;
+    double lr = 0.0;
+    int n = 0;
+    for (int t = start + 1 + static_cast<int>(threadIdx.x); t < end; t += static_cast<int>(blockDim.x)) {
+        if (loss_mask[t] == 0) {
+            continue;
+        }
+        const int out_idx = t - 1;  // shifted layout: trainer_logprob = -losses[out_idx]
+        lp += -static_cast<double>(losses[out_idx]);
+        lr += static_cast<double>(ref_logprobs[out_idx]);
+        n += 1;
+    }
+
+    sh_pol[threadIdx.x] = lp;
+    sh_ref[threadIdx.x] = lr;
+    sh_len[threadIdx.x] = n;
+    __syncthreads();
+
+    for (int stride = static_cast<int>(blockDim.x) / 2; stride > 0; stride >>= 1) {
+        if (static_cast<int>(threadIdx.x) < stride) {
+            sh_pol[threadIdx.x] += sh_pol[threadIdx.x + stride];
+            sh_ref[threadIdx.x] += sh_ref[threadIdx.x + stride];
+            sh_len[threadIdx.x] += sh_len[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+
+    s_pol = sh_pol[0];
+    s_ref = sh_ref[0];
+    len = sh_len[0];
+    __syncthreads();  // all threads finished reading before the next call rewrites shared
+}
+
+__global__ void dpo_custom_dloss_kernel(float* custom_dloss,
+                                        float* metrics,
+                                        const float* losses,
+                                        const float* ref_logprobs,
+                                        const std::uint8_t* loss_mask,
+                                        const std::int32_t* sample_starts,
+                                        const std::int32_t* sample_ends,
+                                        const std::int32_t* pair_chosen,
+                                        const std::int32_t* pair_rejected,
+                                        int pair_count,
+                                        int BT,
+                                        float inv_loss_scale,
+                                        float beta,
+                                        int length_norm) {
+    const int pair = static_cast<int>(blockIdx.x);
+    if (pair >= pair_count) {
+        return;
+    }
+    const int ci = pair_chosen[pair];
+    const int ri = pair_rejected[pair];
+    const int c_start = sample_starts[ci];
+    const int c_end = sample_ends[ci];
+    const int r_start = sample_starts[ri];
+    const int r_end = sample_ends[ri];
+    if (c_start < 0 || c_end > BT || c_start >= c_end || r_start < 0 || r_end > BT || r_start >= r_end) {
+        return;
+    }
+
+    double sc_pol, sc_ref, sr_pol, sr_ref;
+    int len_c, len_r;
+    dpo_reduce_sample(losses, ref_logprobs, loss_mask, c_start, c_end, sc_pol, sc_ref, len_c);
+    dpo_reduce_sample(losses, ref_logprobs, loss_mask, r_start, r_end, sr_pol, sr_ref, len_r);
+
+    const double wc = (length_norm && len_c > 0) ? 1.0 / static_cast<double>(len_c) : 1.0;
+    const double wr = (length_norm && len_r > 0) ? 1.0 / static_cast<double>(len_r) : 1.0;
+    const double margin = static_cast<double>(beta) * ((sc_pol - sc_ref) * wc - (sr_pol - sr_ref) * wr);
+    // g = beta * sigmoid(-margin); custom_dloss = -dL/dlogp_theta = +g*w (chosen) / -g*w (rejected).
+    const double g = static_cast<double>(beta) * (1.0 / (1.0 + exp(margin)));
+
+    for (int t = c_start + 1 + static_cast<int>(threadIdx.x); t < c_end; t += static_cast<int>(blockDim.x)) {
+        if (loss_mask[t] != 0) {
+            custom_dloss[t - 1] = static_cast<float>((g * wc) * static_cast<double>(inv_loss_scale));
+        }
+    }
+    for (int t = r_start + 1 + static_cast<int>(threadIdx.x); t < r_end; t += static_cast<int>(blockDim.x)) {
+        if (loss_mask[t] != 0) {
+            custom_dloss[t - 1] = static_cast<float>((-g * wr) * static_cast<double>(inv_loss_scale));
+        }
+    }
+
+    if (threadIdx.x == 0) {
+        const double loss = -log(1.0 / (1.0 + exp(-margin)));  // -log sigmoid(margin)
+        atomicAdd(metrics + 0, static_cast<float>(loss));
+        atomicAdd(metrics + 1, margin > 0.0 ? 1.0f : 0.0f);
+        atomicAdd(metrics + 2, static_cast<float>(margin));
+        atomicAdd(metrics + 3, 1.0f);
+    }
+}
+
+void compute_dpo_custom_dloss(float* custom_dloss,
+                              float* metrics,
+                              const float* losses,
+                              const float* ref_logprobs,
+                              const std::uint8_t* loss_mask,
+                              const std::int32_t* sample_starts,
+                              const std::int32_t* sample_ends,
+                              const std::int32_t* pair_chosen,
+                              const std::int32_t* pair_rejected,
+                              int pair_count,
+                              int BT,
+                              float loss_scale,
+                              float beta,
+                              int length_norm,
+                              cudaStream_t stream) {
+    if (BT <= 0) {
+        return;
+    }
+    // Zero the full dloss buffer so backward never consumes stale values for the
+    // prompt / padding / final-no-next-token slots the kernel does not write.
+    CUDA_CHECK(cudaMemsetAsync(custom_dloss, 0, static_cast<std::size_t>(BT) * sizeof(float), stream));
+    CUDA_CHECK(cudaMemsetAsync(metrics, 0, 4 * sizeof(float), stream));
+    if (pair_count <= 0) {
+        return;
+    }
+    const float inv_loss_scale = (loss_scale == 0.0f) ? 1.0f : (1.0f / loss_scale);
+    dpo_custom_dloss_kernel<<<pair_count, 256, 0, stream>>>(custom_dloss,
+                                                            metrics,
+                                                            losses,
+                                                            ref_logprobs,
+                                                            loss_mask,
+                                                            sample_starts,
+                                                            sample_ends,
+                                                            pair_chosen,
+                                                            pair_rejected,
+                                                            pair_count,
+                                                            BT,
+                                                            inv_loss_scale,
+                                                            beta,
+                                                            length_norm);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/csrc/src/kernels/kernels.h
+++ b/csrc/src/kernels/kernels.h
@@ -1506,15 +1506,15 @@ constexpr int CROSS_ENTROPY_BACKWARD_CHUNK_SIZE = 4096;
 /// per row (pass the tau=1 logsumexp when tau == 1). `kd_loss_accum` (may be
 /// null) accumulates tau^2 * KL(q || p_tau) over valid tokens via atomicAdd.
 struct KdBackwardArgs {
-    const int* ids = nullptr;       ///< [BT, K] teacher top-K token ids
-    const float* q = nullptr;       ///< [BT, K] renormalized teacher probs at tau
-    const float* lse_tau = nullptr; ///< [BT] logsumexp of logits/tau
-    float inv_tau = 1.0f;           ///< 1/tau
-    float ce_w = 1.0f;              ///< weight of the CE gradient term
-    float kd_scale = 0.0f;          ///< kd_weight * tau (gradient scale of the KD term)
-    float tau_sq = 1.0f;            ///< tau^2 (KD loss metric scale)
-    float* kd_loss_accum = nullptr; ///< [1] scalar accumulator for the KD loss metric
-    int K = 0;                      ///< top-K entries per token
+    const int* ids = nullptr;        ///< [BT, K] teacher top-K token ids
+    const float* q = nullptr;        ///< [BT, K] renormalized teacher probs at tau
+    const float* lse_tau = nullptr;  ///< [BT] logsumexp of logits/tau
+    float inv_tau = 1.0f;            ///< 1/tau
+    float ce_w = 1.0f;               ///< weight of the CE gradient term
+    float kd_scale = 0.0f;           ///< kd_weight * tau (gradient scale of the KD term)
+    float tau_sq = 1.0f;             ///< tau^2 (KD loss metric scale)
+    float* kd_loss_accum = nullptr;  ///< [1] scalar accumulator for the KD loss metric
+    int K = 0;                       ///< top-K entries per token
 };
 
 /// Renormalize per-token teacher top-K logprobs into a probability
@@ -1782,6 +1782,29 @@ void compute_grpo_custom_dloss(float* custom_dloss,
                                float teacher_tau,
                                float kl_tau,
                                cudaStream_t stream);
+
+// DPO (Direct Preference Optimization) preference loss. One logical pair is
+// (chosen sample, rejected sample), identified by pair_chosen[p]/pair_rejected[p]
+// indexing into sample_starts/sample_ends. The per-token custom_dloss is written
+// in the same shifted layout as compute_grpo_custom_dloss: the gradient seed for
+// logical token (out_idx + 1) is stored at custom_dloss[out_idx], read back as
+// trainer_logprob = -losses[out_idx]. metrics is [4]: {loss_sum, correct_sum,
+// margin_sum, pair_count}, accumulated across pairs (the caller averages).
+void compute_dpo_custom_dloss(float* custom_dloss,
+                              float* metrics,
+                              const float* losses,
+                              const float* ref_logprobs,
+                              const std::uint8_t* loss_mask,
+                              const std::int32_t* sample_starts,
+                              const std::int32_t* sample_ends,
+                              const std::int32_t* pair_chosen,
+                              const std::int32_t* pair_rejected,
+                              int pair_count,
+                              int BT,
+                              float loss_scale,
+                              float beta,
+                              int length_norm,
+                              cudaStream_t stream);
 
 /// Scale logits rows by per-token inverse temperature (in-place).
 /// logits is [BT, P], inv_temperature is [BT].

--- a/csrc/src/runtime/core/run_state_types.h
+++ b/csrc/src/runtime/core/run_state_types.h
@@ -90,6 +90,8 @@ struct GrpoNativeScratch {
     Tensor loss_mask;           ///< Device BYTE [B*T], 0/1
     Tensor sample_starts;       ///< Device INT32 [max_samples]
     Tensor sample_ends;         ///< Device INT32 [max_samples]
+    Tensor pair_chosen;         ///< Device INT32 [max_samples], DPO: chosen sample index per pair
+    Tensor pair_rejected;       ///< Device INT32 [max_samples], DPO: rejected sample index per pair
     Tensor custom_dloss;        ///< Device FP32 [B*T], shifted for LM-head backward
     Tensor inv_temperature;     ///< Device FP32 [B*T]
     Tensor metrics;             ///< Device FP32 metric accumulators
@@ -101,6 +103,8 @@ struct GrpoNativeScratch {
     std::array<Tensor, kHostStagingSlots> host_loss_mask;           ///< Pinned BYTE [B*T]
     std::array<Tensor, kHostStagingSlots> host_sample_starts;       ///< Pinned INT32 [max_samples]
     std::array<Tensor, kHostStagingSlots> host_sample_ends;         ///< Pinned INT32 [max_samples]
+    std::array<Tensor, kHostStagingSlots> host_pair_chosen;         ///< Pinned INT32 [max_samples] (DPO)
+    std::array<Tensor, kHostStagingSlots> host_pair_rejected;       ///< Pinned INT32 [max_samples] (DPO)
     Tensor host_metrics;                                            ///< Pinned FP32 metric accumulators
     std::array<cudaEvent_t, kHostStagingSlots> host_copy_done{};
     std::array<bool, kHostStagingSlots> host_copy_recorded{};

--- a/csrc/src/runtime/dsl/dsl_model.h
+++ b/csrc/src/runtime/dsl/dsl_model.h
@@ -75,6 +75,23 @@ struct GrpoNativeMetrics {
     float total_tokens = 0.0f;
 };
 
+struct DpoNativeLossConfig {
+    float loss_scale = 1.0f;
+    float beta = 0.1f;
+    // Divide each sequence's response-token logprob sum by its response length
+    // (SimPO-style); off for minimal pairs where chosen/rejected lengths match.
+    bool length_norm = false;
+};
+
+struct DpoNativeMetrics {
+    float loss = 0.0f;      ///< mean -log sigmoid(beta * margin) over pairs
+    float accuracy = 0.0f;  ///< fraction of pairs with margin > 0
+    float margin = 0.0f;    ///< mean margin
+    /// Raw pair count the means were normalized by (before the max(.,1) clamp);
+    /// lets callers re-weight when combining across data-parallel ranks.
+    float pair_count = 0.0f;
+};
+
 /// Configuration for the offline knowledge-distillation step.
 /// Total loss: ce_weight * CE + kd_weight * tau^2 * KL(teacher_topk || student).
 struct KdLossConfig {

--- a/csrc/src/runtime/dsl/dsl_model.h
+++ b/csrc/src/runtime/dsl/dsl_model.h
@@ -117,21 +117,19 @@ public:
     std::vector<float> dispatch_pp_forward_hidden(Tensor inputs, Tensor position_ids, NCCLCommunicator& comm);
     // Forward as two contiguous block sub-ranges [0..split] then [split+1..last],
     // the boundary residual round-tripped through host; returns final hidden f32.
-    std::vector<float> dispatch_pp_forward_subranges(Tensor inputs,
-                                                           Tensor position_ids,
-                                                           NCCLCommunicator& comm,
-                                                           int split_after_block);
+    std::vector<float>
+    dispatch_pp_forward_subranges(Tensor inputs, Tensor position_ids, NCCLCommunicator& comm, int split_after_block);
     // Run one forward stage (blocks [lo..hi]) eagerly, leaving state resident.
     // When inject_layer >= 0, inject ``inject_host`` into get_residual(inject_layer)
     // first (the cross-GPU activation handoff). Read the result via the executor's
     // debug readers (debug_read_residual_bytes / last_block_hidden_f32).
     void dispatch_pp_forward_stage(Tensor inputs,
-                                         Tensor position_ids,
-                                         NCCLCommunicator& comm,
-                                         int lo,
-                                         int hi,
-                                         std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
-                                         bool preserve_output);
+                                   Tensor position_ids,
+                                   NCCLCommunicator& comm,
+                                   int lo,
+                                   int hi,
+                                   std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
+                                   bool preserve_output);
     // Run one backward stage (blocks [lo..hi]) on this GPU. Forward only this
     // stage's blocks from fwd_inject (block lo-1's residual, captured in the
     // forward pass; empty for lo==0, which forwards from the embedding), then run
@@ -143,37 +141,35 @@ public:
     // d_blocks[hi].res_att / .mlp_down). Read results via the executor readers
     // (block_grad_norms, read_named_bytes for d_blocks[lo-1].*).
     void dispatch_pp_backward_stage(Tensor inputs,
-                                          Tensor targets,
-                                          Tensor position_ids,
-                                          NCCLCommunicator& comm,
-                                          int lo,
-                                          int hi,
-                                          bool is_loss_stage,
-                                          std::vector<std::pair<std::string, std::vector<std::byte>>> fwd_inject,
-                                          std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
-                                          int micro_step = 0,
-                                          int total_micro = 1);
+                                    Tensor targets,
+                                    Tensor position_ids,
+                                    NCCLCommunicator& comm,
+                                    int lo,
+                                    int hi,
+                                    bool is_loss_stage,
+                                    std::vector<std::pair<std::string, std::vector<std::byte>>> fwd_inject,
+                                    std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
+                                    int micro_step = 0,
+                                    int total_micro = 1);
     // Whole-graph backward; returns per-block weight-grad L2 norms (block order).
-    std::vector<float> dispatch_pp_grad_norms_whole(Tensor inputs,
-                                                          Tensor targets,
-                                                          Tensor position_ids,
-                                                          NCCLCommunicator& comm);
+    std::vector<float>
+    dispatch_pp_grad_norms_whole(Tensor inputs, Tensor targets, Tensor position_ids, NCCLCommunicator& comm);
     // One full dispatch-PP training step through the forced-eager sub-range
     // executor: forward (computes the loss), backward (grads to the store), then
     // the optimizer update. Returns the step's mean loss. Single-GPU end-to-end
     // convergence keystone (the cross-GPU stage handoff is validated separately).
     float dispatch_pp_train_step(Tensor inputs,
-                                       Tensor targets,
-                                       Tensor position_ids,
-                                       NCCLCommunicator& comm,
-                                       const optimizers::OptimizerConfig& opt_config,
-                                       int step_idx);
+                                 Tensor targets,
+                                 Tensor position_ids,
+                                 NCCLCommunicator& comm,
+                                 const optimizers::OptimizerConfig& opt_config,
+                                 int step_idx);
     // --- Multi-GPU dispatch training-step host-transfer primitives ---
     // Read the weight gradients for the parameters of blocks [lo..hi] (and, when
     // include_nonblock, the non-block params: lm_head / final norm) to host,
     // keyed by parameter name. The cross-GPU grad collection for the fused step.
-    std::vector<std::pair<std::string, std::vector<std::byte>>> dispatch_pp_read_block_grads(
-        int lo, int hi, bool include_head, bool include_embed);
+    std::vector<std::pair<std::string, std::vector<std::byte>>>
+    dispatch_pp_read_block_grads(int lo, int hi, bool include_head, bool include_embed);
     // Write gradients from host into the grad store by name (host -> device).
     void dispatch_pp_write_grads(const std::vector<std::pair<std::string, std::vector<std::byte>>>& items);
     // Zero the grad accumulators before a backward wavefront. The diagonal schedule
@@ -186,9 +182,8 @@ public:
     // Run the optimizer over the (collected) grad store on this GPU. Uses
     // total-token normalization (ValidTokenCount is not populated on the collecting
     // GPU since the dispatch backward skips the DP loss reduce). step_idx is 1-based.
-    float dispatch_pp_apply_optimizer(NCCLCommunicator& comm,
-                                            const optimizers::OptimizerConfig& opt_config,
-                                            int step_idx);
+    float
+    dispatch_pp_apply_optimizer(NCCLCommunicator& comm, const optimizers::OptimizerConfig& opt_config, int step_idx);
     // Raw (summed) loss from the last forward — readable without ValidTokenCount,
     // which the dispatch backward leaves unset. Monotone with the mean loss, so it
     // tracks convergence.
@@ -197,15 +192,19 @@ public:
     // trainer sums these across microbatches and publishes the total via the setter below so
     // dispatch_pp_apply_optimizer (which runs on the master GPU, not the loss GPU) can scale
     // the grad norm per valid token instead of per total (padded) token.
-    [[nodiscard]] int dispatch_pp_loss_valid_tokens() const { return mDispatchPpLossValidTokens; }
-    void set_dispatch_pp_valid_tokens(int n) { mDispatchPpValidTokens = n; }
+    [[nodiscard]] int dispatch_pp_loss_valid_tokens() const {
+        return mDispatchPpLossValidTokens;
+    }
+    void set_dispatch_pp_valid_tokens(int n) {
+        mDispatchPpValidTokens = n;
+    }
     // Backward as two contiguous block sub-ranges (high range first, boundary
     // grad round-tripped through host); returns per-block grad norms.
     std::vector<float> dispatch_pp_grad_norms_subranges(Tensor inputs,
-                                                              Tensor targets,
-                                                              Tensor position_ids,
-                                                              NCCLCommunicator& comm,
-                                                              int split_after_block);
+                                                        Tensor targets,
+                                                        Tensor position_ids,
+                                                        NCCLCommunicator& comm,
+                                                        int split_after_block);
     void update(NCCLCommunicator& comm,
                 float learning_rate,
                 float beta_1,
@@ -424,6 +423,41 @@ public:
     /// (synchronous D2H read; zeroes the accumulator).
     float consume_kd_loss_sum();
 
+    /// Offline DPO micro-step: forward over a packed batch of (chosen, rejected)
+    /// sequences, compute the per-pair sigmoid-DPO gradient against precomputed
+    /// reference log-probs, and backward through the LM head. Reuses the GRPO
+    /// native scratch (the inference_logprobs buffer carries ref_logprobs).
+    ///
+    /// ref_logprobs_cpu: CPU FP32 [B*T] reference per-token logprob in the shifted
+    ///   layout (ref[out_idx] = logprob of logical token out_idx+1; masked = any).
+    /// sample_starts/ends_cpu: token ranges [start,end) of each packed sequence.
+    /// pair_chosen/pair_rejected_cpu: per pair, the chosen/rejected SAMPLE index.
+    void step_dpo_native(Tensor inputs,
+                         Tensor position_ids,
+                         Tensor targets,
+                         const float* ref_logprobs_cpu,
+                         const std::uint8_t* loss_mask_cpu,
+                         const std::int32_t* sample_starts_cpu,
+                         const std::int32_t* sample_ends_cpu,
+                         int sample_count,
+                         const std::int32_t* pair_chosen_cpu,
+                         const std::int32_t* pair_rejected_cpu,
+                         int pair_count,
+                         int grad_accum_steps,
+                         int micro_step,
+                         NCCLCommunicator& comm,
+                         const DpoNativeLossConfig& loss_config);
+    DpoNativeMetrics consume_dpo_native_metrics();
+
+    /// Per-token reference log-probs for DPO, via the SAME fused-loss forward
+    /// step_dpo_native uses (fp8- and multi-GPU-safe), with NO backward. Returns
+    /// logprob[i] = -loss[i] in the shifted layout (logprob of logical token i+1),
+    /// matching the ref_logprobs the dpo_dloss kernel expects. Call at init: LoRA B
+    /// is zero so the forward equals the start checkpoint = π_ref. Unlike
+    /// compute_logprobs (forward-only + full logits) this neither trips the GDN
+    /// forward-save path nor the fp8 full-logits lm-head GEMM.
+    std::vector<float> compute_ref_logprobs(Tensor inputs, Tensor position_ids, Tensor targets, NCCLCommunicator& comm);
+
     void init_weights(NCCLCommunicator& comm) override;
     void import_weights(const std::string& file_name, bool allow_cast, NCCLCommunicator& comm) override;
 
@@ -531,7 +565,7 @@ private:
     std::unique_ptr<modules::LoRAAdamW8BitState> mLoRAAdamW8BitState;
     std::unique_ptr<modules::LoRANorMuonState> mLoRANorMuonState;
     bool mIsMoEModel = false;
-    bool mUseTokenScale = true;               // apply 1/valid_token_count in global_norm_sqrt
+    bool mUseTokenScale = true;  // apply 1/valid_token_count in global_norm_sqrt
     // dispatch-PP: grads are collected complete onto this GPU by hand (not via DDP),
     // so the optimizer must skip the cross-GPU grad/norm all-reduce that would
     // deadlock waiting for the idle pool.

--- a/csrc/src/runtime/dsl/dsl_model_execution.cpp
+++ b/csrc/src/runtime/dsl/dsl_model_execution.cpp
@@ -430,8 +430,7 @@ void DslModel::allocate_run_state(const RuntimeOptions& options,
     }
     if (auto* exec = dynamic_cast<GraphExecutor*>(mExecutor.get())) {
         exec->ensure_graphs_compiled(B, T);
-        long needed =
-            required_stack_bytes(mRunState->buffer_plan(), exec->compiled_backward(), mModelConfig, mOptions);
+        long needed = required_stack_bytes(mRunState->buffer_plan(), exec->compiled_backward(), mModelConfig, mOptions);
         // dispatch-PP runs sub-range stages with skip_finalize, which keeps the boundary
         // saves (res_att/mlp_down) live on the stack on top of the normal backward peak --
         // the auto-sizer doesn't model that, so add headroom (env, MB). There is ample free
@@ -1157,9 +1156,7 @@ float DslModel::consume_kd_loss_sum() {
 
 // ---- Debug-only dispatch-PP sub-range parity (BF16 full-FT, resident) ------
 
-std::vector<float> DslModel::dispatch_pp_forward_hidden(Tensor inputs,
-                                                              Tensor position_ids,
-                                                              NCCLCommunicator& comm) {
+std::vector<float> DslModel::dispatch_pp_forward_hidden(Tensor inputs, Tensor position_ids, NCCLCommunicator& comm) {
     if (lora_enabled()) {
         throw std::runtime_error("dispatch_pp_forward_hidden: BF16 full-FT only (no LoRA)");
     }
@@ -1176,8 +1173,7 @@ std::vector<float> DslModel::dispatch_pp_forward_hidden(Tensor inputs,
     }
     // Run the whole forward eagerly but keep state resident (skip finalize) so the
     // final hidden state can be read before pruning, matching the sub-range path.
-    ge->set_forward_op_range(
-        0, fwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/true, /*force_linear=*/true);
+    ge->set_forward_op_range(0, fwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/true, /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
@@ -1189,9 +1185,9 @@ std::vector<float> DslModel::dispatch_pp_forward_hidden(Tensor inputs,
 }
 
 std::vector<float> DslModel::dispatch_pp_forward_subranges(Tensor inputs,
-                                                                Tensor position_ids,
-                                                                NCCLCommunicator& comm,
-                                                                int split_after_block) {
+                                                           Tensor position_ids,
+                                                           NCCLCommunicator& comm,
+                                                           int split_after_block) {
     if (lora_enabled()) {
         throw std::runtime_error("dispatch_pp_forward_subranges: BF16 full-FT only (no LoRA)");
     }
@@ -1239,13 +1235,12 @@ std::vector<float> DslModel::dispatch_pp_forward_subranges(Tensor inputs,
 }
 
 void DslModel::dispatch_pp_forward_stage(Tensor inputs,
-                                               Tensor position_ids,
-                                               NCCLCommunicator& comm,
-                                               int lo,
-                                               int hi,
-                                               std::vector<std::pair<std::string, std::vector<std::byte>>>
-                                                   inject_named,
-                                               bool preserve_output) {
+                                         Tensor position_ids,
+                                         NCCLCommunicator& comm,
+                                         int lo,
+                                         int hi,
+                                         std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
+                                         bool preserve_output) {
     GraphExecutor* ge = graph_executor();
     if (!ge) {
         throw std::runtime_error("dispatch_pp_forward_stage: requires the DSL GraphExecutor");
@@ -1267,8 +1262,8 @@ void DslModel::dispatch_pp_forward_stage(Tensor inputs,
     // Stage [0..] starts at the embedding; a resumed stage [lo>0..] starts at the
     // first op of block lo and consumes the injected boundary residual.
     const std::size_t op_lo = (lo == 0) ? 0 : fwd->layer_start_indices[static_cast<std::size_t>(lo)];
-    const std::size_t op_hi = (hi == num_layers - 1) ? fwd->ops.size()
-                                                     : fwd->layer_end_indices[static_cast<std::size_t>(hi)];
+    const std::size_t op_hi =
+        (hi == num_layers - 1) ? fwd->ops.size() : fwd->layer_end_indices[static_cast<std::size_t>(hi)];
 
     if (!inject_named.empty()) {
         ge->set_inject_named(std::move(inject_named));
@@ -1279,8 +1274,11 @@ void DslModel::dispatch_pp_forward_stage(Tensor inputs,
     }
     // skip_finalize keeps the stage's outputs (residual / final hidden) resident
     // for the caller's debug readers and the next stage's boundary read.
-    ge->set_forward_op_range(op_lo, op_hi, /*skip_init=*/false, /*skip_finalize=*/true,
-                                   /*force_linear=*/true);
+    ge->set_forward_op_range(op_lo,
+                             op_hi,
+                             /*skip_init=*/false,
+                             /*skip_finalize=*/true,
+                             /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
@@ -1290,18 +1288,17 @@ void DslModel::dispatch_pp_forward_stage(Tensor inputs,
     ge->clear_inject_named();
 }
 
-void DslModel::dispatch_pp_backward_stage(
-    Tensor inputs,
-    Tensor targets,
-    Tensor position_ids,
-    NCCLCommunicator& comm,
-    int lo,
-    int hi,
-    bool is_loss_stage,
-    std::vector<std::pair<std::string, std::vector<std::byte>>> fwd_inject,
-    std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
-    int micro_step,
-    int total_micro) {
+void DslModel::dispatch_pp_backward_stage(Tensor inputs,
+                                          Tensor targets,
+                                          Tensor position_ids,
+                                          NCCLCommunicator& comm,
+                                          int lo,
+                                          int hi,
+                                          bool is_loss_stage,
+                                          std::vector<std::pair<std::string, std::vector<std::byte>>> fwd_inject,
+                                          std::vector<std::pair<std::string, std::vector<std::byte>>> inject_named,
+                                          int micro_step,
+                                          int total_micro) {
     GraphExecutor* ge = graph_executor();
     if (!ge) {
         throw std::runtime_error("dispatch_pp_backward_stage: requires the DSL GraphExecutor");
@@ -1342,13 +1339,17 @@ void DslModel::dispatch_pp_backward_stage(
     const bool stage_bounded = (lo == 0) || !fwd_inject.empty();
     const std::size_t fwd_op_lo =
         (stage_bounded && lo > 0) ? fwd->layer_start_indices[static_cast<std::size_t>(lo)] : 0;
-    const std::size_t fwd_op_hi = (hi == num_layers - 1) ? fwd->ops.size()
-                                                         : fwd->layer_end_indices[static_cast<std::size_t>(hi)];
+    const std::size_t fwd_op_hi =
+        (hi == num_layers - 1) ? fwd->ops.size() : fwd->layer_end_indices[static_cast<std::size_t>(hi)];
     if (!fwd_inject.empty()) {
-        ge->set_inject_named(fwd_inject);  // copy: re-injected below so the backward recompute of block lo finds its input
+        ge->set_inject_named(
+            fwd_inject);  // copy: re-injected below so the backward recompute of block lo finds its input
     }
-    ge->set_forward_op_range(fwd_op_lo, fwd_op_hi, /*skip_init=*/false, /*skip_finalize=*/false,
-                                   /*force_linear=*/true);
+    ge->set_forward_op_range(fwd_op_lo,
+                             fwd_op_hi,
+                             /*skip_init=*/false,
+                             /*skip_finalize=*/false,
+                             /*force_linear=*/true);
     {
         auto fwd_request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
@@ -1364,8 +1365,11 @@ void DslModel::dispatch_pp_backward_stage(
         const std::size_t n = static_cast<std::size_t>(rs.B) * static_cast<std::size_t>(rs.T);
         if (rs.Losses.Data && rs.Losses.nelem() >= n && n > 0) {
             std::vector<float> h(n);
-            CUDA_CHECK(cudaMemcpyAsync(h.data(), rs.Losses.template get<float>(), n * sizeof(float),
-                                       cudaMemcpyDeviceToHost, rs.MainStream));
+            CUDA_CHECK(cudaMemcpyAsync(h.data(),
+                                       rs.Losses.template get<float>(),
+                                       n * sizeof(float),
+                                       cudaMemcpyDeviceToHost,
+                                       rs.MainStream));
             CUDA_CHECK(cudaStreamSynchronize(rs.MainStream));
             // Per-token CE is exactly 0 for masked/padding positions and strictly > 0 for
             // valid targets, so count(>0) is the local valid-token count. Normalize the loss
@@ -1386,7 +1390,8 @@ void DslModel::dispatch_pp_backward_stage(
     // Inject the incoming boundary gradients (d_blocks[hi].*) and re-inject the
     // forward input boundary (blocks[lo-1].*) so the backward's per-block recompute
     // of block lo can rebuild it from its true input.
-    for (auto& kv : fwd_inject) inject_named.push_back(std::move(kv));
+    for (auto& kv : fwd_inject)
+        inject_named.push_back(std::move(kv));
     if (!inject_named.empty()) {
         ge->set_inject_named(std::move(inject_named));
     }
@@ -1399,8 +1404,11 @@ void DslModel::dispatch_pp_backward_stage(
     // run in block L's stage with no inter-stage gap. The op-index range stays
     // full; skip_finalize keeps the stage's input-boundary gradients
     // (d_blocks[lo-1].*) resident for the next (lower) stage's read.
-    ge->set_backward_op_range(0, bwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/true,
-                                    /*force_linear=*/true);
+    ge->set_backward_op_range(0,
+                              bwd->ops.size(),
+                              /*skip_init=*/false,
+                              /*skip_finalize=*/true,
+                              /*force_linear=*/true);
     // The loss-owning stage runs the leading loss/lm-head ops; the lowest stage
     // (lo == 0) runs the trailing embedding-backward op so its gradient is computed.
     ge->set_backward_layer_range(lo, hi, /*include_loss=*/is_loss_stage, /*include_embed=*/lo == 0);
@@ -1418,10 +1426,8 @@ void DslModel::dispatch_pp_backward_stage(
     ge->set_skip_grad_reduce(false);
 }
 
-std::vector<float> DslModel::dispatch_pp_grad_norms_whole(Tensor inputs,
-                                                               Tensor targets,
-                                                               Tensor position_ids,
-                                                               NCCLCommunicator& comm) {
+std::vector<float>
+DslModel::dispatch_pp_grad_norms_whole(Tensor inputs, Tensor targets, Tensor position_ids, NCCLCommunicator& comm) {
     GraphExecutor* ge = graph_executor();
     if (!ge) {
         throw std::runtime_error("dispatch_pp_grad_norms_whole: requires the DSL GraphExecutor");
@@ -1439,16 +1445,22 @@ std::vector<float> DslModel::dispatch_pp_grad_norms_whole(Tensor inputs,
     // would deadlock here (only this GPU participates). Also skip the DDP grad
     // all-reduce for the same reason.
     ge->set_skip_grad_reduce(true);
-    ge->set_forward_op_range(0, fwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/false,
-                                   /*force_linear=*/true);
+    ge->set_forward_op_range(0,
+                             fwd->ops.size(),
+                             /*skip_init=*/false,
+                             /*skip_finalize=*/false,
+                             /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
         mExecutor->execute_forward(request, comm);
     }
     ge->clear_forward_op_range();
-    ge->set_backward_op_range(0, bwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/false,
-                                    /*force_linear=*/true);
+    ge->set_backward_op_range(0,
+                              bwd->ops.size(),
+                              /*skip_init=*/false,
+                              /*skip_finalize=*/false,
+                              /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_backward_request(*mRunState, mModelConfig, mOptions, inputs, targets, 1, 0);
@@ -1463,11 +1475,11 @@ std::vector<float> DslModel::dispatch_pp_grad_norms_whole(Tensor inputs,
 }
 
 float DslModel::dispatch_pp_train_step(Tensor inputs,
-                                             Tensor targets,
-                                             Tensor position_ids,
-                                             NCCLCommunicator& comm,
-                                             const optimizers::OptimizerConfig& opt_config,
-                                             int step_idx) {
+                                       Tensor targets,
+                                       Tensor position_ids,
+                                       NCCLCommunicator& comm,
+                                       const optimizers::OptimizerConfig& opt_config,
+                                       int step_idx) {
     if (lora_enabled()) {
         throw std::runtime_error("dispatch_pp_train_step: BF16 full-FT only (no LoRA)");
     }
@@ -1492,8 +1504,11 @@ float DslModel::dispatch_pp_train_step(Tensor inputs,
     // the per-token normalization the grads were produced with (else the scale and
     // the grads disagree and the update diverges).
     mUseTokenScale = true;
-    ge->set_forward_op_range(0, fwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/false,
-                                   /*force_linear=*/true);
+    ge->set_forward_op_range(0,
+                             fwd->ops.size(),
+                             /*skip_init=*/false,
+                             /*skip_finalize=*/false,
+                             /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
@@ -1501,8 +1516,11 @@ float DslModel::dispatch_pp_train_step(Tensor inputs,
     }
     ge->clear_forward_op_range();
 
-    ge->set_backward_op_range(0, bwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/false,
-                                    /*force_linear=*/true);
+    ge->set_backward_op_range(0,
+                              bwd->ops.size(),
+                              /*skip_init=*/false,
+                              /*skip_finalize=*/false,
+                              /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_backward_request(*mRunState, mModelConfig, mOptions, inputs, targets, 1, 0);
@@ -1553,8 +1571,10 @@ DslModel::dispatch_pp_read_block_grads(int lo, int hi, bool include_head, bool i
             int ord = 0;
             modules::for_each_lora_layer_weight(grads.block_full(L), [&](modules::LoRATargetId, auto& layer) {
                 const std::string base = "lora.g.L" + std::to_string(L) + "." + std::to_string(ord++);
-                if (layer.A.Data && layer.A.bytes()) out.emplace_back(base + ".A", dbg_tensor_bytes_to_host(layer.A, stream));
-                if (layer.B.Data && layer.B.bytes()) out.emplace_back(base + ".B", dbg_tensor_bytes_to_host(layer.B, stream));
+                if (layer.A.Data && layer.A.bytes())
+                    out.emplace_back(base + ".A", dbg_tensor_bytes_to_host(layer.A, stream));
+                if (layer.B.Data && layer.B.bytes())
+                    out.emplace_back(base + ".B", dbg_tensor_bytes_to_host(layer.B, stream));
             });
         }
         return out;
@@ -1564,7 +1584,8 @@ DslModel::dispatch_pp_read_block_grads(int lo, int hi, bool include_head, bool i
     for (const auto& name : mGrads->param_names()) {
         bool wanted = false;
         if (param_is_any_block(name)) {
-            for (int L = lo; L <= hi && !wanted; ++L) wanted = param_is_block(name, L);
+            for (int L = lo; L <= hi && !wanted; ++L)
+                wanted = param_is_block(name, L);
         } else if (name.find("embed") != std::string::npos) {
             wanted = include_embed;  // computed by the lowest stage's embedding backward
         } else {
@@ -1579,8 +1600,7 @@ DslModel::dispatch_pp_read_block_grads(int lo, int hi, bool include_head, bool i
     return out;
 }
 
-void DslModel::dispatch_pp_write_grads(
-    const std::vector<std::pair<std::string, std::vector<std::byte>>>& items) {
+void DslModel::dispatch_pp_write_grads(const std::vector<std::pair<std::string, std::vector<std::byte>>>& items) {
     if (lora_enabled()) {
         cudaStream_t stream = mRunState->MainStream;
         auto& grads = lora_grads();
@@ -1590,8 +1610,9 @@ void DslModel::dispatch_pp_write_grads(
             auto it = block_ptrs.find(L);
             if (it != block_ptrs.end()) return it->second;
             std::vector<std::pair<Tensor*, Tensor*>> v;
-            modules::for_each_lora_layer_weight(grads.block_full(L),
-                                                [&](modules::LoRATargetId, auto& layer) { v.emplace_back(&layer.A, &layer.B); });
+            modules::for_each_lora_layer_weight(grads.block_full(L), [&](modules::LoRATargetId, auto& layer) {
+                v.emplace_back(&layer.A, &layer.B);
+            });
             return block_ptrs.emplace(L, std::move(v)).first->second;
         };
         for (const auto& [name, bytes] : items) {
@@ -1641,8 +1662,10 @@ std::vector<std::pair<std::string, std::vector<std::byte>>> DslModel::dispatch_p
             int ord = 0;
             modules::for_each_lora_layer_weight(w.get_master_block(L, stream), [&](modules::LoRATargetId, auto& layer) {
                 const std::string base = "lora.w.L" + std::to_string(L) + "." + std::to_string(ord++);
-                if (layer.A.Data && layer.A.bytes()) out.emplace_back(base + ".A", dbg_tensor_bytes_to_host(layer.A, stream));
-                if (layer.B.Data && layer.B.bytes()) out.emplace_back(base + ".B", dbg_tensor_bytes_to_host(layer.B, stream));
+                if (layer.A.Data && layer.A.bytes())
+                    out.emplace_back(base + ".A", dbg_tensor_bytes_to_host(layer.A, stream));
+                if (layer.B.Data && layer.B.bytes())
+                    out.emplace_back(base + ".B", dbg_tensor_bytes_to_host(layer.B, stream));
             });
         }
         return out;
@@ -1657,8 +1680,7 @@ std::vector<std::pair<std::string, std::vector<std::byte>>> DslModel::dispatch_p
     return out;
 }
 
-void DslModel::dispatch_pp_write_weights(
-    const std::vector<std::pair<std::string, std::vector<std::byte>>>& items) {
+void DslModel::dispatch_pp_write_weights(const std::vector<std::pair<std::string, std::vector<std::byte>>>& items) {
     if (lora_enabled()) {
         cudaStream_t stream = mRunState->MainStream;
         auto& w = lora_weights();
@@ -1667,8 +1689,9 @@ void DslModel::dispatch_pp_write_weights(
             auto it = block_ptrs.find(L);
             if (it != block_ptrs.end()) return it->second;
             std::vector<std::pair<Tensor*, Tensor*>> v;
-            modules::for_each_lora_layer_weight(w.get_master_block(L, stream),
-                                                [&](modules::LoRATargetId, auto& layer) { v.emplace_back(&layer.A, &layer.B); });
+            modules::for_each_lora_layer_weight(w.get_master_block(L, stream), [&](modules::LoRATargetId, auto& layer) {
+                v.emplace_back(&layer.A, &layer.B);
+            });
             return block_ptrs.emplace(L, std::move(v)).first->second;
         };
         for (const auto& [name, bytes] : items) {
@@ -1715,8 +1738,8 @@ float DslModel::dispatch_pp_raw_loss() const {
 }
 
 float DslModel::dispatch_pp_apply_optimizer(NCCLCommunicator& comm,
-                                                  const optimizers::OptimizerConfig& opt_config,
-                                                  int step_idx) {
+                                            const optimizers::OptimizerConfig& opt_config,
+                                            int step_idx) {
     // The dispatch backward skips the DP loss all-reduce (would deadlock), but the loss
     // stage counted valid (non-pad) tokens locally over the step's microbatches. Publish
     // that into ValidTokenCount and use per-valid-token normalization so the grad norm (and
@@ -1741,10 +1764,10 @@ float DslModel::dispatch_pp_apply_optimizer(NCCLCommunicator& comm,
 }
 
 std::vector<float> DslModel::dispatch_pp_grad_norms_subranges(Tensor inputs,
-                                                                   Tensor targets,
-                                                                   Tensor position_ids,
-                                                                   NCCLCommunicator& comm,
-                                                                   int split_after_block) {
+                                                              Tensor targets,
+                                                              Tensor position_ids,
+                                                              NCCLCommunicator& comm,
+                                                              int split_after_block) {
     if (lora_enabled()) {
         throw std::runtime_error("dispatch_pp_grad_norms_subranges: BF16 full-FT only (no LoRA)");
     }
@@ -1766,8 +1789,11 @@ std::vector<float> DslModel::dispatch_pp_grad_norms_subranges(Tensor inputs,
     // Whole-graph forward (forced-eager: the stream-driven path issues per-rank
     // collectives that deadlock on a single GPU) saves the activations the backward
     // consumes.
-    ge->set_forward_op_range(0, fwd->ops.size(), /*skip_init=*/false, /*skip_finalize=*/false,
-                                   /*force_linear=*/true);
+    ge->set_forward_op_range(0,
+                             fwd->ops.size(),
+                             /*skip_init=*/false,
+                             /*skip_finalize=*/false,
+                             /*force_linear=*/true);
     {
         auto request =
             causal_lm_profile().make_forward_request(*mRunState, mModelConfig, mOptions, inputs, position_ids, 0);
@@ -1804,6 +1830,258 @@ std::vector<float> DslModel::dispatch_pp_grad_norms_subranges(Tensor inputs,
     ge->set_skip_grad_reduce(false);
 
     return ge->block_grad_norms();
+}
+void DslModel::step_dpo_native(Tensor inputs,
+                               Tensor position_ids,
+                               Tensor targets,
+                               const float* ref_logprobs_cpu,
+                               const std::uint8_t* loss_mask_cpu,
+                               const std::int32_t* sample_starts_cpu,
+                               const std::int32_t* sample_ends_cpu,
+                               int sample_count,
+                               const std::int32_t* pair_chosen_cpu,
+                               const std::int32_t* pair_rejected_cpu,
+                               int pair_count,
+                               int grad_accum_steps,
+                               int micro_step,
+                               NCCLCommunicator& comm,
+                               const DpoNativeLossConfig& loss_config) {
+    if (!mExecutor) {
+        throw std::logic_error("DslModel::step_dpo_native called before allocate_run_state()");
+    }
+    if (!ref_logprobs_cpu || !loss_mask_cpu || !sample_starts_cpu || !sample_ends_cpu) {
+        throw std::invalid_argument("step_dpo_native requires ref_logprobs, loss_mask, sample ranges");
+    }
+    // pair_count == 0 is a valid degenerate micro-batch (an all-padding row in a
+    // sharded layout): the dloss buffer is zeroed and forward/backward still run
+    // so NCCL collectives stay matched across ranks.
+    if (sample_count < 0 || pair_count < 0) {
+        throw std::invalid_argument("step_dpo_native requires non-negative sample and pair counts");
+    }
+    if (pair_count > 0 && (!pair_chosen_cpu || !pair_rejected_cpu)) {
+        throw std::invalid_argument("step_dpo_native requires pair indices when pair_count > 0");
+    }
+    if (!(loss_config.loss_scale > 0.0f) || !std::isfinite(loss_config.loss_scale)) {
+        throw std::invalid_argument("step_dpo_native loss_scale must be finite and positive");
+    }
+    // Disable the optimizer's implicit divide-by-ValidTokenCount, matching the
+    // GRPO native path: DPO normalizes explicitly via loss_scale.
+    mUseTokenScale = false;
+
+    auto& rs = *mRunState;
+    auto& scratch = rs.grpo_native_scratch();
+    cudaStream_t main_stream = rs.MainStream;
+    const int B_val = static_cast<int>(inputs.Sizes[0]);
+    const int T_val = static_cast<int>(inputs.Sizes[1]);
+    const std::size_t bt = static_cast<std::size_t>(B_val) * static_cast<std::size_t>(T_val);
+    if (bt > static_cast<std::size_t>(scratch.max_tokens) ||
+        static_cast<std::size_t>(sample_count) > static_cast<std::size_t>(scratch.max_samples) ||
+        static_cast<std::size_t>(pair_count) > static_cast<std::size_t>(scratch.max_samples)) {
+        throw std::runtime_error("step_dpo_native inputs exceed allocated GRPO scratch capacity");
+    }
+    // Reset the (shared) metric accumulators once per optimizer step; the kernel
+    // atomicAdds across micro-steps. DPO uses the first 4 slots of the buffer.
+    if (micro_step == 0) {
+        CUDA_CHECK(cudaMemsetAsync(scratch.metrics.Data, 0, 4 * sizeof(float), main_stream));
+    }
+
+    const int staging_slot = scratch.next_host_slot;
+    scratch.next_host_slot = (scratch.next_host_slot + 1) % modules::GrpoNativeScratch::kHostStagingSlots;
+    if (scratch.host_copy_recorded[staging_slot]) {
+        CUDA_CHECK(cudaEventSynchronize(scratch.host_copy_done[staging_slot]));
+    }
+
+    // Reference per-token logprobs ride the GRPO inference_logprobs buffer.
+    std::memcpy(scratch.host_inference_logprobs[staging_slot].get<float>(), ref_logprobs_cpu, bt * sizeof(float));
+    CUDA_CHECK(cudaMemcpyAsync(scratch.inference_logprobs.Data,
+                               scratch.host_inference_logprobs[staging_slot].Data,
+                               bt * sizeof(float),
+                               cudaMemcpyHostToDevice,
+                               main_stream));
+    std::memcpy(scratch.host_loss_mask[staging_slot].get<std::uint8_t>(), loss_mask_cpu, bt * sizeof(std::uint8_t));
+    CUDA_CHECK(cudaMemcpyAsync(scratch.loss_mask.Data,
+                               scratch.host_loss_mask[staging_slot].Data,
+                               bt * sizeof(std::uint8_t),
+                               cudaMemcpyHostToDevice,
+                               main_stream));
+    if (sample_count > 0) {
+        std::memcpy(scratch.host_sample_starts[staging_slot].get<std::int32_t>(),
+                    sample_starts_cpu,
+                    static_cast<std::size_t>(sample_count) * sizeof(std::int32_t));
+        std::memcpy(scratch.host_sample_ends[staging_slot].get<std::int32_t>(),
+                    sample_ends_cpu,
+                    static_cast<std::size_t>(sample_count) * sizeof(std::int32_t));
+        CUDA_CHECK(cudaMemcpyAsync(scratch.sample_starts.Data,
+                                   scratch.host_sample_starts[staging_slot].Data,
+                                   static_cast<std::size_t>(sample_count) * sizeof(std::int32_t),
+                                   cudaMemcpyHostToDevice,
+                                   main_stream));
+        CUDA_CHECK(cudaMemcpyAsync(scratch.sample_ends.Data,
+                                   scratch.host_sample_ends[staging_slot].Data,
+                                   static_cast<std::size_t>(sample_count) * sizeof(std::int32_t),
+                                   cudaMemcpyHostToDevice,
+                                   main_stream));
+    }
+    if (pair_count > 0) {
+        std::memcpy(scratch.host_pair_chosen[staging_slot].get<std::int32_t>(),
+                    pair_chosen_cpu,
+                    static_cast<std::size_t>(pair_count) * sizeof(std::int32_t));
+        std::memcpy(scratch.host_pair_rejected[staging_slot].get<std::int32_t>(),
+                    pair_rejected_cpu,
+                    static_cast<std::size_t>(pair_count) * sizeof(std::int32_t));
+        CUDA_CHECK(cudaMemcpyAsync(scratch.pair_chosen.Data,
+                                   scratch.host_pair_chosen[staging_slot].Data,
+                                   static_cast<std::size_t>(pair_count) * sizeof(std::int32_t),
+                                   cudaMemcpyHostToDevice,
+                                   main_stream));
+        CUDA_CHECK(cudaMemcpyAsync(scratch.pair_rejected.Data,
+                                   scratch.host_pair_rejected[staging_slot].Data,
+                                   static_cast<std::size_t>(pair_count) * sizeof(std::int32_t),
+                                   cudaMemcpyHostToDevice,
+                                   main_stream));
+    }
+    CUDA_CHECK(cudaEventRecord(scratch.host_copy_done[staging_slot], main_stream));
+    scratch.host_copy_recorded[staging_slot] = true;
+
+    const bool doc_masking_active =
+        causal_lm_profile().apply_doc_masking(*mExecutor, mOptions, mModelConfig, inputs, position_ids, micro_step);
+
+    if (lora_enabled()) {
+        ensure_lora_run_state(comm, B_val, T_val);
+        if (qlora_enabled() && micro_step == 0 && mQLoRAProvider) {
+            mQLoRAProvider->invalidate_cache();
+        }
+        mLoRARunState->micro_step = micro_step;
+        mLoRARunState->is_training = true;
+    }
+
+    auto forward_request =
+        causal_lm_profile().make_eval_request(rs, mModelConfig, mOptions, inputs, position_ids, targets, micro_step);
+    forward_request.mode = ExecutionMode::Forward;
+    forward_request.reduce_loss_on_completion = false;
+    mExecutor->execute_forward(forward_request, comm);
+
+    compute_dpo_custom_dloss(scratch.custom_dloss.get<float>(),
+                             scratch.metrics.get<float>(),
+                             rs.Losses.get<float>(),
+                             scratch.inference_logprobs.get<float>(),
+                             scratch.loss_mask.get<std::uint8_t>(),
+                             scratch.sample_starts.get<std::int32_t>(),
+                             scratch.sample_ends.get<std::int32_t>(),
+                             scratch.pair_chosen.get<std::int32_t>(),
+                             scratch.pair_rejected.get<std::int32_t>(),
+                             pair_count,
+                             static_cast<int>(bt),
+                             loss_config.loss_scale,
+                             loss_config.beta,
+                             loss_config.length_norm ? 1 : 0,
+                             main_stream);
+
+    if (!lora_enabled()) {
+        auto backward_request =
+            causal_lm_profile()
+                .make_backward_request(rs, mModelConfig, mOptions, inputs, targets, grad_accum_steps, micro_step);
+        backward_request.custom_dloss_gpu = scratch.custom_dloss.get<float>();
+        mExecutor->execute_backward(backward_request, comm);
+        if (doc_masking_active) mExecutor->clear_doc_masking();
+        return;
+    }
+
+    mLoRAGrads->start_micro_step(main_stream, micro_step, grad_accum_steps);
+    auto backward_request =
+        causal_lm_profile()
+            .make_backward_request(rs, mModelConfig, mOptions, inputs, targets, grad_accum_steps, micro_step);
+    backward_request.custom_dloss_gpu = scratch.custom_dloss.get<float>();
+    mExecutor->execute_backward(backward_request, comm);
+    if (doc_masking_active) mExecutor->clear_doc_masking();
+    mLoRAGrads->end_micro_step(main_stream, comm);
+    internal::record_event_if_not_capturing(rs.BackwardDone, main_stream);
+}
+
+DpoNativeMetrics DslModel::consume_dpo_native_metrics() {
+    if (!mRunState) {
+        throw std::logic_error("DslModel::consume_dpo_native_metrics called before allocate_run_state()");
+    }
+    auto& rs = *mRunState;
+    auto& scratch = rs.grpo_native_scratch();
+    CUDA_CHECK(cudaMemcpyAsync(scratch.host_metrics.Data,
+                               scratch.metrics.Data,
+                               4 * sizeof(float),
+                               cudaMemcpyDeviceToHost,
+                               rs.MainStream));
+    CUDA_CHECK(cudaStreamSynchronize(rs.MainStream));
+
+    const auto* values = scratch.host_metrics.get<float>();
+    const float pair_count = values[3];
+    const float denom = std::max(pair_count, 1.0f);
+    DpoNativeMetrics metrics;
+    metrics.loss = values[0] / denom;
+    metrics.accuracy = values[1] / denom;
+    metrics.margin = values[2] / denom;
+    metrics.pair_count = pair_count;
+    return metrics;
+}
+
+std::vector<float>
+DslModel::compute_ref_logprobs(Tensor inputs, Tensor position_ids, Tensor targets, NCCLCommunicator& comm) {
+    if (!mExecutor) {
+        throw std::logic_error("DslModel::compute_ref_logprobs called before allocate_run_state()");
+    }
+    auto& rs = *mRunState;
+    const int B_val = static_cast<int>(inputs.Sizes[0]);
+    const int T_val = static_cast<int>(inputs.Sizes[1]);
+    const std::size_t bt = static_cast<std::size_t>(B_val) * static_cast<std::size_t>(T_val);
+
+    const bool doc_masking_active =
+        causal_lm_profile().apply_doc_masking(*mExecutor, mOptions, mModelConfig, inputs, position_ids, 0);
+
+    // BASE-ONLY reference: the DPO reference is the FROZEN start checkpoint, so the LoRA
+    // adapter must NOT be applied here — this runs inline per training step, AFTER the
+    // policy adapter has diverged (nonzero). (Previously this ran the LoRA-on training
+    // forward and only equalled the reference at init where the delta is zero; called
+    // mid-training it returned the live policy, making the DPO margin identically 0.)
+    // Disable LoRA for this one forward by nulling the executor's run_state
+    // (apply_lora_slices_forward early-returns on a null run_state). fp8 activation scaling
+    // lives in DslRunState, not the LoRA state, so this still shares the policy forward's
+    // per-batch scale: margin == 0 at init (identical base activations) and an exact frozen
+    // reference once the policy diverges. Restore the live state afterwards.
+    if (lora_enabled()) {
+        mExecutor->set_lora_state(mLoRAConfig ? &*mLoRAConfig : nullptr,
+                                  mLoRAWeights.get(),
+                                  mLoRAGrads.get(),
+                                  /*run_state=*/nullptr);
+    }
+
+    auto forward_request =
+        causal_lm_profile().make_eval_request(rs, mModelConfig, mOptions, inputs, position_ids, targets, 0);
+    forward_request.mode = ExecutionMode::Forward;
+    forward_request.reduce_loss_on_completion = false;
+    mExecutor->execute_forward(forward_request, comm);
+
+    if (lora_enabled()) {
+        ensure_lora_run_state(comm, B_val, T_val);
+        mExecutor->set_lora_state(mLoRAConfig ? &*mLoRAConfig : nullptr,
+                                  mLoRAWeights.get(),
+                                  mLoRAGrads.get(),
+                                  mLoRARunState.get());
+    }
+
+    if (doc_masking_active) {
+        mExecutor->clear_doc_masking();
+    }
+
+    // rs.Losses holds per-token CE = -logprob(target). Return logprob = -CE.
+    std::vector<float> logprobs(bt, 0.0f);
+    CUDA_CHECK(cudaMemcpyAsync(logprobs.data(),
+                               rs.Losses.get<float>(),
+                               bt * sizeof(float),
+                               cudaMemcpyDeviceToHost,
+                               rs.MainStream));
+    CUDA_CHECK(cudaStreamSynchronize(rs.MainStream));
+    for (auto& v : logprobs) {
+        v = -v;
+    }
+    return logprobs;
 }
 
 }  // namespace dsl

--- a/csrc/src/runtime/dsl/dsl_run_state.cpp
+++ b/csrc/src/runtime/dsl/dsl_run_state.cpp
@@ -1077,6 +1077,10 @@ void DslRunState::allocate_scratch_buffers(const PretrainedConfig& cfg) {
         mAllocator->allocate(ETensorDType::INT32, "grpo_sample_starts", EAllocationType::ON_DEVICE, {BT});
     mGrpoNativeScratch.sample_ends =
         mAllocator->allocate(ETensorDType::INT32, "grpo_sample_ends", EAllocationType::ON_DEVICE, {BT});
+    mGrpoNativeScratch.pair_chosen =
+        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_chosen", EAllocationType::ON_DEVICE, {BT});
+    mGrpoNativeScratch.pair_rejected =
+        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_rejected", EAllocationType::ON_DEVICE, {BT});
     mGrpoNativeScratch.custom_dloss =
         mAllocator->allocate(ETensorDType::FP32, "grpo_custom_dloss", EAllocationType::ON_DEVICE, {BT});
     mGrpoNativeScratch.inv_temperature =
@@ -1118,6 +1122,15 @@ void DslRunState::allocate_scratch_buffers(const PretrainedConfig& cfg) {
                                                                          ("grpo_host_sample_ends_" + suffix).c_str(),
                                                                          EAllocationType::PINNED,
                                                                          {BT});
+        mGrpoNativeScratch.host_pair_chosen[slot] = mAllocator->allocate(ETensorDType::INT32,
+                                                                         ("grpo_host_pair_chosen_" + suffix).c_str(),
+                                                                         EAllocationType::PINNED,
+                                                                         {BT});
+        mGrpoNativeScratch.host_pair_rejected[slot] =
+            mAllocator->allocate(ETensorDType::INT32,
+                                 ("grpo_host_pair_rejected_" + suffix).c_str(),
+                                 EAllocationType::PINNED,
+                                 {BT});
     }
 
     // Encoder backward scratch buffers - skip in LoRA-only mode since embedding backward is skipped entirely

--- a/csrc/src/testing/kernels/test-dpo-dloss.cu
+++ b/csrc/src/testing/kernels/test-dpo-dloss.cu
@@ -137,6 +137,7 @@ void run_case(const DpoCfg& cfg) {
     float* d_metrics = nullptr;
     REQUIRE(cudaMalloc(&d_dloss, BT * sizeof(float)) == cudaSuccess);
     REQUIRE(cudaMalloc(&d_metrics, 4 * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMemset(d_metrics, 0, 4 * sizeof(float)) == cudaSuccess);
 
     compute_dpo_custom_dloss(d_dloss,
                              d_metrics,
@@ -224,6 +225,7 @@ TEST_CASE("dpo dloss step-0 identity gives loss log2 and +/- beta/2", "[dpo][ker
     float* d_metrics = nullptr;
     REQUIRE(cudaMalloc(&d_dloss, BT * sizeof(float)) == cudaSuccess);
     REQUIRE(cudaMalloc(&d_metrics, 4 * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMemset(d_metrics, 0, 4 * sizeof(float)) == cudaSuccess);
 
     compute_dpo_custom_dloss(d_dloss,
                              d_metrics,

--- a/csrc/src/testing/kernels/test-dpo-dloss.cu
+++ b/csrc/src/testing/kernels/test-dpo-dloss.cu
@@ -1,0 +1,263 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity tests for the native DPO custom-dloss CUDA kernel against a scalar CPU
+// reference implementing the sigmoid-DPO per-pair formula. The reference and the
+// kernel share the shifted target-slot convention of the GRPO path:
+// trainer_logprob(out_idx) = -losses[out_idx] carries logical token out_idx + 1,
+// and custom_dloss[out_idx] is the gradient seed for that logical token.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "kernels/kernels.h"
+
+namespace {
+
+struct DpoCfg {
+    float beta = 0.1f;
+    int length_norm = 0;
+    float loss_scale = 1.0f;
+};
+
+// Sum the response-token policy/reference log-probs of one sample [start, end).
+// Response token t (loss_mask[t] != 0) is seeded at out_idx = t - 1.
+void seq_sums(const std::vector<float>& losses,
+              const std::vector<float>& ref,
+              const std::vector<std::uint8_t>& mask,
+              int start,
+              int end,
+              double& s_pol,
+              double& s_ref,
+              int& len) {
+    s_pol = 0.0;
+    s_ref = 0.0;
+    len = 0;
+    for (int t = start + 1; t < end; ++t) {
+        if (mask[t] == 0) {
+            continue;
+        }
+        const int out_idx = t - 1;
+        s_pol += -static_cast<double>(losses[out_idx]);
+        s_ref += static_cast<double>(ref[out_idx]);
+        ++len;
+    }
+}
+
+// metrics_out = {loss, correct, margin, pair_count} for a single pair, matching
+// the kernel's per-pair accumulation into metrics[4].
+void reference_dpo(const std::vector<float>& losses,
+                   const std::vector<float>& ref,
+                   const std::vector<std::uint8_t>& mask,
+                   const std::vector<std::int32_t>& starts,
+                   const std::vector<std::int32_t>& ends,
+                   int chosen,
+                   int rejected,
+                   const DpoCfg& cfg,
+                   std::vector<float>& dloss_out,
+                   std::vector<float>& metrics_out) {
+    dloss_out.assign(losses.size(), 0.0f);
+    double sc_pol, sc_ref, sr_pol, sr_ref;
+    int len_c, len_r;
+    seq_sums(losses, ref, mask, starts[chosen], ends[chosen], sc_pol, sc_ref, len_c);
+    seq_sums(losses, ref, mask, starts[rejected], ends[rejected], sr_pol, sr_ref, len_r);
+    const double wc = (cfg.length_norm && len_c > 0) ? 1.0 / static_cast<double>(len_c) : 1.0;
+    const double wr = (cfg.length_norm && len_r > 0) ? 1.0 / static_cast<double>(len_r) : 1.0;
+    const double margin = static_cast<double>(cfg.beta) * ((sc_pol - sc_ref) * wc - (sr_pol - sr_ref) * wr);
+    const double g = static_cast<double>(cfg.beta) * (1.0 / (1.0 + std::exp(margin)));  // beta * sigmoid(-margin)
+    const double inv_scale = (cfg.loss_scale == 0.0f) ? 1.0 : 1.0 / static_cast<double>(cfg.loss_scale);
+    for (int t = starts[chosen] + 1; t < ends[chosen]; ++t) {
+        if (mask[t] != 0) {
+            dloss_out[t - 1] = static_cast<float>((g * wc) * inv_scale);
+        }
+    }
+    for (int t = starts[rejected] + 1; t < ends[rejected]; ++t) {
+        if (mask[t] != 0) {
+            dloss_out[t - 1] = static_cast<float>((-g * wr) * inv_scale);
+        }
+    }
+    const double loss = -std::log(1.0 / (1.0 + std::exp(-margin)));  // -log sigmoid(margin)
+    metrics_out = {static_cast<float>(loss), margin > 0.0 ? 1.0f : 0.0f, static_cast<float>(margin), 1.0f};
+}
+
+template <class T>
+T* to_device(const std::vector<T>& v) {
+    T* d = nullptr;
+    REQUIRE(cudaMalloc(&d, v.size() * sizeof(T)) == cudaSuccess);
+    REQUIRE(cudaMemcpy(d, v.data(), v.size() * sizeof(T), cudaMemcpyHostToDevice) == cudaSuccess);
+    return d;
+}
+
+void require_close(const std::vector<float>& actual, const std::vector<float>& expected) {
+    REQUIRE(actual.size() == expected.size());
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        INFO("index " << i);
+        REQUIRE(actual[i] == Catch::Approx(expected[i]).epsilon(1e-5).margin(1e-6));
+    }
+}
+
+bool gpu_available() {
+    int count = 0;
+    return cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+// Two samples packed back-to-back: sample 0 = chosen [0, 5), sample 1 = rejected [5, 9), BT = 9.
+struct Fixture {
+    std::vector<float> losses = {0.1f, 0.5f, 0.3f, 0.2f, 0.4f, 0.6f, 0.7f, 0.2f, 0.9f};
+    std::vector<float> ref = {-0.2f, -0.4f, -0.6f, -0.3f, -0.5f, -0.7f, -0.1f, -0.8f, -0.3f};
+    std::vector<std::uint8_t> mask = {0, 1, 1, 1, 0, 0, 1, 1, 0};
+    std::vector<std::int32_t> starts = {0, 5};
+    std::vector<std::int32_t> ends = {5, 9};
+    std::vector<std::int32_t> pair_chosen = {0};
+    std::vector<std::int32_t> pair_rejected = {1};
+};
+
+void run_case(const DpoCfg& cfg) {
+    Fixture fx;
+    const int BT = static_cast<int>(fx.losses.size());
+    const int pair_count = static_cast<int>(fx.pair_chosen.size());
+
+    std::vector<float> ref_dloss, ref_metrics;
+    reference_dpo(fx.losses, fx.ref, fx.mask, fx.starts, fx.ends, 0, 1, cfg, ref_dloss, ref_metrics);
+
+    float* d_losses = to_device(fx.losses);
+    float* d_ref = to_device(fx.ref);
+    std::uint8_t* d_mask = to_device(fx.mask);
+    std::int32_t* d_starts = to_device(fx.starts);
+    std::int32_t* d_ends = to_device(fx.ends);
+    std::int32_t* d_pc = to_device(fx.pair_chosen);
+    std::int32_t* d_pr = to_device(fx.pair_rejected);
+    float* d_dloss = nullptr;
+    float* d_metrics = nullptr;
+    REQUIRE(cudaMalloc(&d_dloss, BT * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_metrics, 4 * sizeof(float)) == cudaSuccess);
+
+    compute_dpo_custom_dloss(d_dloss,
+                             d_metrics,
+                             d_losses,
+                             d_ref,
+                             d_mask,
+                             d_starts,
+                             d_ends,
+                             d_pc,
+                             d_pr,
+                             pair_count,
+                             BT,
+                             cfg.loss_scale,
+                             cfg.beta,
+                             cfg.length_norm,
+                             nullptr);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    std::vector<float> got_dloss(BT, 0.0f);
+    std::vector<float> got_metrics(4, 0.0f);
+    REQUIRE(cudaMemcpy(got_dloss.data(), d_dloss, BT * sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(cudaMemcpy(got_metrics.data(), d_metrics, 4 * sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+
+    require_close(got_dloss, ref_dloss);
+    require_close(got_metrics, ref_metrics);
+
+    for (void* p : {static_cast<void*>(d_losses),
+                    static_cast<void*>(d_ref),
+                    static_cast<void*>(d_mask),
+                    static_cast<void*>(d_starts),
+                    static_cast<void*>(d_ends),
+                    static_cast<void*>(d_pc),
+                    static_cast<void*>(d_pr),
+                    static_cast<void*>(d_dloss),
+                    static_cast<void*>(d_metrics)}) {
+        if (p) cudaFree(p);
+    }
+}
+
+}  // namespace
+
+TEST_CASE("dpo dloss kernel matches reference (no length norm)", "[dpo][kernels]") {
+    if (!gpu_available()) SKIP("no CUDA device available");
+    run_case(DpoCfg{0.1f, 0, 1.0f});
+}
+
+TEST_CASE("dpo dloss kernel matches reference (length norm)", "[dpo][kernels]") {
+    if (!gpu_available()) SKIP("no CUDA device available");
+    run_case(DpoCfg{0.1f, 1, 1.0f});
+}
+
+TEST_CASE("dpo dloss kernel matches reference (loss scale)", "[dpo][kernels]") {
+    if (!gpu_available()) SKIP("no CUDA device available");
+    run_case(DpoCfg{0.25f, 0, 4.0f});
+}
+
+TEST_CASE("dpo dloss step-0 identity gives loss log2 and +/- beta/2", "[dpo][kernels]") {
+    if (!gpu_available()) SKIP("no CUDA device available");
+    // pi_theta == pi_ref => margin 0 => loss log 2, g = beta/2.
+    Fixture fx;
+    for (std::size_t i = 0; i < fx.losses.size(); ++i) {
+        fx.ref[i] = -fx.losses[i];
+    }
+    const DpoCfg cfg{0.1f, 0, 1.0f};
+    const int BT = static_cast<int>(fx.losses.size());
+
+    std::vector<float> ref_dloss, ref_metrics;
+    reference_dpo(fx.losses, fx.ref, fx.mask, fx.starts, fx.ends, 0, 1, cfg, ref_dloss, ref_metrics);
+    REQUIRE(ref_metrics[0] == Catch::Approx(std::log(2.0)).epsilon(1e-5));
+    for (int t = fx.starts[0] + 1; t < fx.ends[0]; ++t) {
+        if (fx.mask[t]) REQUIRE(ref_dloss[t - 1] == Catch::Approx(+0.05f).epsilon(1e-5));
+    }
+    for (int t = fx.starts[1] + 1; t < fx.ends[1]; ++t) {
+        if (fx.mask[t]) REQUIRE(ref_dloss[t - 1] == Catch::Approx(-0.05f).epsilon(1e-5));
+    }
+
+    float* d_losses = to_device(fx.losses);
+    float* d_ref = to_device(fx.ref);
+    std::uint8_t* d_mask = to_device(fx.mask);
+    std::int32_t* d_starts = to_device(fx.starts);
+    std::int32_t* d_ends = to_device(fx.ends);
+    std::int32_t* d_pc = to_device(fx.pair_chosen);
+    std::int32_t* d_pr = to_device(fx.pair_rejected);
+    float* d_dloss = nullptr;
+    float* d_metrics = nullptr;
+    REQUIRE(cudaMalloc(&d_dloss, BT * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&d_metrics, 4 * sizeof(float)) == cudaSuccess);
+
+    compute_dpo_custom_dloss(d_dloss,
+                             d_metrics,
+                             d_losses,
+                             d_ref,
+                             d_mask,
+                             d_starts,
+                             d_ends,
+                             d_pc,
+                             d_pr,
+                             1,
+                             BT,
+                             cfg.loss_scale,
+                             cfg.beta,
+                             cfg.length_norm,
+                             nullptr);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    std::vector<float> got_dloss(BT, 0.0f);
+    std::vector<float> got_metrics(4, 0.0f);
+    REQUIRE(cudaMemcpy(got_dloss.data(), d_dloss, BT * sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(cudaMemcpy(got_metrics.data(), d_metrics, 4 * sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+    require_close(got_dloss, ref_dloss);
+    REQUIRE(got_metrics[0] == Catch::Approx(std::log(2.0)).epsilon(1e-5));
+
+    for (void* p : {static_cast<void*>(d_losses),
+                    static_cast<void*>(d_ref),
+                    static_cast<void*>(d_mask),
+                    static_cast<void*>(d_starts),
+                    static_cast<void*>(d_ends),
+                    static_cast<void*>(d_pc),
+                    static_cast<void*>(d_pr),
+                    static_cast<void*>(d_dloss),
+                    static_cast<void*>(d_metrics)}) {
+        if (p) cudaFree(p);
+    }
+}

--- a/csrc/src/testing/tokenizer/test-chat-template.cpp
+++ b/csrc/src/testing/tokenizer/test-chat-template.cpp
@@ -117,3 +117,65 @@ TEST_CASE("apply_chat_template honors enable_thinking generation prompt", "[toke
     REQUIRE(count_substr(thinking, "</think>") == 0);
     REQUIRE(count_substr(no_think, "</think>") == 1);
 }
+
+TEST_CASE("thinking-only loss masks final answers and direct turns", "[tokenizer][chat-template]") {
+    const char* model_dir = std::getenv("SUROGATE_TEST_MODEL");
+    if (!model_dir) {
+        SUCCEED("SUROGATE_TEST_MODEL not set; skipping chat-template regression test");
+        return;
+    }
+    Tokenizer tok = Tokenizer::from_pretrained(model_dir);
+
+    SECTION("thinking turn trains reasoning and close marker only") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "<think>\nAdun doi si doi.\n</think>\n\nPatru."},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::THINKING_ONLY);
+        std::string trained = decode_trained(tok, enc);
+
+        REQUIRE(trained.find("Adun doi si doi.") != std::string::npos);
+        REQUIRE(trained.find("</think>") != std::string::npos);
+        REQUIRE(trained.find("Patru.") == std::string::npos);
+    }
+
+    SECTION("direct turn has no trained tokens") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "Patru."},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::THINKING_ONLY);
+        REQUIRE(decode_trained(tok, enc).empty());
+    }
+}
+
+TEST_CASE("final-only loss masks reasoning and direct turns", "[tokenizer][chat-template]") {
+    const char* model_dir = std::getenv("SUROGATE_TEST_MODEL");
+    if (!model_dir) {
+        SUCCEED("SUROGATE_TEST_MODEL not set; skipping chat-template regression test");
+        return;
+    }
+    Tokenizer tok = Tokenizer::from_pretrained(model_dir);
+
+    SECTION("thinking turn trains only the final answer") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "<think>\nAdun doi si doi.\n</think>\n\n#### 4"},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::FINAL_ONLY);
+        std::string trained = decode_trained(tok, enc);
+
+        REQUIRE(trained.find("Adun doi si doi.") == std::string::npos);
+        REQUIRE(trained.find("</think>") == std::string::npos);
+        REQUIRE(trained.find("#### 4") != std::string::npos);
+    }
+
+    SECTION("direct turn has no trained tokens") {
+        std::vector<ChatMessage> msgs = {
+            {"user", "Cat fac 2+2?"},
+            {"assistant", "#### 4"},
+        };
+        auto enc = tok.encode_for_training(msgs, LossStrategy::FINAL_ONLY);
+        REQUIRE(decode_trained(tok, enc).empty());
+    }
+}

--- a/csrc/src/tokenizer/tokenizer.cpp
+++ b/csrc/src/tokenizer/tokenizer.cpp
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -868,11 +869,28 @@ TrainingEncoded Tokenizer::encode_for_training(const std::vector<ChatMessage>& m
 
         if (render_with_asst.size() > render_with_user.size()) {
             std::string response = render_with_asst.substr(render_with_user.size());
+            if (strategy == LossStrategy::THINKING_ONLY || strategy == LossStrategy::FINAL_ONLY) {
+                constexpr std::string_view close_tag = "</think>";
+                const size_t close_pos = response.find(close_tag);
+                if (close_pos != std::string::npos) {
+                    const size_t close_end = close_pos + close_tag.size();
+                    segments.push_back({response.substr(0, close_end), strategy == LossStrategy::THINKING_ONLY});
+                    if (close_end < response.size()) {
+                        segments.push_back({response.substr(close_end), strategy == LossStrategy::FINAL_ONLY});
+                    }
+                } else {
+                    segments.push_back({std::move(response), false});
+                }
+                prev_render = std::move(render_with_asst);
+                continue;
+            }
             bool trainable = false;
             switch (strategy) {
                 case LossStrategy::ALL:
                 case LossStrategy::DEFAULT: trainable = true; break;
                 case LossStrategy::LAST_ROUND: trainable = is_last_round; break;
+                case LossStrategy::THINKING_ONLY: break;
+                case LossStrategy::FINAL_ONLY: break;
             }
             segments.push_back({std::move(response), trainable});
         }

--- a/csrc/src/tokenizer/tokenizer.h
+++ b/csrc/src/tokenizer/tokenizer.h
@@ -17,9 +17,11 @@ namespace tokenizer {
 
 // Loss masking strategy for encode_for_training().
 enum class LossStrategy {
-    DEFAULT,     // Train on all assistant responses + suffix tokens
-    LAST_ROUND,  // Train only on the last assistant response + suffix
-    ALL          // Train on all tokens (including system/user)
+    DEFAULT,        // Train on all assistant responses + suffix tokens
+    LAST_ROUND,     // Train only on the last assistant response + suffix
+    THINKING_ONLY,  // Train reasoning through </think>; mask final answers
+    FINAL_ONLY,     // Train final answers after </think>; mask reasoning/direct turns
+    ALL             // Train on all tokens (including system/user)
 };
 
 // Result of encode_for_training().
@@ -102,6 +104,8 @@ public:
     // The strategy controls which tokens are trainable:
     //   DEFAULT    — all assistant response + suffix tokens
     //   LAST_ROUND — only the last assistant response + suffix
+    //   THINKING_ONLY — reasoning tokens through </think>; direct/final tokens masked
+    //   FINAL_ONLY — final tokens after </think>; reasoning/direct tokens masked
     //   ALL        — all tokens (system, user, assistant, template)
     //
     // labels[0] is always -100.

--- a/docs/getting-started/quickstart-dpo.md
+++ b/docs/getting-started/quickstart-dpo.md
@@ -7,9 +7,9 @@ rejected}` triples and run a single command.
 
 ## 1) Prepare preference data
 
-A `type: preference` dataset is JSONL with three fields per row. `prompt` may be a
+A `type: preference` dataset is JSONL with three required fields per row. `prompt` may be a
 string or a chat `messages` list; `chosen`/`rejected` are the two competing assistant
-continuations:
+continuations. Chat rows may also set `enable_thinking`:
 
 ```json
 {"prompt": "Scrie corect în limba română.", "chosen": "Ei mergeau acasă.", "rejected": "Ei mergerăm acasă."}
@@ -46,16 +46,20 @@ loss:
   type: dpo
   dpo_beta: 0.1                           # KL temperature; higher pushes harder from the reference
   length_norm: false                      # enable when chosen/rejected lengths differ a lot
+  span_mask: false                        # score only disjoint differing token spans
+  reference_free: false                  # optimize the absolute chosen/rejected gap
+  target_margin: 0.0                     # requires reference_free; beta-scaled target gap
 
 datasets:
   - path: ./pairs.jsonl
     type: preference
 ```
 
-DPO inherits all SFT settings (LoRA, recipe, optimizer, schedule). The base model is
-frozen; only the LoRA adapter is trained. The **reference** is the start checkpoint,
-captured once at the beginning (with the adapter disabled) and cached to
-`output_dir/ref_logprobs.npz`.
+DPO inherits all SFT settings (LoRA, recipe, optimizer, schedule, checkpoint resume
+and retention). The base model is frozen; only the LoRA adapter is trained. In
+standard DPO, the **reference** is the frozen start checkpoint and is evaluated
+inline on each exact micro-batch. This keeps FP8 activation scaling aligned with
+the policy forward. `reference_free: true` skips that extra reference forward.
 
 ## 3) Run
 
@@ -82,10 +86,9 @@ step=1 dpo_loss=0.6871 acc=1.000 margin=0.0121 ...
 
 ## 5) Outputs
 
-- `output_dir/step_{:08}/adapter_model.safetensors` — LoRA checkpoints at `save_steps`.
+- `output_dir/step_{:08}/adapter_model.safetensors` — LoRA checkpoints at `save_steps`;
+  older checkpoints are removed according to `save_total_limit`.
 - `output_dir/final_adapter/` — the final LoRA adapter.
-- `output_dir/ref_logprobs.npz` — the cached reference (safe to delete; recomputed if
-  the model/data/layout change).
 
 Merge an adapter into a standalone model with:
 
@@ -100,8 +103,9 @@ surogate merge --base-model ./path/to/start_checkpoint \
   general quality); too low barely moves the model. `0.1` is a reasonable start.
 - **Build minimal pairs.** Broad, full-rewrite pairs leak style/length; prefer pairs
   that isolate the exact behavior you want to change.
-- **Small learning rate.** The preference gradient is small; `master_dtype`/
-  `gradient_dtype` default to `fp32` so it isn't lost to BF16 rounding.
+- **Small learning rate.** The preference gradient is small; `gradient_dtype` and
+  the trainable LoRA weights use FP32 so it is not lost to BF16 rounding. The frozen
+  base does not receive a wasteful FP32 master copy.
 
 ## See also
 

--- a/docs/getting-started/quickstart-dpo.md
+++ b/docs/getting-started/quickstart-dpo.md
@@ -1,0 +1,111 @@
+# Quickstart: Preference Fine-Tuning (DPO)
+
+This runs an offline **Direct Preference Optimization** job. DPO teaches a model to
+prefer a *chosen* response over a *rejected* one for the same prompt — directly, with
+no reward model and no rollouts. You supply a static dataset of `{prompt, chosen,
+rejected}` triples and run a single command.
+
+## 1) Prepare preference data
+
+A `type: preference` dataset is JSONL with three fields per row. `prompt` may be a
+string or a chat `messages` list; `chosen`/`rejected` are the two competing assistant
+continuations:
+
+```json
+{"prompt": "Scrie corect în limba română.", "chosen": "Ei mergeau acasă.", "rejected": "Ei mergerăm acasă."}
+```
+
+Loss is applied only to the response tokens. Minimal pairs — where `chosen` and
+`rejected` differ in as little as a single word — give the cleanest signal, because
+the model learns the preferred token rather than incidental style or length.
+
+## 2) Write a config
+
+```yaml
+# dpo.yaml
+model: ./path/to/start_checkpoint        # the model to fine-tune (also the DPO reference)
+output_dir: ./out_dpo
+
+lora: true
+lora_rank: 16
+lora_alpha: 32
+lora_target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+
+recipe: fp8-hybrid
+optimizer: adamw_8bit
+learning_rate: 5.0e-7
+lr_scheduler_type: constant
+gpus: 1
+per_device_train_batch_size: 8           # must be even — each pair is 2 rows (B/2 pairs/step)
+gradient_accumulation_steps: 1
+sequence_len: 1024
+max_steps: 80
+save_steps: 20
+
+loss:
+  type: dpo
+  dpo_beta: 0.1                           # KL temperature; higher pushes harder from the reference
+  length_norm: false                      # enable when chosen/rejected lengths differ a lot
+
+datasets:
+  - path: ./pairs.jsonl
+    type: preference
+```
+
+DPO inherits all SFT settings (LoRA, recipe, optimizer, schedule). The base model is
+frozen; only the LoRA adapter is trained. The **reference** is the start checkpoint,
+captured once at the beginning (with the adapter disabled) and cached to
+`output_dir/ref_logprobs.npz`.
+
+## 3) Run
+
+```bash
+CUDA_VISIBLE_DEVICES=0 surogate dpo dpo.yaml
+```
+
+For multiple GPUs, set `gpus: N`; distinct pairs are sharded across the GPUs
+(data-parallel) and gradients are averaged.
+
+## 4) What to expect
+
+```
+step=0 dpo_loss=0.6931 acc=0.000 margin=0.0000 ...
+step=1 dpo_loss=0.6871 acc=1.000 margin=0.0121 ...
+```
+
+- **Step 0** logs `dpo_loss ≈ 0.6931 = log 2` with `margin = 0`. This is the identity
+  check: at initialization the policy equals the reference (LoRA `B` is zero-init), so
+  the preference margin is exactly zero. If you don't see ~0.693 at step 0, something
+  is wrong with the reference or the data layout.
+- As training proceeds, `dpo_loss` decreases, `margin` goes positive, and `acc`
+  (fraction of pairs with `margin > 0`) rises toward 1.0.
+
+## 5) Outputs
+
+- `output_dir/step_{:08}/adapter_model.safetensors` — LoRA checkpoints at `save_steps`.
+- `output_dir/final_adapter/` — the final LoRA adapter.
+- `output_dir/ref_logprobs.npz` — the cached reference (safe to delete; recomputed if
+  the model/data/layout change).
+
+Merge an adapter into a standalone model with:
+
+```bash
+surogate merge --base-model ./path/to/start_checkpoint \
+  --checkpoint-dir ./out_dpo/step_00000040 --output ./out_dpo_eval
+```
+
+## Tips
+
+- **`dpo_beta`** is the main knob. Too high overfits the preference (and can hurt
+  general quality); too low barely moves the model. `0.1` is a reasonable start.
+- **Build minimal pairs.** Broad, full-rewrite pairs leak style/length; prefer pairs
+  that isolate the exact behavior you want to change.
+- **Small learning rate.** The preference gradient is small; `master_dtype`/
+  `gradient_dtype` default to `fp32` so it isn't lost to BF16 rounding.
+
+## See also
+
+- [Training Modes](training-modes.md)
+- [Quickstart: GRPO](quickstart-grpo.md)
+- [Config reference](../reference/config.md)
+- [CLI reference](../reference/cli.md)

--- a/docs/getting-started/training-modes.md
+++ b/docs/getting-started/training-modes.md
@@ -155,7 +155,7 @@ loss   = −log σ(margin)
 ```
 
 - **What updates?** LoRA adapter parameters (base model is frozen)
-- **Reference model:** the start checkpoint, captured once (LoRA disabled) and cached
+- **Reference model:** the frozen start checkpoint, evaluated inline with LoRA disabled
 - **Typical data:** `type: preference` datasets (`{prompt, chosen, rejected}`)
 - **Typical run shape:** a few hundred gradient steps over preference pairs
 
@@ -170,6 +170,7 @@ loss:
   type: dpo
   dpo_beta: 0.1
   length_norm: false   # enable when chosen/rejected lengths differ a lot
+  span_mask: false     # optionally score only differing token spans
 datasets:
   - path: pairs.jsonl
     type: preference

--- a/docs/getting-started/training-modes.md
+++ b/docs/getting-started/training-modes.md
@@ -1,11 +1,12 @@
 # Training Modes
 
-Surogate supports four practical ways to adapt a model:
+Surogate supports five practical ways to adapt a model:
 
 1) **Pretraining / Continued Pretraining (PT)**
 2) **Full Fine-Tuning**
 3) **LoRA / QLoRA (Adapter Fine-Tuning)**
 4) **RL Fine-Tuning (GRPO)**
+5) **Preference Fine-Tuning (DPO)**
 
 They differ in *which parameters are updated*, *how much data you need*, and *how much compute/VRAM you’ll spend*.
 
@@ -22,6 +23,7 @@ They differ in *which parameters are updated*, *how much data you need*, and *ho
 | Same as LoRA but you’re VRAM-limited | **QLoRA** |
 | Improve reasoning, math, coding via reward-based training | **GRPO** |
 | Compress a larger model into a smaller one from the same family | **SFT + [Knowledge Distillation](../guides/distillation.md)** |
+| Steer behavior from chosen-vs-rejected preference pairs (offline) | **DPO** |
 
 ---
 
@@ -142,6 +144,49 @@ surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml
 
 ---
 
+## 5) Preference Fine-Tuning (DPO)
+
+### How it works
+**DPO** (Direct Preference Optimization) teaches a model to prefer a *chosen* response over a *rejected* one for the same prompt, directly — no reward model and no rollouts. It is **offline**: you supply a static dataset of `{prompt, chosen, rejected}` triples, and the loss raises the implicit reward of `chosen` relative to `rejected`:
+
+```
+margin = β · [ (logπθ − logπref)(chosen) − (logπθ − logπref)(rejected) ]
+loss   = −log σ(margin)
+```
+
+- **What updates?** LoRA adapter parameters (base model is frozen)
+- **Reference model:** the start checkpoint, captured once (LoRA disabled) and cached
+- **Typical data:** `type: preference` datasets (`{prompt, chosen, rejected}`)
+- **Typical run shape:** a few hundred gradient steps over preference pairs
+
+In Surogate, DPO runs from a single config:
+
+```bash
+surogate dpo path/to/config.yaml
+```
+
+```yaml
+loss:
+  type: dpo
+  dpo_beta: 0.1
+  length_norm: false   # enable when chosen/rejected lengths differ a lot
+datasets:
+  - path: pairs.jsonl
+    type: preference
+```
+
+### When to use it
+- You have **paired preferences** (chosen vs rejected), not a reward function or pure demonstrations.
+- You want to fix a specific behavior with **minimal, targeted contrasts** (e.g. correct vs incorrect word forms) without the cost/instability of RL.
+- You want something simpler than GRPO: no inference server, no orchestrator.
+
+### Tradeoffs
+- Needs preference pairs; quality depends heavily on pair construction.
+- `dpo_beta` controls how hard the policy is pushed from the reference — too high overfits, too low barely moves.
+- Offline only (pairs are fixed; no on-policy regeneration).
+
+---
+
 ## Practical recommendations
 
 - Start with **LoRA (bf16 recipe)** unless you have a strong reason not to.
@@ -149,6 +194,7 @@ surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml
 - Use **Full fine-tuning** when you want maximum quality and have budget.
 - Use **(Continued) pretraining** for domain adaptation on large raw text.
 - Use **GRPO** when you have a reward signal and want to go beyond imitation learning.
+- Use **DPO** when you have chosen-vs-rejected preference pairs and want offline preference steering without a reward model.
 
 ---
 
@@ -157,6 +203,7 @@ surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml
 - [Quickstart: Pretraining](quickstart-pretraining.md)
 - [Quickstart: Supervised Fine-Tuning](quickstart-sft.md)
 - [Quickstart: GRPO](quickstart-grpo.md)
+- [Quickstart: DPO](quickstart-dpo.md)
 - [Configuration](../guides/configuration.md)
 - [Precision & recipes](../guides/precision-and-recipes.md)
 - [QLoRA](../guides/qlora.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ Follow these guides to run your first training:
 - [Quickstart: SFT](getting-started/quickstart-sft.md)
 - [Quickstart: Pre-training](getting-started/quickstart-pretraining.md)
 - [Quickstart: GRPO](getting-started/quickstart-grpo.md)
+- [Quickstart: DPO](getting-started/quickstart-dpo.md)
 
 ## Hardware / Requirements
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,18 @@ Options:
 
 - `--hub_token <token>`: optional, Hugging Face token for private model access
 
+### `dpo`
+
+Offline Direct Preference Optimization on `{prompt, chosen, rejected}` pairs.
+
+```bash
+surogate dpo path/to/config.yaml
+```
+
+Options:
+
+- `--hub_token <token>`: optional, Hugging Face token for private model access
+
 ### `pt`
 
 Pretraining.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -336,9 +336,10 @@ datasets:
 
 #### Preference Dataset Options (`type: "preference"`)
 
-For offline DPO. Each JSONL row has exactly three fields — `prompt` (a string or a
-chat `messages` list), `chosen`, and `rejected` (the two competing assistant
-continuations). Loss is applied only on the response tokens. Used by the
+For offline DPO. Each JSONL row has `prompt` (a string or a chat `messages` list),
+`chosen`, and `rejected` (the two competing assistant continuations). Chat rows may
+also set `enable_thinking` to control the generation prefix. Loss is applied only
+on the response tokens. Used by the
 `surogate dpo` command together with the [DPO loss block](#dpo-settings).
 
 ```json
@@ -355,18 +356,21 @@ datasets:
 ## DPO Settings
 
 Direct Preference Optimization (the `surogate dpo` command). Offline: a static set
-of `{prompt, chosen, rejected}` pairs (`type: preference`) with the reference model
-(the start checkpoint) captured once and cached — no reward model, no rollouts. See
+of `{prompt, chosen, rejected}` pairs (`type: preference`) with the frozen reference
+model evaluated inline — no reward model, no rollouts. See
 [Training Modes](../getting-started/training-modes.md) and
 [Quickstart: DPO](../getting-started/quickstart-dpo.md).
 
 Configured under a nested `loss:` block:
 
-| Option        | Type   | Default | Description                                                                                          |
-| ------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
-| `type`        | string | `"dpo"` | Loss type. Must be `"dpo"`.                                                                          |
-| `dpo_beta`    | float  | `0.1`   | KL temperature β. The implicit reward is `β · (logπθ − logπref)`; higher β pushes harder from the reference. |
-| `length_norm` | bool   | `false` | Divide each response's log-prob sum by its length (SimPO-style). Leave off for minimal/equal-length pairs. |
+| Option           | Type   | Default | Description                                                                                          |
+| ---------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `type`           | string | `"dpo"` | Loss type. Must be `"dpo"`.                                                                          |
+| `dpo_beta`       | float  | `0.1`   | KL temperature β. The implicit reward is `β · (logπθ − logπref)`; higher β pushes harder from the reference. |
+| `length_norm`    | bool   | `false` | Divide each response's log-prob sum by its length (SimPO-style). Leave off for minimal/equal-length pairs. |
+| `span_mask`      | bool   | `false` | Score only the disjoint token spans that differ; rows without surviving edits on both sides are dropped. |
+| `reference_free` | bool   | `false` | Optimize the chosen/rejected likelihood gap directly and skip the frozen-reference forward. |
+| `target_margin`  | float  | `0.0`   | Non-negative beta-scaled target gap for reference-free training. Requires `reference_free: true`. |
 
 **Example:**
 ```yaml
@@ -374,14 +378,18 @@ loss:
   type: dpo
   dpo_beta: 0.1
   length_norm: false
+  span_mask: false
+  reference_free: false
+  target_margin: 0.0
 datasets:
   - path: ./pairs.jsonl
 	type: preference
 ```
 
-DPO inherits all LoRA, recipe, optimizer, and training-loop settings from the SFT
-config; `master_dtype`/`gradient_dtype` default to `fp32` (the preference gradient is
-small) and CUDA graphs are disabled (the native DPO step is not graph-captured).
+DPO inherits all LoRA, recipe, optimizer, checkpoint-resume, retention, and
+training-loop settings from the SFT config. `gradient_dtype` and the LoRA dtype
+default to FP32; the frozen base does not require an FP32 master copy. CUDA graphs
+are disabled because the native DPO step is not graph-captured.
 
 ## Memory Optimization Settings
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -264,7 +264,7 @@ Each dataset in the `datasets` or `validation_datasets` list is configured with 
 | Option    | Type   | Default   | Description                                                                                                          |
 | --------- | ------ | --------- | -------------------------------------------------------------------------------------------------------------------- |
 | `path`    | string | required  | HuggingFace dataset repo, s3:// URL, gs:// URL, or path to local file or directory.                                  |
-| `type`    | string | required  | Dataset type. Options: `"text"`, `"instruction"`, `"conversation"`, `"auto"` (auto-detect format).                   |
+| `type`    | string | required  | Dataset type. Options: `"text"`, `"instruction"`, `"conversation"`, `"preference"` (DPO), `"auto"` (auto-detect format). |
 | `subset`  | string | `null`    | HuggingFace dataset subset/configuration name to load (e.g., `"default"` for datasets with multiple configurations). |
 | `split`   | string | `"train"` | Dataset split to load. Common values: `"train"`, `"test"`, `"validation"`.                                           |
 | `samples` | int    | `null`    | Limit the number of samples to use from this dataset. If not specified, uses all available samples.                  |
@@ -333,6 +333,55 @@ datasets:
 	messages_field: messages
 	split: train_sft
 ```
+
+#### Preference Dataset Options (`type: "preference"`)
+
+For offline DPO. Each JSONL row has exactly three fields — `prompt` (a string or a
+chat `messages` list), `chosen`, and `rejected` (the two competing assistant
+continuations). Loss is applied only on the response tokens. Used by the
+`surogate dpo` command together with the [DPO loss block](#dpo-settings).
+
+```json
+{"prompt": "...", "chosen": "preferred response", "rejected": "dispreferred response"}
+```
+
+**Example:**
+```yaml
+datasets:
+  - path: ./pairs.jsonl
+	type: preference
+```
+
+## DPO Settings
+
+Direct Preference Optimization (the `surogate dpo` command). Offline: a static set
+of `{prompt, chosen, rejected}` pairs (`type: preference`) with the reference model
+(the start checkpoint) captured once and cached — no reward model, no rollouts. See
+[Training Modes](../getting-started/training-modes.md) and
+[Quickstart: DPO](../getting-started/quickstart-dpo.md).
+
+Configured under a nested `loss:` block:
+
+| Option        | Type   | Default | Description                                                                                          |
+| ------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `type`        | string | `"dpo"` | Loss type. Must be `"dpo"`.                                                                          |
+| `dpo_beta`    | float  | `0.1`   | KL temperature β. The implicit reward is `β · (logπθ − logπref)`; higher β pushes harder from the reference. |
+| `length_norm` | bool   | `false` | Divide each response's log-prob sum by its length (SimPO-style). Leave off for minimal/equal-length pairs. |
+
+**Example:**
+```yaml
+loss:
+  type: dpo
+  dpo_beta: 0.1
+  length_norm: false
+datasets:
+  - path: ./pairs.jsonl
+	type: preference
+```
+
+DPO inherits all LoRA, recipe, optimizer, and training-loop settings from the SFT
+config; `master_dtype`/`gradient_dtype` default to `fp32` (the preference gradient is
+small) and CUDA graphs are disabled (the native DPO step is not graph-captured).
 
 ## Memory Optimization Settings
 

--- a/surogate/cli/dpo.py
+++ b/surogate/cli/dpo.py
@@ -1,0 +1,28 @@
+import argparse
+import sys
+
+from surogate.core.config.loader import load_config
+from surogate.utils.dict import DictDefault
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def prepare_command_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser()
+
+    parser.add_argument("config", type=str, help="Path or HTTP(s) URL to config file")
+    parser.add_argument("--hub_token", type=str, help="Hugging Face token for private model access", default=None)
+
+    return parser
+
+
+if __name__ == "__main__":
+    args = prepare_command_parser().parse_args(sys.argv[1:])
+
+    from surogate.dpo.config import DPOTrainConfig
+    from surogate.dpo.trainer import dpo_main
+
+    config = load_config(DPOTrainConfig, args.config)
+    dpo_main(config, DictDefault(**args.__dict__))

--- a/surogate/cli/main.py
+++ b/surogate/cli/main.py
@@ -41,6 +41,7 @@ logger = get_logger()
 
 COMMAND_MAPPING: dict[str, str] = {
     "sft": "surogate.cli.sft",
+    "dpo": "surogate.cli.dpo",
     "pt": "surogate.cli.pt",
     "grpo": "surogate.cli.grpo",
     "grpo-colocate": "surogate.cli.grpo_colocate",
@@ -82,6 +83,11 @@ def parse_args():
     from surogate.cli.sft import prepare_command_parser as sft_prepare_command_parser
 
     sft_prepare_command_parser(subparsers.add_parser("sft", help="Supervised Fine-Tuning"))
+
+    # dpo command
+    from surogate.cli.dpo import prepare_command_parser as dpo_prepare_command_parser
+
+    dpo_prepare_command_parser(subparsers.add_parser("dpo", help="Direct Preference Optimization (offline)"))
 
     # pretrain command
     from surogate.cli.pt import prepare_command_parser as pt_prepare_command_parser
@@ -160,16 +166,23 @@ def parse_args():
     # jackalope is intercepted before argparse (see maybe_exec_jackalope); this
     # entry exists only so it shows up in `surogate --help`. add_help=False so its
     # own `--help` passes through to the dashboard binary.
-    subparsers.add_parser(
-        "jackalope", help="Launch the jackalope live-training dashboard (TUI)", add_help=False
-    )
+    subparsers.add_parser("jackalope", help="Launch the jackalope live-training dashboard (TUI)", add_help=False)
 
     args = parser.parse_args(sys.argv[1:])
     if args.command is None:
         parser.print_help()
         sys.exit(1)
 
-    commands_with_config = ["sft", "pt", "grpo_train", "grpo_infer", "grpo_orch", "tokenize", "distill-capture"]
+    commands_with_config = [
+        "sft",
+        "dpo",
+        "pt",
+        "grpo_train",
+        "grpo_infer",
+        "grpo_orch",
+        "tokenize",
+        "distill-capture",
+    ]
     if args.command in commands_with_config and not getattr(args, "config", None):
         parser.print_help()
         sys.exit(1)

--- a/surogate/core/config/enums.py
+++ b/surogate/core/config/enums.py
@@ -5,6 +5,7 @@ class SurogateDatasetType(str, Enum):
     text = "text"
     instruction = "instruction"
     conversation = "conversation"
+    preference = "preference"  # {prompt, chosen, rejected} pairs for offline DPO
     auto = "auto"
 
 

--- a/surogate/dpo/config.py
+++ b/surogate/dpo/config.py
@@ -1,0 +1,83 @@
+"""Offline DPO training configuration.
+
+DPOTrainConfig extends SFTConfig with the DPO loss block. Model, LoRA, QLoRA,
+precision, optimizer, and runtime fields are inherited from SFTConfig. Unlike
+GRPO, DPO keeps `datasets` (it reads static preference pairs of the form
+{prompt, chosen, rejected}); see surogate/dpo/data.py.
+"""
+
+from dataclasses import dataclass, fields
+from typing import Literal
+
+from surogate.core.config.sft_config import SFTConfig
+from surogate.utils.dict import DictDefault
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class DPOLossConfig:
+    """Sigmoid-DPO loss parameters."""
+
+    type: Literal["dpo"] = "dpo"
+    # KL temperature. The implicit reward is beta * (logpi_theta - logpi_ref).
+    dpo_beta: float = 0.1
+    # Divide each sequence's response-token logprob sum by its response length
+    # (SimPO-style). Off for minimal pairs where chosen/rejected lengths match.
+    length_norm: bool = False
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DPOLossConfig":
+        known = {f.name for f in fields(cls)}
+        unknown = set(d) - known
+        if unknown:
+            raise ValueError(f"unknown DPO loss config keys: {sorted(unknown)}")
+        return cls(**d)
+
+
+@dataclass
+class DPOTrainConfig(SFTConfig):
+    """Configuration for offline DPO training with Surogate."""
+
+    loss: DPOLossConfig | None = None
+
+    def __init__(self, cfg: DictDefault):
+        # The DPO per-token gradient is beta * sigmoid(-margin) * (softmax - 1{target}),
+        # typically far smaller than an SFT gradient — keep fp32 master/grad so BF16
+        # rounding does not swamp the preference signal (mirrors GRPO).
+        if "master_dtype" not in cfg:
+            cfg["master_dtype"] = "fp32"
+        if "gradient_dtype" not in cfg:
+            cfg["gradient_dtype"] = "fp32"
+
+        # The DPO trainer tokenizes preference pairs itself (surogate/dpo/data.py)
+        # and packs each (chosen, rejected) pair atomically, so the generic SFT
+        # sample-packing path is bypassed.
+        cfg["sample_packing"] = "false"
+
+        # Pairs are heavily masked (prompt + padding tokens carry no loss); the
+        # compact lm_head path skips work on those rows.
+        if "lmhead_drop_ignored_rows" not in cfg:
+            cfg["lmhead_drop_ignored_rows"] = True
+
+        super().__init__(cfg)
+
+        loss_cfg = cfg.get("loss", {})
+        if isinstance(loss_cfg, DPOLossConfig):
+            self.loss = loss_cfg
+        elif isinstance(loss_cfg, dict) and loss_cfg:
+            self.loss = DPOLossConfig.from_dict(dict(loss_cfg))
+        else:
+            self.loss = DPOLossConfig()
+
+        # Initialize inherited config (model_dir, runtime_config, lora_config, ...).
+        # The SFT path runs this from TokenizeDatasets.__init__(); the DPO trainer
+        # bypasses that pipeline, so call it here directly (as GRPO does).
+        self.__post_init__()
+
+        # The native DPO step is not graph-captured (it mirrors the native GRPO
+        # step, which also disables CUDA graphs).
+        if self.use_cuda_graphs:
+            self.use_cuda_graphs = False
+            self.runtime_config.use_cuda_graphs = False

--- a/surogate/dpo/config.py
+++ b/surogate/dpo/config.py
@@ -26,6 +26,10 @@ class DPOLossConfig:
     # Divide each sequence's response-token logprob sum by its response length
     # (SimPO-style). Off for minimal pairs where chosen/rejected lengths match.
     length_norm: bool = False
+    # Confine the loss to the tokens where chosen and rejected differ (common
+    # prefix/suffix excluded). For minimal word-substitution pairs the gradient
+    # then cannot shift style/length/language — only the substituted form.
+    span_mask: bool = False
 
     @classmethod
     def from_dict(cls, d: dict) -> "DPOLossConfig":

--- a/surogate/dpo/config.py
+++ b/surogate/dpo/config.py
@@ -44,10 +44,15 @@ class DPOTrainConfig(SFTConfig):
 
     def __init__(self, cfg: DictDefault):
         # The DPO per-token gradient is beta * sigmoid(-margin) * (softmax - 1{target}),
-        # typically far smaller than an SFT gradient — keep fp32 master/grad so BF16
-        # rounding does not swamp the preference signal (mirrors GRPO).
-        if "master_dtype" not in cfg:
-            cfg["master_dtype"] = "fp32"
+        # far smaller than an SFT gradient, so keep the trainable parameters in fp32 to
+        # avoid BF16 rounding swamping the signal. This is a LoRA-only run (the base is
+        # frozen), so precision must come from the *adapter*, not a full-model master:
+        #   - lora_dtype defaults to "fp32" -> the trainable LoRA weights are fp32.
+        #   - gradient_dtype=fp32 -> the (tiny) LoRA gradients are fp32.
+        # Do NOT force master_dtype=fp32: it would allocate an fp32 copy of the entire
+        # frozen base (~2x the model, e.g. +9 GB for a 2B) in the persistent arena for
+        # no benefit, and that waste is what tipped fp8-hybrid / multi-GPU / large-batch
+        # runs into spurious arena OOMs at trainer construction.
         if "gradient_dtype" not in cfg:
             cfg["gradient_dtype"] = "fp32"
 

--- a/surogate/dpo/config.py
+++ b/surogate/dpo/config.py
@@ -30,6 +30,12 @@ class DPOLossConfig:
     # prefix/suffix excluded). For minimal word-substitution pairs the gradient
     # then cannot shift style/length/language — only the substituted form.
     span_mask: bool = False
+    # Optimize the chosen/rejected likelihood gap directly instead of its
+    # change from the frozen start policy.
+    reference_free: bool = False
+    # Required beta-scaled likelihood margin for reference-free training
+    # (SimPO-style gamma).
+    target_margin: float = 0.0
 
     @classmethod
     def from_dict(cls, d: dict) -> "DPOLossConfig":
@@ -79,6 +85,13 @@ class DPOTrainConfig(SFTConfig):
             self.loss = DPOLossConfig.from_dict(dict(loss_cfg))
         else:
             self.loss = DPOLossConfig()
+
+        if self.loss.dpo_beta <= 0:
+            raise ValueError("loss.dpo_beta must be positive")
+        if self.loss.target_margin < 0:
+            raise ValueError("loss.target_margin must be non-negative")
+        if self.loss.target_margin and not self.loss.reference_free:
+            raise ValueError("loss.target_margin requires loss.reference_free=true")
 
         # Initialize inherited config (model_dir, runtime_config, lora_config, ...).
         # The SFT path runs this from TokenizeDatasets.__init__(); the DPO trainer

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
+from difflib import SequenceMatcher
 from typing import Any
 
 import numpy as np
@@ -48,10 +50,17 @@ class PrefBatch:
         return int(self.input_ids.shape[0])
 
 
-def _render(tok, prompt: Any, response: str) -> tuple[list[int], list[int]]:
+def _render(tok, prompt: Any, response: str, enable_thinking: bool | None = None) -> tuple[list[int], list[int]]:
     """Return (prompt_ids, response_ids). `prompt` is a string or a messages list."""
     if isinstance(prompt, list):
-        prompt_ids = tok.apply_chat_template(prompt, add_generation_prompt=True, tokenize=True)
+        kwargs = {"add_generation_prompt": True, "tokenize": True}
+        if enable_thinking is not None:
+            kwargs["enable_thinking"] = enable_thinking
+        prompt_ids = tok.apply_chat_template(prompt, **kwargs)
+        if isinstance(prompt_ids, Mapping):
+            prompt_ids = prompt_ids["input_ids"]
+        if prompt_ids and isinstance(prompt_ids[0], list):
+            prompt_ids = prompt_ids[0]
     else:
         prompt_ids = tok(prompt, add_special_tokens=True)["input_ids"]
     response_ids = tok(response, add_special_tokens=False)["input_ids"]
@@ -72,25 +81,25 @@ def _layout_sequence(prompt_ids: list[int], response_ids: list[int], max_len: in
     return ids, prompt_len
 
 
-def _diff_span(chosen_ids: list[int], rejected_ids: list[int]) -> tuple[int, int, int, int] | None:
-    """Longest-common-prefix/suffix diff of two token lists.
-
-    Returns (c_start, c_end, r_start, r_end) — the half-open differing spans in
-    each list — or None if the lists are identical. The common suffix is bounded
-    so the spans never underrun the prefix (all-diff worst case keeps full spans).
-    """
+def _diff_segments(
+    chosen_ids: list[int], rejected_ids: list[int]
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]]] | None:
+    """Return disjoint half-open token segments that differ between responses."""
     if chosen_ids == rejected_ids:
         return None
-    lcp = 0
-    for a, b in zip(chosen_ids, rejected_ids):
-        if a != b:
-            break
-        lcp += 1
-    lcs = 0
-    max_lcs = min(len(chosen_ids), len(rejected_ids)) - lcp
-    while lcs < max_lcs and chosen_ids[-1 - lcs] == rejected_ids[-1 - lcs]:
-        lcs += 1
-    return lcp, len(chosen_ids) - lcs, lcp, len(rejected_ids) - lcs
+
+    chosen_segments = []
+    rejected_segments = []
+    for tag, c_start, c_end, r_start, r_end in SequenceMatcher(
+        a=chosen_ids, b=rejected_ids, autojunk=False
+    ).get_opcodes():
+        if tag == "equal":
+            continue
+        if c_start < c_end:
+            chosen_segments.append((c_start, c_end))
+        if r_start < r_end:
+            rejected_segments.append((r_start, r_end))
+    return chosen_segments, rejected_segments
 
 
 def tokenize_preference_pairs(
@@ -101,11 +110,9 @@ def tokenize_preference_pairs(
     Rows whose prompt+response cannot fit a single response token in `max_len`
     are dropped (logged). Raises ValueError if no pair survives.
 
-    span_mask=True confines loss_mask to the tokens where chosen and rejected
-    DIFFER (common prefix and suffix excluded). For minimal word-substitution
-    pairs this makes the DPO gradient structurally unable to shift style,
-    length, or language of the surrounding text — only the substituted form is
-    scored. Identical-tokenization rows are dropped (no contrastive signal).
+    span_mask=True confines loss_mask to the disjoint token blocks where chosen
+    and rejected differ. Identical-tokenization rows, and rows where truncation
+    removes every differing token from either side, are dropped.
     """
     if pad_id is None:
         pad_id = tok.pad_token_id
@@ -115,15 +122,16 @@ def tokenize_preference_pairs(
             raise ValueError("tokenizer has neither pad_token_id nor eos_token_id; pass pad_id explicitly")
 
     seqs: list[tuple[list[int], int]] = []  # (ids, prompt_len), chosen then rejected per kept pair
-    spans: list[tuple[int, int] | None] = []  # per-sequence (start, end) into the RESPONSE, or None = all
+    segments: list[list[tuple[int, int]] | None] = []  # response segments per sequence; None = all
     dropped = 0
     dropped_identical = 0
     for row in rows:
         prompt = row["prompt"]
+        enable_thinking = row.get("enable_thinking")
         laid = []
         resp_ids = []
         for key in ("chosen", "rejected"):
-            p_ids, r_ids = _render(tok, prompt, row[key])
+            p_ids, r_ids = _render(tok, prompt, row[key], enable_thinking)
             res = _layout_sequence(p_ids, r_ids, max_len, pad_id)
             if res is None:
                 laid = []
@@ -134,25 +142,30 @@ def tokenize_preference_pairs(
             dropped += 1
             continue
         if span_mask:
-            d = _diff_span(resp_ids[0], resp_ids[1])
+            d = _diff_segments(resp_ids[0], resp_ids[1])
             if d is None:
                 dropped_identical += 1
                 continue
-            # Adjust spans for any response-head tokens lost to left-truncation.
-            adj = []
-            for (ids, p_len), r_full, (s, e) in zip(laid, resp_ids, [d[:2], d[2:]]):
+            # Adjust edited segments for response-head tokens lost to left-truncation.
+            adjusted_pair = []
+            for (ids, p_len), r_full, diff_segments in zip(laid, resp_ids, d):
                 head_dropped = len(r_full) - (len(ids) - p_len)
-                s2, e2 = max(0, s - head_dropped), e - head_dropped
-                if e2 <= s2:  # differing span truncated away — no contrastive signal
-                    adj = []
-                    break
-                adj.append((s2, e2))
-            if len(adj) != 2:
+                response_len = len(ids) - p_len
+                adjusted = []
+                for start, end in diff_segments:
+                    start = max(0, start - head_dropped)
+                    end = min(response_len, end - head_dropped)
+                    if start < end:
+                        adjusted.append((start, end))
+                adjusted_pair.append(adjusted)
+            # The native objective is two-sided; an insertion/deletion or
+            # truncation must not leave one sequence with an empty mask.
+            if not all(adjusted_pair):
                 dropped += 1
                 continue
-            spans.extend(adj)
+            segments.extend(adjusted_pair)
         else:
-            spans.extend([None, None])
+            segments.extend([None, None])
         seqs.extend(laid)
 
     n_pairs = len(seqs) // 2
@@ -180,13 +193,12 @@ def tokenize_preference_pairs(
         # targets[j] = ids[j+1]; targets[L-1..] stay 0 (unused / masked).
         if L >= 2:
             targets[k, : L - 1] = ids[1:L]
-        span = spans[k]
-        if span is None:
+        diff_segments = segments[k]
+        if diff_segments is None:
             loss_mask[k, prompt_len:L] = 1  # response tokens (incl. the last) are scored
         else:
-            a = min(prompt_len + span[0], L - 1)
-            b = min(prompt_len + span[1], L)
-            loss_mask[k, a : max(b, a + 1)] = 1  # only the differing span is scored
+            for start, end in diff_segments:
+                loss_mask[k, prompt_len + start : prompt_len + end] = 1
         position_ids[k, :L] = np.arange(L, dtype=np.int32)
         seq_len[k] = L
 
@@ -208,7 +220,7 @@ def tokenize_preference_pairs(
 # upstream changes (model, max_len, prompt rendering, or the rows themselves) so a
 # stale sidecar can never silently feed wrong references into training.
 
-RENDER_VERSION = 1  # bump if _render / _layout_sequence semantics change
+RENDER_VERSION = 2  # bump if _render / _layout_sequence semantics change
 
 
 def rows_digest(rows: list[dict]) -> str:
@@ -217,7 +229,9 @@ def rows_digest(rows: list[dict]) -> str:
     for r in rows:
         h.update(
             json.dumps(
-                [r.get("prompt"), r.get("chosen"), r.get("rejected")], ensure_ascii=False, sort_keys=True
+                [r.get("prompt"), r.get("chosen"), r.get("rejected"), r.get("enable_thinking")],
+                ensure_ascii=False,
+                sort_keys=True,
             ).encode("utf-8")
         )
     return h.hexdigest()[:16]

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -1,0 +1,133 @@
+"""Preference-pair tokenization for offline DPO.
+
+Each preference row is {prompt, chosen, rejected}. We render prompt+chosen and
+prompt+rejected, mask the prompt (loss only on the response continuation), and
+lay each sequence out as its own right-padded row of width `max_len`. A
+micro-batch of B rows is therefore B/2 atomic pairs (pair k = rows 2k, 2k+1);
+the trainer (surogate/dpo/data.py packing → step_dpo_native) keeps both rows of a
+pair in the same optimizer step.
+
+Engine conventions (must match step_dpo_native / the dpo_dloss kernel):
+- targets[j] = input_ids[j+1]; targets[last] = 0 (unused, masked).
+- loss_mask[j] = 1 iff position j holds a scored response token. The logprob of
+  token j is read from losses[j-1] (shifted layout), so the FIRST response token
+  (position = prompt_len) and the LAST response token are both scored.
+- position_ids restart at 0 per row; padding uses position 0 and loss_mask 0.
+  Right padding + causal attention means padding never affects real-token logits.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class PrefBatch:
+    """Tokenized preference pairs, one sequence per row (chosen=2k, rejected=2k+1)."""
+
+    max_len: int
+    n_pairs: int
+    input_ids: np.ndarray  # int32 [2*n_pairs, max_len]
+    targets: np.ndarray  # int32 [2*n_pairs, max_len]
+    loss_mask: np.ndarray  # uint8 [2*n_pairs, max_len]
+    position_ids: np.ndarray  # int32 [2*n_pairs, max_len]
+    seq_len: np.ndarray  # int32 [2*n_pairs] real (unpadded) length per row
+
+    @property
+    def n_seq(self) -> int:
+        return int(self.input_ids.shape[0])
+
+
+def _render(tok, prompt: Any, response: str) -> tuple[list[int], list[int]]:
+    """Return (prompt_ids, response_ids). `prompt` is a string or a messages list."""
+    if isinstance(prompt, list):
+        prompt_ids = tok.apply_chat_template(prompt, add_generation_prompt=True, tokenize=True)
+    else:
+        prompt_ids = tok(prompt, add_special_tokens=True)["input_ids"]
+    response_ids = tok(response, add_special_tokens=False)["input_ids"]
+    return list(prompt_ids), list(response_ids)
+
+
+def _layout_sequence(prompt_ids: list[int], response_ids: list[int], max_len: int, pad_id: int):
+    """Left-truncate the prompt so the response is preserved; return (ids, prompt_len)
+    or None if no response token survives."""
+    ids = prompt_ids + response_ids
+    prompt_len = len(prompt_ids)
+    if len(ids) > max_len:
+        drop = len(ids) - max_len
+        ids = ids[drop:]
+        prompt_len = max(0, prompt_len - drop)
+    if prompt_len >= len(ids):  # response fully truncated away
+        return None
+    return ids, prompt_len
+
+
+def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int | None = None) -> PrefBatch:
+    """Tokenize {prompt, chosen, rejected} rows into a one-sequence-per-row PrefBatch.
+
+    Rows whose prompt+response cannot fit a single response token in `max_len`
+    are dropped (logged). Raises ValueError if no pair survives.
+    """
+    if pad_id is None:
+        pad_id = tok.pad_token_id
+        if pad_id is None:
+            pad_id = tok.eos_token_id
+        if pad_id is None:
+            raise ValueError("tokenizer has neither pad_token_id nor eos_token_id; pass pad_id explicitly")
+
+    seqs: list[tuple[list[int], int]] = []  # (ids, prompt_len), chosen then rejected per kept pair
+    dropped = 0
+    for row in rows:
+        prompt = row["prompt"]
+        laid = []
+        for key in ("chosen", "rejected"):
+            p_ids, r_ids = _render(tok, prompt, row[key])
+            res = _layout_sequence(p_ids, r_ids, max_len, pad_id)
+            if res is None:
+                laid = []
+                break
+            laid.append(res)
+        if len(laid) != 2:
+            dropped += 1
+            continue
+        seqs.extend(laid)
+
+    n_pairs = len(seqs) // 2
+    if n_pairs == 0:
+        raise ValueError("tokenize_preference_pairs: no preference pair fit in max_len")
+    if dropped:
+        logger.warning("tokenize_preference_pairs: dropped %d row(s) that did not fit max_len=%d", dropped, max_len)
+
+    n_seq = 2 * n_pairs
+    input_ids = np.full((n_seq, max_len), pad_id, dtype=np.int32)
+    targets = np.zeros((n_seq, max_len), dtype=np.int32)
+    loss_mask = np.zeros((n_seq, max_len), dtype=np.uint8)
+    position_ids = np.zeros((n_seq, max_len), dtype=np.int32)
+    seq_len = np.zeros((n_seq,), dtype=np.int32)
+
+    for k, (ids, prompt_len) in enumerate(seqs):
+        L = len(ids)
+        input_ids[k, :L] = ids
+        # targets[j] = ids[j+1]; targets[L-1..] stay 0 (unused / masked).
+        if L >= 2:
+            targets[k, : L - 1] = ids[1:L]
+        loss_mask[k, prompt_len:L] = 1  # response tokens (incl. the last) are scored
+        position_ids[k, :L] = np.arange(L, dtype=np.int32)
+        seq_len[k] = L
+
+    return PrefBatch(
+        max_len=max_len,
+        n_pairs=n_pairs,
+        input_ids=input_ids,
+        targets=targets,
+        loss_mask=loss_mask,
+        position_ids=position_ids,
+        seq_len=seq_len,
+    )

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -41,6 +41,7 @@ class PrefBatch:
     loss_mask: np.ndarray  # uint8 [2*n_pairs, max_len]
     position_ids: np.ndarray  # int32 [2*n_pairs, max_len]
     seq_len: np.ndarray  # int32 [2*n_pairs] real (unpadded) length per row
+    ref: np.ndarray | None = None  # float32 [2*n_pairs, max_len] reference logprobs (filled by precompute)
 
     @property
     def n_seq(self) -> int:
@@ -172,13 +173,16 @@ def sidecar_hash(
 
 
 def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int) -> np.ndarray:
-    """Reference per-token log-probs (LoRA disabled => the start checkpoint) for
-    every sequence, in the shifted layout (ref[k, j] = logprob of token j+1).
+    """Reference per-token log-probs of the frozen start checkpoint, in the shifted
+    layout (ref[k, j] = logprob of token j+1).
 
-    `trainer` is a low-level `_surogate.SurogateTrainer` exposing
-    `compute_logprobs(input_ids, targets, use_lora, position_ids)`. Rows are fed in
-    fixed [engine_b, max_len] chunks (the engine's static batch shape); a short
-    final chunk is padded and its extra rows discarded.
+    Uses `trainer.forward_for_grpo` (the regular training forward, which — unlike
+    `compute_logprobs`'s forward-only path — is correct for the Qwen3.5 gated
+    DeltaNet ops). It must be called BEFORE any optimizer step: LoRA B is
+    zero-initialised, so at init the adapter contributes nothing and the forward
+    equals the start checkpoint = π_ref. Rows are fed in fixed [engine_b, max_len]
+    chunks (the engine's static batch shape); a short final chunk is padded and its
+    extra rows discarded.
     """
     n_seq, max_len = batch.input_ids.shape
     ref = np.zeros((n_seq, max_len), dtype=np.float32)
@@ -191,7 +195,7 @@ def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int) -> np.ndar
         ids[:rows] = batch.input_ids[start:end]
         tgt[:rows] = batch.targets[start:end]
         pos[:rows] = batch.position_ids[start:end]
-        out = trainer.compute_logprobs(ids, tgt, use_lora=False, position_ids=pos)
+        out = trainer.forward_for_grpo(ids, tgt, position_ids=pos)
         ref[start:end] = np.asarray(out, dtype=np.float32)[:rows]
     return ref
 

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -18,6 +18,8 @@ Engine conventions (must match step_dpo_native / the dpo_dloss kernel):
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -131,3 +133,86 @@ def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int |
         position_ids=position_ids,
         seq_len=seq_len,
     )
+
+
+# --- Reference log-prob precompute + sidecar cache --------------------------
+# DPO needs the frozen start model's per-token log-probs for both chosen and
+# rejected. They depend only on (start model, tokenization layout), so we compute
+# them ONCE and cache to a sidecar. The cache key must change whenever anything
+# upstream changes (model, max_len, prompt rendering, or the rows themselves) so a
+# stale sidecar can never silently feed wrong references into training.
+
+RENDER_VERSION = 1  # bump if _render / _layout_sequence semantics change
+
+
+def rows_digest(rows: list[dict]) -> str:
+    """Stable digest of the preference rows (order-sensitive)."""
+    h = hashlib.sha256()
+    for r in rows:
+        h.update(
+            json.dumps(
+                [r.get("prompt"), r.get("chosen"), r.get("rejected")], ensure_ascii=False, sort_keys=True
+            ).encode("utf-8")
+        )
+    return h.hexdigest()[:16]
+
+
+def sidecar_hash(
+    *, model: str, max_len: int, n_rows: int, rows_digest: str = "", render_version: int = RENDER_VERSION
+) -> str:
+    """Cache key for a reference-logprob sidecar."""
+    payload = {
+        "model": model,
+        "max_len": max_len,
+        "n_rows": n_rows,
+        "rows_digest": rows_digest,
+        "render_version": render_version,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+
+
+def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int) -> np.ndarray:
+    """Reference per-token log-probs (LoRA disabled => the start checkpoint) for
+    every sequence, in the shifted layout (ref[k, j] = logprob of token j+1).
+
+    `trainer` is a low-level `_surogate.SurogateTrainer` exposing
+    `compute_logprobs(input_ids, targets, use_lora, position_ids)`. Rows are fed in
+    fixed [engine_b, max_len] chunks (the engine's static batch shape); a short
+    final chunk is padded and its extra rows discarded.
+    """
+    n_seq, max_len = batch.input_ids.shape
+    ref = np.zeros((n_seq, max_len), dtype=np.float32)
+    for start in range(0, n_seq, engine_b):
+        end = min(start + engine_b, n_seq)
+        rows = end - start
+        ids = np.zeros((engine_b, max_len), dtype=np.int32)
+        tgt = np.zeros((engine_b, max_len), dtype=np.int32)
+        pos = np.zeros((engine_b, max_len), dtype=np.int32)
+        ids[:rows] = batch.input_ids[start:end]
+        tgt[:rows] = batch.targets[start:end]
+        pos[:rows] = batch.position_ids[start:end]
+        out = trainer.compute_logprobs(ids, tgt, use_lora=False, position_ids=pos)
+        ref[start:end] = np.asarray(out, dtype=np.float32)[:rows]
+    return ref
+
+
+def save_ref_sidecar(path: str, key: str, ref: np.ndarray) -> None:
+    np.savez(path, key=np.array(key), ref=ref.astype(np.float32))
+
+
+def load_ref_sidecar(path: str, expected_key: str) -> np.ndarray | None:
+    """Return cached reference logprobs if the sidecar matches `expected_key`,
+    else None (caller recomputes). Returns None on any read error."""
+    import os
+
+    if not os.path.exists(path):
+        return None
+    try:
+        data = np.load(path, allow_pickle=False)
+        if str(data["key"]) != expected_key:
+            logger.warning("DPO ref sidecar key mismatch (%s); recomputing", path)
+            return None
+        return data["ref"]
+    except (OSError, ValueError, KeyError) as exc:
+        logger.warning("DPO ref sidecar unreadable (%s: %s); recomputing", path, exc)
+        return None

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -176,12 +176,18 @@ def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int, host_rows:
     """Reference per-token log-probs of the frozen start checkpoint, in the shifted
     layout (ref[k, j] = logprob of token j+1).
 
+    WARNING — batch-invariant recipes only (e.g. bf16). NOT used by the DPO trainer,
+    which computes the reference INLINE per micro-step (see surogate/dpo/trainer.py).
+    Offline precompute is INCORRECT under fp8-hybrid: fp8 derives the activation scale
+    from the current batch's amax, so these fixed sequential chunks scale each pair
+    differently from the training loop's reshuffled batches → a spurious nonzero margin
+    at init. Kept only for batch-invariant (bf16) experiments / debugging.
+
     Uses `trainer.compute_ref_logprobs_dpo` — the SAME fused-loss forward that
-    `step_dpo_native` runs (fp8- and multi-GPU-safe), with no backward. It must be
-    called BEFORE any optimizer step: LoRA B is zero-initialised, so at init the
-    adapter contributes nothing and the forward equals the start checkpoint = π_ref.
-    Rows are fed in fixed `[host_rows * engine_b, max_len]` chunks (one B-block per
-    data-parallel rank); a short final chunk is padded and its extra rows discarded.
+    `step_dpo_native` runs, with no backward. Must be called BEFORE any optimizer step:
+    LoRA B is zero-initialised, so at init the adapter contributes nothing and the
+    forward equals the start checkpoint = π_ref. Rows are fed in fixed
+    `[host_rows * engine_b, max_len]` chunks (one B-block per data-parallel rank).
     """
     n_seq, max_len = batch.input_ids.shape
     chunk = engine_b * max(1, host_rows)

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -172,30 +172,30 @@ def sidecar_hash(
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:16]
 
 
-def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int) -> np.ndarray:
+def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int, host_rows: int = 1) -> np.ndarray:
     """Reference per-token log-probs of the frozen start checkpoint, in the shifted
     layout (ref[k, j] = logprob of token j+1).
 
-    Uses `trainer.forward_for_grpo` (the regular training forward, which — unlike
-    `compute_logprobs`'s forward-only path — is correct for the Qwen3.5 gated
-    DeltaNet ops). It must be called BEFORE any optimizer step: LoRA B is
-    zero-initialised, so at init the adapter contributes nothing and the forward
-    equals the start checkpoint = π_ref. Rows are fed in fixed [engine_b, max_len]
-    chunks (the engine's static batch shape); a short final chunk is padded and its
-    extra rows discarded.
+    Uses `trainer.compute_ref_logprobs_dpo` — the SAME fused-loss forward that
+    `step_dpo_native` runs (fp8- and multi-GPU-safe), with no backward. It must be
+    called BEFORE any optimizer step: LoRA B is zero-initialised, so at init the
+    adapter contributes nothing and the forward equals the start checkpoint = π_ref.
+    Rows are fed in fixed `[host_rows * engine_b, max_len]` chunks (one B-block per
+    data-parallel rank); a short final chunk is padded and its extra rows discarded.
     """
     n_seq, max_len = batch.input_ids.shape
+    chunk = engine_b * max(1, host_rows)
     ref = np.zeros((n_seq, max_len), dtype=np.float32)
-    for start in range(0, n_seq, engine_b):
-        end = min(start + engine_b, n_seq)
+    for start in range(0, n_seq, chunk):
+        end = min(start + chunk, n_seq)
         rows = end - start
-        ids = np.zeros((engine_b, max_len), dtype=np.int32)
-        tgt = np.zeros((engine_b, max_len), dtype=np.int32)
-        pos = np.zeros((engine_b, max_len), dtype=np.int32)
+        ids = np.zeros((chunk, max_len), dtype=np.int32)
+        tgt = np.zeros((chunk, max_len), dtype=np.int32)
+        pos = np.zeros((chunk, max_len), dtype=np.int32)
         ids[:rows] = batch.input_ids[start:end]
         tgt[:rows] = batch.targets[start:end]
         pos[:rows] = batch.position_ids[start:end]
-        out = trainer.forward_for_grpo(ids, tgt, position_ids=pos)
+        out = trainer.compute_ref_logprobs_dpo(ids, tgt, position_ids=pos)
         ref[start:end] = np.asarray(out, dtype=np.float32)[:rows]
     return ref
 

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -72,11 +72,40 @@ def _layout_sequence(prompt_ids: list[int], response_ids: list[int], max_len: in
     return ids, prompt_len
 
 
-def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int | None = None) -> PrefBatch:
+def _diff_span(chosen_ids: list[int], rejected_ids: list[int]) -> tuple[int, int, int, int] | None:
+    """Longest-common-prefix/suffix diff of two token lists.
+
+    Returns (c_start, c_end, r_start, r_end) — the half-open differing spans in
+    each list — or None if the lists are identical. The common suffix is bounded
+    so the spans never underrun the prefix (all-diff worst case keeps full spans).
+    """
+    if chosen_ids == rejected_ids:
+        return None
+    lcp = 0
+    for a, b in zip(chosen_ids, rejected_ids):
+        if a != b:
+            break
+        lcp += 1
+    lcs = 0
+    max_lcs = min(len(chosen_ids), len(rejected_ids)) - lcp
+    while lcs < max_lcs and chosen_ids[-1 - lcs] == rejected_ids[-1 - lcs]:
+        lcs += 1
+    return lcp, len(chosen_ids) - lcs, lcp, len(rejected_ids) - lcs
+
+
+def tokenize_preference_pairs(
+    rows: list[dict], tok, max_len: int, pad_id: int | None = None, span_mask: bool = False
+) -> PrefBatch:
     """Tokenize {prompt, chosen, rejected} rows into a one-sequence-per-row PrefBatch.
 
     Rows whose prompt+response cannot fit a single response token in `max_len`
     are dropped (logged). Raises ValueError if no pair survives.
+
+    span_mask=True confines loss_mask to the tokens where chosen and rejected
+    DIFFER (common prefix and suffix excluded). For minimal word-substitution
+    pairs this makes the DPO gradient structurally unable to shift style,
+    length, or language of the surrounding text — only the substituted form is
+    scored. Identical-tokenization rows are dropped (no contrastive signal).
     """
     if pad_id is None:
         pad_id = tok.pad_token_id
@@ -86,10 +115,13 @@ def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int |
             raise ValueError("tokenizer has neither pad_token_id nor eos_token_id; pass pad_id explicitly")
 
     seqs: list[tuple[list[int], int]] = []  # (ids, prompt_len), chosen then rejected per kept pair
+    spans: list[tuple[int, int] | None] = []  # per-sequence (start, end) into the RESPONSE, or None = all
     dropped = 0
+    dropped_identical = 0
     for row in rows:
         prompt = row["prompt"]
         laid = []
+        resp_ids = []
         for key in ("chosen", "rejected"):
             p_ids, r_ids = _render(tok, prompt, row[key])
             res = _layout_sequence(p_ids, r_ids, max_len, pad_id)
@@ -97,9 +129,30 @@ def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int |
                 laid = []
                 break
             laid.append(res)
+            resp_ids.append(r_ids)
         if len(laid) != 2:
             dropped += 1
             continue
+        if span_mask:
+            d = _diff_span(resp_ids[0], resp_ids[1])
+            if d is None:
+                dropped_identical += 1
+                continue
+            # Adjust spans for any response-head tokens lost to left-truncation.
+            adj = []
+            for (ids, p_len), r_full, (s, e) in zip(laid, resp_ids, [d[:2], d[2:]]):
+                head_dropped = len(r_full) - (len(ids) - p_len)
+                s2, e2 = max(0, s - head_dropped), e - head_dropped
+                if e2 <= s2:  # differing span truncated away — no contrastive signal
+                    adj = []
+                    break
+                adj.append((s2, e2))
+            if len(adj) != 2:
+                dropped += 1
+                continue
+            spans.extend(adj)
+        else:
+            spans.extend([None, None])
         seqs.extend(laid)
 
     n_pairs = len(seqs) // 2
@@ -107,6 +160,12 @@ def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int |
         raise ValueError("tokenize_preference_pairs: no preference pair fit in max_len")
     if dropped:
         logger.warning("tokenize_preference_pairs: dropped %d row(s) that did not fit max_len=%d", dropped, max_len)
+    if dropped_identical:
+        logger.warning(
+            "tokenize_preference_pairs: dropped %d row(s) with identical chosen/rejected tokenization "
+            "(span_mask needs a differing span)",
+            dropped_identical,
+        )
 
     n_seq = 2 * n_pairs
     input_ids = np.full((n_seq, max_len), pad_id, dtype=np.int32)
@@ -121,7 +180,13 @@ def tokenize_preference_pairs(rows: list[dict], tok, max_len: int, pad_id: int |
         # targets[j] = ids[j+1]; targets[L-1..] stay 0 (unused / masked).
         if L >= 2:
             targets[k, : L - 1] = ids[1:L]
-        loss_mask[k, prompt_len:L] = 1  # response tokens (incl. the last) are scored
+        span = spans[k]
+        if span is None:
+            loss_mask[k, prompt_len:L] = 1  # response tokens (incl. the last) are scored
+        else:
+            a = min(prompt_len + span[0], L - 1)
+            b = min(prompt_len + span[1], L)
+            loss_mask[k, a : max(b, a + 1)] = 1  # only the differing span is scored
         position_ids[k, :L] = np.arange(L, dtype=np.int32)
         seq_len[k] = L
 

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -136,7 +136,7 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     ref = load_ref_sidecar(sidecar_path, key)
     if ref is None or ref.shape[0] != batch.n_seq:
         logger.info("Precomputing reference logprobs (LoRA disabled)...")
-        ref = precompute_ref_logprobs(trainer, batch, engine_b=B)
+        ref = precompute_ref_logprobs(trainer, batch, engine_b=B, host_rows=ngpu)
         save_ref_sidecar(sidecar_path, key, ref)
         logger.info(f"Reference logprobs cached -> {sidecar_path}")
     else:

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -1,0 +1,270 @@
+"""Offline DPO trainer.
+
+Static (prompt, chosen, rejected) pairs are tokenized one sequence per row
+(surogate/dpo/data.py); a reference forward of the frozen start checkpoint
+(LoRA disabled) is precomputed once and cached. Each optimizer step runs
+`grad_accum` micro-steps; each micro-step feeds `ngpu` host rows (distinct pairs
+per GPU = data-parallel sharding), every host row holding B sequences = B/2
+atomic pairs. step_dpo_native computes the sigmoid-DPO gradient natively and
+backpropagates; the optimizer then updates the LoRA adapter.
+
+No rollouts, no inference engine — purely offline.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+
+from surogate import _surogate
+from surogate.dpo.config import DPOTrainConfig
+from surogate.dpo.data import (
+    load_ref_sidecar,
+    precompute_ref_logprobs,
+    rows_digest,
+    save_ref_sidecar,
+    sidecar_hash,
+    tokenize_preference_pairs,
+)
+from surogate.train.lr_schedule import LRSchedule
+from surogate.utils.hf import get_model_weights_path
+from surogate.utils.logger import get_logger
+from surogate.utils.tensor import to_surogate_dtype
+
+logger = get_logger()
+
+
+def _load_pref_rows(path: str) -> list[dict]:
+    rows = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            if "prompt" in r and "chosen" in r and "rejected" in r:
+                rows.append({"prompt": r["prompt"], "chosen": r["chosen"], "rejected": r["rejected"]})
+    if not rows:
+        raise ValueError(f"no {{prompt, chosen, rejected}} rows in {path}")
+    return rows
+
+
+def _gpu_batch(pair_idx: list[int], batch, T: int):
+    """Build one GPU's micro-batch from a list of pair indices (each pair = 2 rows).
+
+    Returns flat per-token arrays of length len(pair_idx)*2*T and the sample/pair
+    index arrays (token offsets into this GPU's [0, B*T) buffer).
+    """
+    seq_rows = []
+    for p in pair_idx:
+        seq_rows.append(2 * p)  # chosen
+        seq_rows.append(2 * p + 1)  # rejected
+    B = len(seq_rows)
+    input_ids = batch.input_ids[seq_rows]  # [B, T]
+    targets = batch.targets[seq_rows]
+    position_ids = batch.position_ids[seq_rows]
+    loss_mask = batch.loss_mask[seq_rows].reshape(-1)  # [B*T]
+    ref = batch.ref[seq_rows].reshape(-1)  # [B*T]
+    sample_starts = np.array([i * T for i in range(B)], dtype=np.int32)
+    sample_ends = np.array([i * T + int(batch.seq_len[seq_rows[i]]) for i in range(B)], dtype=np.int32)
+    pair_chosen = np.array([2 * k for k in range(len(pair_idx))], dtype=np.int32)
+    pair_rejected = np.array([2 * k + 1 for k in range(len(pair_idx))], dtype=np.int32)
+    return {
+        "input_ids": input_ids.astype(np.int32),
+        "targets": targets.astype(np.int32),
+        "position_ids": position_ids.astype(np.int32),
+        "loss_mask": loss_mask.astype(np.uint8),
+        "ref": ref.astype(np.float32),
+        "sample_starts": sample_starts,
+        "sample_ends": sample_ends,
+        "pair_chosen": pair_chosen,
+        "pair_rejected": pair_rejected,
+    }
+
+
+def dpo_main(config: DPOTrainConfig, args=None) -> None:
+    ngpu = max(1, int(config.gpus or 1))
+    B = int(config.per_device_train_batch_size)
+    T = int(config.sequence_len)
+    if B % 2 != 0:
+        raise ValueError(f"per_device_train_batch_size must be even (pairs are 2 rows); got {B}")
+    pairs_per_gpu = B // 2
+
+    # --- compile the DSL IR + JIT kernels (mirrors SurogateTrainerWrapper) ---
+    from surogate.dsl.ir_builder import build_dsl_ir_for_model
+
+    dsl_extra = {}
+    if getattr(config, "ep_size", 1) > 1:
+        dsl_extra["ep_size"] = config.ep_size
+    ir_json = build_dsl_ir_for_model(config.model_dir, extra_config=dsl_extra or None)
+    config.runtime_config.dsl_ir_json = ir_json
+
+    from surogate.kernels.jit_compile import compile_jit_kernels
+
+    jit_manifests = compile_jit_kernels(ir_json)
+    if jit_manifests:
+        config.runtime_config.jit_kernel_manifests = jit_manifests
+
+    # --- build trainer + import start weights -------------------------------
+    logger.info(f"Creating DPO trainer for {config.model} ({ngpu} GPU(s), B={B}, T={T})")
+    trainer = _surogate.SurogateTrainer(
+        ngpu=ngpu,
+        config=_surogate.PretrainedConfig.from_pretrained(config.model_dir, to_surogate_dtype(config.torch_dtype)),
+        options=config.runtime_config,
+        batch_size=B,
+        seq_len=T,
+        grad_accum=1,  # set dynamically per optimizer step
+        memcpy_all_gather=config.memcpy_all_gather,
+        memcpy_send_recv=config.memcpy_send_recv,
+        lora_config=config.lora_config,
+        qlora_config=config.qlora_config,
+    )
+    model_weights_path = get_model_weights_path(config.model_dir)
+    logger.info(f"Importing start weights from {model_weights_path}")
+    trainer.import_weights(model_weights_path)
+
+    # --- tokenize preference pairs -----------------------------------------
+    rows = _load_pref_rows(config.datasets[0].path)
+    batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T)
+    logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
+
+    # --- reference logprobs (frozen start model), cached in a sidecar -------
+    sidecar_path = str(Path(config.output_dir) / "ref_logprobs.npz")
+    Path(config.output_dir).mkdir(parents=True, exist_ok=True)
+    key = sidecar_hash(model=config.model_dir, max_len=T, n_rows=len(rows), rows_digest=rows_digest(rows))
+    ref = load_ref_sidecar(sidecar_path, key)
+    if ref is None or ref.shape[0] != batch.n_seq:
+        logger.info("Precomputing reference logprobs (LoRA disabled)...")
+        ref = precompute_ref_logprobs(trainer, batch, engine_b=B)
+        save_ref_sidecar(sidecar_path, key, ref)
+        logger.info(f"Reference logprobs cached -> {sidecar_path}")
+    else:
+        logger.info(f"Loaded cached reference logprobs <- {sidecar_path}")
+    batch.ref = ref  # attach for _gpu_batch
+
+    # --- schedule ----------------------------------------------------------
+    pairs_per_step = pairs_per_gpu * ngpu * int(config.gradient_accumulation_steps)
+    if config.max_steps and config.max_steps > 0:
+        max_steps = int(config.max_steps)
+    else:
+        epochs = max(1, int(config.num_epochs or 1))
+        max_steps = max(1, (batch.n_pairs * epochs) // pairs_per_step)
+    warmup = config.warmup_steps or (int(max_steps * config.warmup_ratio) if config.warmup_ratio else 0)
+    lr_schedule = LRSchedule(
+        base_lr=config.learning_rate,
+        max_steps=max_steps,
+        warmup_steps=warmup,
+        cooldown_steps=config.cooldown_steps,
+        final_lr=config.learning_rate * config.final_lr_fraction,
+        schedule_type=config.lr_scheduler_type,
+        wsd_decay_steps_fraction=config.wsd_decay_steps_fraction,
+    )
+    checkpoint_dir = config.checkpoint_dir or str(Path(config.output_dir))
+
+    # --- infinite shuffled pair stream -------------------------------------
+    rng = np.random.RandomState(config.train_seed if config.train_seed is not None else 0)
+
+    def pair_stream():
+        while True:
+            order = rng.permutation(batch.n_pairs)
+            for p in order:
+                yield int(p)
+
+    stream = pair_stream()
+
+    def next_pairs(n: int) -> list[int]:
+        return [next(stream) for _ in range(n)]
+
+    metrics_path = config.surogate_metrics_path
+    logger.info(
+        f"DPO training: {max_steps} steps x {pairs_per_step} pairs/step "
+        f"(grad_accum={config.gradient_accumulation_steps}, beta={config.loss.dpo_beta}, "
+        f"length_norm={config.loss.length_norm})"
+    )
+
+    for step in range(max_steps):
+        t0 = time.time()
+        trainer.set_grad_accumulation(int(config.gradient_accumulation_steps))
+        # one optimizer step normalizes by the mean over its pairs; gradients are
+        # AVG-allreduced across GPUs, so compensate the per-GPU average back to a
+        # global sum (/ ngpu), matching the native GRPO convention.
+        effective_loss_scale = float(pairs_per_step) / float(ngpu)
+
+        for _ in range(int(config.gradient_accumulation_steps)):
+            gpu_batches = [_gpu_batch(next_pairs(pairs_per_gpu), batch, T) for _ in range(ngpu)]
+            input_step = np.concatenate([gb["input_ids"] for gb in gpu_batches], axis=0)  # [ngpu*B, T]
+            pos_step = np.concatenate([gb["position_ids"] for gb in gpu_batches], axis=0)
+            targets_step = np.concatenate([gb["targets"] for gb in gpu_batches], axis=0)
+
+            if ngpu > 1:
+                ref_step = np.stack([gb["ref"] for gb in gpu_batches])  # [ngpu, B*T]
+                loss_mask_step = np.stack([gb["loss_mask"] for gb in gpu_batches])
+                sample_starts = np.stack([gb["sample_starts"] for gb in gpu_batches])  # [ngpu, B]
+                sample_ends = np.stack([gb["sample_ends"] for gb in gpu_batches])
+                pair_chosen = np.stack([gb["pair_chosen"] for gb in gpu_batches])  # [ngpu, B/2]
+                pair_rejected = np.stack([gb["pair_rejected"] for gb in gpu_batches])
+            else:
+                gb = gpu_batches[0]
+                ref_step = gb["ref"]
+                loss_mask_step = gb["loss_mask"]
+                sample_starts = gb["sample_starts"]
+                sample_ends = gb["sample_ends"]
+                pair_chosen = gb["pair_chosen"]
+                pair_rejected = gb["pair_rejected"]
+
+            trainer.step_dpo_native(
+                input_step,
+                targets_step,
+                ref_step,
+                loss_mask_step,
+                sample_starts,
+                sample_ends,
+                pair_chosen,
+                pair_rejected,
+                position_ids=pos_step,
+                loss_scale=effective_loss_scale,
+                beta=float(config.loss.dpo_beta),
+                length_norm=1 if config.loss.length_norm else 0,
+            )
+
+        lr = lr_schedule.get_lr(step)
+        opt_config = _surogate.OptimizerConfig(
+            optimizer=config.optimizer,
+            learning_rate=lr,
+            weight_decay=config.weight_decay,
+            grad_clip=config.max_grad_norm,
+            adamw_beta1=config.adamw_beta1,
+            adamw_beta2=config.adamw_beta2,
+            adamw_epsilon=config.adamw_epsilon,
+        )
+        result = trainer.update_with_config(opt_config, step + 1)
+        m = dict(trainer.get_dpo_native_metrics())
+        dt = time.time() - t0
+
+        if step % max(1, config.logging_steps) == 0:
+            logger.info(
+                f"step={step} dpo_loss={m.get('dpo_loss', 0):.4f} acc={m.get('dpo_accuracy', 0):.3f} "
+                f"margin={m.get('dpo_margin', 0):.4f} grad_norm={result['norm']:.4f} lr={lr:.2e} "
+                f"pairs={int(m.get('dpo_pairs', 0))} {dt * 1000:.0f}ms"
+            )
+            if metrics_path:
+                try:  # metrics logging must never kill training
+                    Path(metrics_path).parent.mkdir(parents=True, exist_ok=True)
+                    with open(metrics_path, "a", encoding="utf-8") as mf:
+                        mf.write(json.dumps({"step": step, "lr": lr, "grad_norm": result["norm"], **m}) + "\n")
+                except OSError as exc:
+                    logger.warning("could not write DPO metrics to %s: %s", metrics_path, exc)
+
+        if config.save_steps > 0 and step > 0 and step % config.save_steps == 0:
+            logger.info(f"Saving checkpoint at step {step}...")
+            trainer.save_checkpoint(checkpoint_dir, step)
+
+    # --- final adapter ------------------------------------------------------
+    out = Path(config.output_dir)
+    if config.lora:
+        adapter_dir = out / "final_adapter"
+        adapter_dir.mkdir(parents=True, exist_ok=True)
+        trainer.export_adapter(str(adapter_dir))
+        logger.info(f"Final LoRA adapter saved to {adapter_dir}")
+    logger.info("DPO training complete.")

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -18,9 +18,15 @@ share the identical scale, so at init the margin is exactly 0 (loss = log 2) und
 fp8 and bf16 alike. Cost: one extra (no-backward) forward per micro-step.
 
 No rollouts, no inference engine — purely offline.
+
+For local-contrast training, ``reference_free`` skips the frozen-policy
+forward and optimizes the chosen-vs-rejected likelihood gap directly.
+``target_margin`` applies a SimPO-style minimum margin.
 """
 
 import json
+import shutil
+import tempfile
 import time
 from pathlib import Path
 
@@ -32,6 +38,7 @@ from surogate.dpo.data import tokenize_preference_pairs
 from surogate.train.lr_schedule import LRSchedule
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
+from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
 from surogate.utils.tensor import to_surogate_dtype
 
 logger = get_logger()
@@ -46,9 +53,22 @@ def _load_pref_rows(path: str) -> list[dict]:
                 continue
             r = json.loads(line)
             if "prompt" in r and "chosen" in r and "rejected" in r:
-                rows.append({"prompt": r["prompt"], "chosen": r["chosen"], "rejected": r["rejected"]})
+                row = {"prompt": r["prompt"], "chosen": r["chosen"], "rejected": r["rejected"]}
+                if "enable_thinking" in r:
+                    row["enable_thinking"] = r["enable_thinking"]
+                rows.append(row)
     if not rows:
         raise ValueError(f"no {{prompt, chosen, rejected}} rows in {path}")
+    return rows
+
+
+def _load_pref_datasets(paths: list[str]) -> list[dict]:
+    """Load configured preference shards in declaration order."""
+    if not paths:
+        raise ValueError("DPO requires at least one preference dataset")
+    rows = []
+    for path in paths:
+        rows.extend(_load_pref_rows(path))
     return rows
 
 
@@ -83,6 +103,40 @@ def _gpu_batch(pair_idx: list[int], batch, T: int):
     }
 
 
+def _reference_free_logprobs(
+    gpu_batches: list[dict],
+    B: int,
+    T: int,
+    beta: float,
+    target_margin: float,
+    length_norm: bool,
+) -> np.ndarray:
+    """Build synthetic references for direct likelihood-gap optimization.
+
+    The native kernel subtracts the chosen reference sum (or mean) from the
+    beta-scaled policy gap. Distribute the requested offset across chosen
+    tokens in sum mode so the effective target does not grow with edit length.
+    """
+    refs = np.zeros((len(gpu_batches) * B, T), dtype=np.float32)
+    if target_margin == 0:
+        return refs
+    for gpu_index, gpu_batch in enumerate(gpu_batches):
+        mask = gpu_batch["loss_mask"].reshape(B, T)
+        for sample_index in gpu_batch["pair_chosen"]:
+            sample_index = int(sample_index)
+            token_positions = np.flatnonzero(mask[sample_index])
+            # The native loss reads ref_logprobs[t - 1] for loss_mask[t].
+            token_positions = token_positions[token_positions > 0] - 1
+            if not len(token_positions):
+                continue
+            offset = float(target_margin) / float(beta)
+            if not length_norm:
+                offset /= len(token_positions)
+            row = gpu_index * B + sample_index
+            refs[row, token_positions] = offset
+    return refs
+
+
 def dpo_main(config: DPOTrainConfig, args=None) -> None:
     ngpu = max(1, int(config.gpus or 1))
     B = int(config.per_device_train_batch_size)
@@ -90,6 +144,7 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     if B % 2 != 0:
         raise ValueError(f"per_device_train_batch_size must be even (pairs are 2 rows); got {B}")
     pairs_per_gpu = B // 2
+    checkpoint_dir = config.checkpoint_dir or str(Path(config.output_dir))
 
     # --- compile the DSL IR + JIT kernels (mirrors SurogateTrainerWrapper) ---
     from surogate.dsl.ir_builder import build_dsl_ir_for_model
@@ -122,10 +177,35 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     )
     model_weights_path = get_model_weights_path(config.model_dir)
     logger.info(f"Importing start weights from {model_weights_path}")
-    trainer.import_weights(model_weights_path)
+    if config.adapter_path:
+        # Native import expects Surogate key paths, while an adapter previously
+        # prepared for vLLM may use the wrapper's language_model prefix. Work on
+        # a temporary copy so the user's source adapter is never mutated.
+        logger.info(f"Merging inherited adapter from {config.adapter_path} into start weights")
+        with tempfile.TemporaryDirectory(prefix="surogate-dpo-adapter-") as temporary_dir:
+            adapter_copy = Path(temporary_dir) / "adapter"
+            shutil.copytree(config.adapter_path, adapter_copy)
+            ensure_surogate_lora_compat(adapter_copy, config.model_dir)
+            trainer.set_adapter_path(str(adapter_copy))
+            trainer.import_weights(model_weights_path)
+    else:
+        trainer.import_weights(model_weights_path)
+
+    start_step = 0
+    if config.resume_from_checkpoint:
+        latest_step = _surogate.find_latest_checkpoint(checkpoint_dir)
+        if latest_step >= 0:
+            checkpoint_path = Path(checkpoint_dir) / f"step_{latest_step:08d}"
+            if config.lora:
+                ensure_surogate_lora_compat(checkpoint_path, config.model_dir)
+            logger.info(f"Resuming DPO from checkpoint step {latest_step}")
+            trainer.load_checkpoint(checkpoint_dir, latest_step)
+            start_step = latest_step
+        else:
+            logger.info("No DPO checkpoint found; starting from step 0")
 
     # --- tokenize preference pairs -----------------------------------------
-    rows = _load_pref_rows(config.datasets[0].path)
+    rows = _load_pref_datasets([dataset.path for dataset in (config.datasets or [])])
     batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T, span_mask=config.loss.span_mask)
     logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
     Path(config.output_dir).mkdir(parents=True, exist_ok=True)
@@ -150,8 +230,6 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
         schedule_type=config.lr_scheduler_type,
         wsd_decay_steps_fraction=config.wsd_decay_steps_fraction,
     )
-    checkpoint_dir = config.checkpoint_dir or str(Path(config.output_dir))
-
     # --- infinite shuffled pair stream -------------------------------------
     rng = np.random.RandomState(config.train_seed if config.train_seed is not None else 0)
 
@@ -163,6 +241,11 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
 
     stream = pair_stream()
 
+    # Checkpoints identify the next optimizer step. Replaying the deterministic
+    # pair stream restores the same data order as an uninterrupted run.
+    for _ in range(start_step * pairs_per_step):
+        next(stream)
+
     def next_pairs(n: int) -> list[int]:
         return [next(stream) for _ in range(n)]
 
@@ -170,10 +253,11 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     logger.info(
         f"DPO training: {max_steps} steps x {pairs_per_step} pairs/step "
         f"(grad_accum={config.gradient_accumulation_steps}, beta={config.loss.dpo_beta}, "
-        f"length_norm={config.loss.length_norm})"
+        f"length_norm={config.loss.length_norm}, reference_free={config.loss.reference_free}, "
+        f"target_margin={config.loss.target_margin})"
     )
 
-    for step in range(max_steps):
+    for step in range(start_step, max_steps):
         t0 = time.time()
         trainer.set_grad_accumulation(int(config.gradient_accumulation_steps))
         # one optimizer step normalizes by the mean over its pairs; gradients are
@@ -190,10 +274,20 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
             # Frozen reference (LoRA disabled) on the SAME rows/scale as the policy
             # forward below — fp8-correct (see module docstring). [ngpu*B, T] row order
             # matches input_step, so reshaping to [ngpu, B*T] aligns with the per-GPU layout.
-            ref_2d = np.asarray(
-                trainer.compute_ref_logprobs_dpo(input_step, targets_step, position_ids=pos_step),
-                dtype=np.float32,
-            )  # [ngpu*B, T]
+            if config.loss.reference_free:
+                ref_2d = _reference_free_logprobs(
+                    gpu_batches,
+                    B,
+                    T,
+                    beta=float(config.loss.dpo_beta),
+                    target_margin=float(config.loss.target_margin),
+                    length_norm=bool(config.loss.length_norm),
+                )
+            else:
+                ref_2d = np.asarray(
+                    trainer.compute_ref_logprobs_dpo(input_step, targets_step, position_ids=pos_step),
+                    dtype=np.float32,
+                )  # [ngpu*B, T]
 
             if ngpu > 1:
                 ref_step = ref_2d.reshape(ngpu, B * T)  # [ngpu, B*T]
@@ -254,9 +348,14 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
                 except OSError as exc:
                     logger.warning("could not write DPO metrics to %s: %s", metrics_path, exc)
 
-        if config.save_steps > 0 and step > 0 and step % config.save_steps == 0:
-            logger.info(f"Saving checkpoint at step {step}...")
-            trainer.save_checkpoint(checkpoint_dir, step)
+        completed_step = step + 1
+        if config.save_steps > 0 and completed_step % config.save_steps == 0:
+            logger.info(f"Saving checkpoint at step {completed_step}...")
+            trainer.save_checkpoint(checkpoint_dir, completed_step)
+            if config.save_total_limit and config.save_total_limit > 0:
+                removed = _surogate.clean_old_checkpoints(checkpoint_dir, config.save_total_limit, -1)
+                if removed:
+                    logger.info(f"Removed {removed} old checkpoints; keeping the newest {config.save_total_limit}")
 
     # --- final adapter ------------------------------------------------------
     out = Path(config.output_dir)
@@ -264,5 +363,6 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
         adapter_dir = out / "final_adapter"
         adapter_dir.mkdir(parents=True, exist_ok=True)
         trainer.export_adapter(str(adapter_dir))
+        ensure_vllm_lora_compat(adapter_dir, config.model_dir)
         logger.info(f"Final LoRA adapter saved to {adapter_dir}")
     logger.info("DPO training complete.")

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -1,12 +1,21 @@
 """Offline DPO trainer.
 
 Static (prompt, chosen, rejected) pairs are tokenized one sequence per row
-(surogate/dpo/data.py); a reference forward of the frozen start checkpoint
-(LoRA disabled) is precomputed once and cached. Each optimizer step runs
-`grad_accum` micro-steps; each micro-step feeds `ngpu` host rows (distinct pairs
-per GPU = data-parallel sharding), every host row holding B sequences = B/2
-atomic pairs. step_dpo_native computes the sigmoid-DPO gradient natively and
-backpropagates; the optimizer then updates the LoRA adapter.
+(surogate/dpo/data.py). Each optimizer step runs `grad_accum` micro-steps; each
+micro-step feeds `ngpu` host rows (distinct pairs per GPU = data-parallel
+sharding), every host row holding B sequences = B/2 atomic pairs. step_dpo_native
+computes the sigmoid-DPO gradient natively and backpropagates; the optimizer then
+updates the LoRA adapter.
+
+Reference log-probs (frozen start checkpoint, LoRA disabled) are computed INLINE
+per micro-step on the EXACT same rows as the policy forward, not precomputed
+offline. This is required for fp8: fp8-hybrid derives the activation scale from
+the current batch's amax, so a sequence's log-probs depend on its batch-mates. An
+offline pass (fixed sequential chunks) and the training loop (reshuffled batches)
+would scale the same pair differently → a spurious nonzero margin at init (where
+π_θ == π_ref). Computing the reference in the same micro-batch makes both forwards
+share the identical scale, so at init the margin is exactly 0 (loss = log 2) under
+fp8 and bf16 alike. Cost: one extra (no-backward) forward per micro-step.
 
 No rollouts, no inference engine — purely offline.
 """
@@ -19,14 +28,7 @@ import numpy as np
 
 from surogate import _surogate
 from surogate.dpo.config import DPOTrainConfig
-from surogate.dpo.data import (
-    load_ref_sidecar,
-    precompute_ref_logprobs,
-    rows_digest,
-    save_ref_sidecar,
-    sidecar_hash,
-    tokenize_preference_pairs,
-)
+from surogate.dpo.data import tokenize_preference_pairs
 from surogate.train.lr_schedule import LRSchedule
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
@@ -65,7 +67,6 @@ def _gpu_batch(pair_idx: list[int], batch, T: int):
     targets = batch.targets[seq_rows]
     position_ids = batch.position_ids[seq_rows]
     loss_mask = batch.loss_mask[seq_rows].reshape(-1)  # [B*T]
-    ref = batch.ref[seq_rows].reshape(-1)  # [B*T]
     sample_starts = np.array([i * T for i in range(B)], dtype=np.int32)
     sample_ends = np.array([i * T + int(batch.seq_len[seq_rows[i]]) for i in range(B)], dtype=np.int32)
     pair_chosen = np.array([2 * k for k in range(len(pair_idx))], dtype=np.int32)
@@ -75,7 +76,6 @@ def _gpu_batch(pair_idx: list[int], batch, T: int):
         "targets": targets.astype(np.int32),
         "position_ids": position_ids.astype(np.int32),
         "loss_mask": loss_mask.astype(np.uint8),
-        "ref": ref.astype(np.float32),
         "sample_starts": sample_starts,
         "sample_ends": sample_ends,
         "pair_chosen": pair_chosen,
@@ -128,20 +128,10 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     rows = _load_pref_rows(config.datasets[0].path)
     batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T)
     logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
-
-    # --- reference logprobs (frozen start model), cached in a sidecar -------
-    sidecar_path = str(Path(config.output_dir) / "ref_logprobs.npz")
     Path(config.output_dir).mkdir(parents=True, exist_ok=True)
-    key = sidecar_hash(model=config.model_dir, max_len=T, n_rows=len(rows), rows_digest=rows_digest(rows))
-    ref = load_ref_sidecar(sidecar_path, key)
-    if ref is None or ref.shape[0] != batch.n_seq:
-        logger.info("Precomputing reference logprobs (LoRA disabled)...")
-        ref = precompute_ref_logprobs(trainer, batch, engine_b=B, host_rows=ngpu)
-        save_ref_sidecar(sidecar_path, key, ref)
-        logger.info(f"Reference logprobs cached -> {sidecar_path}")
-    else:
-        logger.info(f"Loaded cached reference logprobs <- {sidecar_path}")
-    batch.ref = ref  # attach for _gpu_batch
+    # Reference log-probs are computed INLINE per micro-step (see module docstring):
+    # the frozen-ref forward must share the policy step's exact batch so fp8's
+    # current-batch activation scaling produces a matching scale (margin == 0 at init).
 
     # --- schedule ----------------------------------------------------------
     pairs_per_step = pairs_per_gpu * ngpu * int(config.gradient_accumulation_steps)
@@ -197,8 +187,16 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
             pos_step = np.concatenate([gb["position_ids"] for gb in gpu_batches], axis=0)
             targets_step = np.concatenate([gb["targets"] for gb in gpu_batches], axis=0)
 
+            # Frozen reference (LoRA disabled) on the SAME rows/scale as the policy
+            # forward below — fp8-correct (see module docstring). [ngpu*B, T] row order
+            # matches input_step, so reshaping to [ngpu, B*T] aligns with the per-GPU layout.
+            ref_2d = np.asarray(
+                trainer.compute_ref_logprobs_dpo(input_step, targets_step, position_ids=pos_step),
+                dtype=np.float32,
+            )  # [ngpu*B, T]
+
             if ngpu > 1:
-                ref_step = np.stack([gb["ref"] for gb in gpu_batches])  # [ngpu, B*T]
+                ref_step = ref_2d.reshape(ngpu, B * T)  # [ngpu, B*T]
                 loss_mask_step = np.stack([gb["loss_mask"] for gb in gpu_batches])
                 sample_starts = np.stack([gb["sample_starts"] for gb in gpu_batches])  # [ngpu, B]
                 sample_ends = np.stack([gb["sample_ends"] for gb in gpu_batches])
@@ -206,7 +204,7 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
                 pair_rejected = np.stack([gb["pair_rejected"] for gb in gpu_batches])
             else:
                 gb = gpu_batches[0]
-                ref_step = gb["ref"]
+                ref_step = ref_2d.reshape(B * T)
                 loss_mask_step = gb["loss_mask"]
                 sample_starts = gb["sample_starts"]
                 sample_ends = gb["sample_ends"]

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -126,7 +126,7 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
 
     # --- tokenize preference pairs -----------------------------------------
     rows = _load_pref_rows(config.datasets[0].path)
-    batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T)
+    batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T, span_mask=config.loss.span_mask)
     logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
     Path(config.output_dir).mkdir(parents=True, exist_ok=True)
     # Reference log-probs are computed INLINE per micro-step (see module docstring):

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -26,6 +26,7 @@ from surogate.train.lr_schedule import LRSchedule
 from surogate.train.metrics_writer import MetricsWriter
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
+from surogate.utils.lora_compat import ensure_vllm_lora_compat
 from surogate.utils.tensor import to_surogate_dtype
 
 logger = get_logger()
@@ -490,6 +491,7 @@ class GRPOTrainer:
             adapter_dir = output_path / "final_adapter"
             adapter_dir.mkdir(parents=True, exist_ok=True)
             self.trainer.export_adapter(str(adapter_dir))
+            ensure_vllm_lora_compat(adapter_dir, config.model_dir)
             logger.info(f"Final LoRA adapter saved to {adapter_dir}")
 
             if config.merge_adapter:

--- a/surogate/grpo/weight_broadcast.py
+++ b/surogate/grpo/weight_broadcast.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from surogate.grpo.config import NoiseSchedulerConfig
 from surogate.utils.logger import get_logger
+from surogate.utils.lora_compat import ensure_vllm_lora_compat
 
 logger = get_logger()
 
@@ -69,6 +70,7 @@ class SurogateWeightBroadcast:
 
         if self.adapter_only:
             trainer.export_adapter(str(save_dir))
+            ensure_vllm_lora_compat(save_dir, self.base_model_dir)
         else:
             trainer.export_model(str(save_dir))
 
@@ -188,6 +190,7 @@ class ColocateWeightBroadcast:
 
         # Export PEFT adapter files (adapter_config.json + safetensors)
         trainer.export_adapter(str(save_dir))
+        ensure_vllm_lora_compat(save_dir, self.base_model_dir)
 
         # QeRL: inject noise into exported adapter files
         self._maybe_inject_noise_on_disk(save_dir, step)

--- a/surogate/train/distributed.py
+++ b/surogate/train/distributed.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from surogate.core.config.sft_config import SFTConfig
 from surogate.train.vision import OnTheFlyMultimodalBatcher, init_mm_helpers, load_multimodal_datasets
+from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
 
 # Lazy import Ray to avoid dependency when not using distributed training
 _ray = None
@@ -505,6 +506,11 @@ class NodeTrainer:
                 self._trainer.set_adapter_path(self._config.adapter_path)
             self._trainer.import_weights(weights_path)
             logger.info(f"Node {self.node_rank}: Loading checkpoint from step {self.start_step}...")
+            if self._config.lora:
+                ensure_surogate_lora_compat(
+                    Path(self._config.checkpoint_dir) / f"step_{self.start_step:08d}",
+                    self._config.model_dir,
+                )
             self._trainer.load_checkpoint(str(self._config.checkpoint_dir), self.start_step)
             logger.info(f"Node {self.node_rank}: Checkpoint loaded successfully")
         else:
@@ -1494,6 +1500,8 @@ class RayDistributedTrainer:
                             logger.warning(
                                 f"Export timed out after 120s. {len(ready)}/{len(export_refs)} nodes completed."
                             )
+
+                    ensure_vllm_lora_compat(adapter_dir, config.model_dir)
 
                     # Merge adapter into base model if requested (only on head node)
                     if config.merge_adapter:

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -25,6 +25,7 @@ from surogate.train.vision import OnTheFlyMultimodalBatcher, init_mm_helpers, lo
 from surogate.utils.adapter_merge import merge_adapter
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
+from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
 from surogate.utils.model import estimate_model_parameters
 from surogate.utils.tensor import to_surogate_dtype
 
@@ -494,6 +495,11 @@ class SurogateTrainerWrapper:
                     self.trainer.set_adapter_path(config.adapter_path)
                 self.trainer.import_weights(base_weights_path)
                 logger.info(f"Loading checkpoint from step {self.start_step}...")
+                if config.lora:
+                    ensure_surogate_lora_compat(
+                        Path(config.checkpoint_dir) / f"step_{self.start_step:08d}",
+                        config.model_dir,
+                    )
                 self.trainer.load_checkpoint(str(config.checkpoint_dir), self.start_step)
             else:
                 logger.warning("No checkpoint found to resume from. Starting training from beginning.")
@@ -814,6 +820,7 @@ class SurogateTrainerWrapper:
                 logger.info(f"Saving LoRA adapter to {adapter_dir}...")
                 adapter_dir.mkdir(parents=True, exist_ok=True)
                 self.trainer.export_adapter(str(adapter_dir))
+                ensure_vllm_lora_compat(adapter_dir, self.config.model_dir)
                 logger.info("done")
                 logger.info(f"LoRA adapter saved to {adapter_dir}")
 
@@ -1202,9 +1209,7 @@ class SurogateTrainerWrapper:
         kd_ids = kd_logprobs = None
         if self._kd_enabled:
             kd_chunk_rows = self.config.gpus * self.config.per_device_train_batch_size
-            kd_ids = np.empty(
-                (kd_chunk_rows, self.config.sequence_len, self.config.distillation.top_k), dtype=np.int32
-            )
+            kd_ids = np.empty((kd_chunk_rows, self.config.sequence_len, self.config.distillation.top_k), dtype=np.int32)
             kd_logprobs = np.empty(
                 (kd_chunk_rows, self.config.sequence_len, self.config.distillation.top_k), dtype=np.float32
             )
@@ -1455,8 +1460,7 @@ class SurogateTrainerWrapper:
                 M = self.config.gpus * self._dpp_chunks if self.config.lora else 1
                 rows = M * bsz
                 loss = self.trainer.dispatch_pp_train_step_multigpu(
-                    in_tokens[:rows], out_tokens[:rows], self._dpp_los, self._dpp_his,
-                    opt_config, step, False, M
+                    in_tokens[:rows], out_tokens[:rows], self._dpp_los, self._dpp_his, opt_config, step, False, M
                 )
                 result = {"loss": float(loss), "norm": float(self.trainer.dispatch_pp_last_grad_norm())}
             elif use_full_step_graphs:

--- a/surogate/utils/adapter_merge.py
+++ b/surogate/utils/adapter_merge.py
@@ -46,6 +46,30 @@ def _strip_adapter_key(key: str) -> str:
     return key
 
 
+def _select_prefix_probe(expected_st_key: str, safetensor_keys: list[str]) -> str | None:
+    """Resolve one adapter key without confusing the language model with MTP."""
+    if expected_st_key in safetensor_keys:
+        return expected_st_key
+
+    suffix = expected_st_key.split(".", 1)[1] if "." in expected_st_key else expected_st_key
+    matches = [key for key in safetensor_keys if key.endswith(suffix)]
+    if not matches:
+        return None
+
+    if expected_st_key.startswith("model.layers."):
+        language_model = [key for key in matches if key.startswith("model.language_model.layers.")]
+        if len(language_model) == 1:
+            return language_model[0]
+    if expected_st_key.startswith("mtp.layers."):
+        mtp = [key for key in matches if key.startswith("mtp.layers.")]
+        if len(mtp) == 1:
+            return mtp[0]
+
+    if len(matches) == 1:
+        return matches[0]
+    raise ValueError(f"ambiguous LoRA target for {expected_st_key}: {matches}")
+
+
 def _build_lora_lookup(
     adapter_weights: dict[str, torch.Tensor],
     safetensor_keys: list[str],
@@ -81,15 +105,13 @@ def _build_lora_lookup(
     prefix_remap = ("", "")  # (from_prefix, to_prefix)
 
     if expected_st_key not in safetensor_key_set:
-        # Find the matching safetensor key by suffix
-        suffix = expected_st_key.split(".", 1)[1] if "." in expected_st_key else expected_st_key
-        for st_key in safetensor_keys:
-            if st_key.endswith(suffix):
-                actual_prefix = st_key[: len(st_key) - len(suffix)]
-                expected_prefix = expected_st_key[: len(expected_st_key) - len(suffix)]
-                if actual_prefix != expected_prefix:
-                    prefix_remap = (expected_prefix, actual_prefix)
-                break
+        matched_key = _select_prefix_probe(expected_st_key, safetensor_keys)
+        if matched_key is not None:
+            suffix = expected_st_key.split(".", 1)[1] if "." in expected_st_key else expected_st_key
+            actual_prefix = matched_key[: len(matched_key) - len(suffix)]
+            expected_prefix = expected_st_key[: len(expected_st_key) - len(suffix)]
+            if actual_prefix != expected_prefix:
+                prefix_remap = (expected_prefix, actual_prefix)
 
     # Step 3: build final lookup keyed by safetensor key (with .weight suffix)
     from_pfx, to_pfx = prefix_remap
@@ -204,8 +226,6 @@ def merge_adapter(
 
     # Process each safetensor shard: copy then merge LoRA in-place
     merged_count = 0
-    router_count = 0
-
     for st_file in st_files:
         shard_name = os.path.basename(st_file)
         output_shard = os.path.join(output_path, shard_name)

--- a/surogate/utils/lora_compat.py
+++ b/surogate/utils/lora_compat.py
@@ -1,0 +1,115 @@
+"""Compatibility fixes for exported PEFT LoRA adapters."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+
+_QWEN35_MM_ARCHITECTURES = {
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+}
+_EXPORTED_PREFIX = "base_model.model.model."
+_VLLM_PREFIX = "base_model.model.model.language_model."
+
+
+def _base_architectures(base_model_dir: str | Path | None) -> set[str]:
+    if base_model_dir is None:
+        return set()
+    config_path = Path(base_model_dir) / "config.json"
+    if not config_path.is_file():
+        return set()
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    return {str(name) for name in config.get("architectures", [])}
+
+
+def ensure_vllm_lora_compat(
+    adapter_dir: str | Path,
+    base_model_dir: str | Path | None,
+) -> bool:
+    """Normalize Qwen3.5 multimodal adapter keys for vLLM dynamic loading.
+
+    Surogate trains the text model directly and exports ``model.layers`` keys.
+    The Hugging Face Qwen3.5 conditional-generation wrapper nests those layers
+    under ``model.language_model``. vLLM uses that wrapper path when attaching
+    LoRA weights, so the missing component otherwise makes the adapter a no-op.
+
+    Returns ``True`` only when the safetensors file was rewritten.
+    """
+    if not (_base_architectures(base_model_dir) & _QWEN35_MM_ARCHITECTURES):
+        return False
+
+    adapter_path = Path(adapter_dir) / "adapter_model.safetensors"
+    if not adapter_path.is_file():
+        return False
+
+    with safe_open(adapter_path, framework="pt") as handle:
+        keys = list(handle.keys())
+        metadata = handle.metadata()
+
+    needs_remap = any(key.startswith(_EXPORTED_PREFIX) and not key.startswith(_VLLM_PREFIX) for key in keys)
+    if not needs_remap:
+        return False
+
+    tensors = load_file(str(adapter_path), device="cpu")
+    remapped = {}
+    for key, tensor in tensors.items():
+        if key.startswith(_EXPORTED_PREFIX) and not key.startswith(_VLLM_PREFIX):
+            key = _VLLM_PREFIX + key[len(_EXPORTED_PREFIX) :]
+        if key in remapped:
+            raise ValueError(f"LoRA key collision while normalizing {adapter_path}: {key}")
+        remapped[key] = tensor
+
+    temporary_path = adapter_path.with_suffix(".safetensors.tmp")
+    save_file(remapped, str(temporary_path), metadata=metadata)
+    os.replace(temporary_path, adapter_path)
+    return True
+
+
+def ensure_surogate_lora_compat(
+    adapter_dir: str | Path,
+    base_model_dir: str | Path | None,
+) -> bool:
+    """Restore Qwen3.5 multimodal adapter keys before native checkpoint resume.
+
+    Native Surogate checkpoints address the text tower as ``model.layers``.
+    Older checkpoints may have been normalized in place for vLLM, which uses
+    ``model.language_model.layers``. Convert those keys back before calling the
+    native checkpoint loader so resume cannot silently skip adapter weights.
+
+    Returns ``True`` only when the safetensors file was rewritten.
+    """
+    if not (_base_architectures(base_model_dir) & _QWEN35_MM_ARCHITECTURES):
+        return False
+
+    adapter_path = Path(adapter_dir) / "adapter_model.safetensors"
+    if not adapter_path.is_file():
+        return False
+
+    with safe_open(adapter_path, framework="pt") as handle:
+        keys = list(handle.keys())
+        metadata = handle.metadata()
+
+    if not any(key.startswith(_VLLM_PREFIX) for key in keys):
+        return False
+
+    tensors = load_file(str(adapter_path), device="cpu")
+    remapped = {}
+    for key, tensor in tensors.items():
+        if key.startswith(_VLLM_PREFIX):
+            key = _EXPORTED_PREFIX + key[len(_VLLM_PREFIX) :]
+        if key in remapped:
+            raise ValueError(f"LoRA key collision while restoring {adapter_path}: {key}")
+        remapped[key] = tensor
+
+    temporary_path = adapter_path.with_suffix(".safetensors.tmp")
+    save_file(remapped, str(temporary_path), metadata=metadata)
+    os.replace(temporary_path, adapter_path)
+    return True

--- a/tests/dpo/test_config.py
+++ b/tests/dpo/test_config.py
@@ -1,0 +1,57 @@
+"""DPOTrainConfig parses the nested DPO loss block and inherits SFT fields."""
+
+import yaml
+
+from surogate.core.config.loader import load_config
+from surogate.dpo.config import DPOLossConfig, DPOTrainConfig
+
+MODEL = "ro/train/out_opmix_wordform_s50_a010_eval"
+
+
+def _write(tmp_path, loss):
+    p = tmp_path / "dpo.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": MODEL,
+                "lora": True,
+                "lora_rank": 16,
+                "lora_alpha": 32,
+                "recipe": "bf16",
+                "gpus": 1,
+                "loss": loss,
+                "datasets": [{"path": "x.jsonl", "type": "preference"}],
+            }
+        )
+    )
+    return str(p)
+
+
+def test_parses_dpo_loss_block(tmp_path):
+    cfg = load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "dpo_beta": 0.2, "length_norm": True}))
+    assert isinstance(cfg.loss, DPOLossConfig)
+    assert cfg.loss.type == "dpo"
+    assert cfg.loss.dpo_beta == 0.2
+    assert cfg.loss.length_norm is True
+
+
+def test_defaults_when_loss_absent(tmp_path):
+    cfg = load_config(DPOTrainConfig, _write(tmp_path, None))
+    assert isinstance(cfg.loss, DPOLossConfig)
+    assert cfg.loss.dpo_beta == 0.1
+    assert cfg.loss.length_norm is False
+
+
+def test_rejects_unknown_loss_key(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown DPO loss config"):
+        load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "bogus": 1}))
+
+
+def test_inherits_sft_fields(tmp_path):
+    cfg = load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "dpo_beta": 0.1}))
+    assert cfg.lora is True
+    assert cfg.lora_rank == 16
+    # DPO bypasses SFT packing and disables CUDA graphs.
+    assert cfg.use_cuda_graphs is False

--- a/tests/dpo/test_config.py
+++ b/tests/dpo/test_config.py
@@ -1,11 +1,24 @@
 """DPOTrainConfig parses the nested DPO loss block and inherits SFT fields."""
 
+from types import SimpleNamespace
+
+import pytest
 import yaml
 
 from surogate.core.config.loader import load_config
 from surogate.dpo.config import DPOLossConfig, DPOTrainConfig
 
-MODEL = "ro/train/out_opmix_wordform_s50_a010_eval"
+MODEL = "local-test-model"
+
+
+@pytest.fixture(autouse=True)
+def _skip_model_loading(monkeypatch):
+    """Config parsing tests must not download or require a model checkout."""
+
+    def fake_post_init(config):
+        config.runtime_config = SimpleNamespace(use_cuda_graphs=config.use_cuda_graphs)
+
+    monkeypatch.setattr(DPOTrainConfig, "__post_init__", fake_post_init)
 
 
 def _write(tmp_path, loss):
@@ -28,11 +41,25 @@ def _write(tmp_path, loss):
 
 
 def test_parses_dpo_loss_block(tmp_path):
-    cfg = load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "dpo_beta": 0.2, "length_norm": True}))
+    cfg = load_config(
+        DPOTrainConfig,
+        _write(
+            tmp_path,
+            {
+                "type": "dpo",
+                "dpo_beta": 0.2,
+                "length_norm": True,
+                "reference_free": True,
+                "target_margin": 1.0,
+            },
+        ),
+    )
     assert isinstance(cfg.loss, DPOLossConfig)
     assert cfg.loss.type == "dpo"
     assert cfg.loss.dpo_beta == 0.2
     assert cfg.loss.length_norm is True
+    assert cfg.loss.reference_free is True
+    assert cfg.loss.target_margin == 1.0
 
 
 def test_defaults_when_loss_absent(tmp_path):
@@ -43,10 +70,18 @@ def test_defaults_when_loss_absent(tmp_path):
 
 
 def test_rejects_unknown_loss_key(tmp_path):
-    import pytest
-
     with pytest.raises(ValueError, match="unknown DPO loss config"):
         load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "bogus": 1}))
+
+
+def test_target_margin_requires_reference_free(tmp_path):
+    with pytest.raises(ValueError, match="target_margin requires"):
+        load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "target_margin": 1.0}))
+
+
+def test_dpo_beta_must_be_positive(tmp_path):
+    with pytest.raises(ValueError, match="dpo_beta must be positive"):
+        load_config(DPOTrainConfig, _write(tmp_path, {"type": "dpo", "dpo_beta": 0.0}))
 
 
 def test_inherits_sft_fields(tmp_path):

--- a/tests/dpo/test_e2e_smoke.py
+++ b/tests/dpo/test_e2e_smoke.py
@@ -1,0 +1,87 @@
+"""End-to-end DPO smoke test (Tasks 6+7): `surogate dpo <yaml>` runs a real
+2B-LoRA offline DPO over a handful of minimal pairs and:
+  - exits 0,
+  - logs step-0 dpo_loss ~= log 2 = 0.693 (pi_theta == pi_ref at LoRA init),
+  - writes a step checkpoint + a final adapter.
+
+Needs a GPU and the frontier model on disk, so it is marked slow.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+SUROGATE = shutil.which("surogate") or os.path.join(os.path.dirname(sys.executable), "surogate")
+
+MODEL = "ro/train/out_opmix_wordform_s50_a010_eval"
+
+
+@pytest.mark.slow
+def test_dpo_end_to_end(tmp_path):
+    data = tmp_path / "pairs.jsonl"
+    with open(data, "w", encoding="utf-8") as f:
+        for _ in range(8):
+            f.write(
+                json.dumps(
+                    {
+                        "prompt": "Scrie corect în limba română.",
+                        "chosen": "Ei mergeau acasă obosiți.",
+                        "rejected": "Ei mergerăm acasă obosiți.",
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+    out = tmp_path / "out"
+    cfg = tmp_path / "dpo.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "model": MODEL,
+                "lora": True,
+                "lora_rank": 8,
+                "lora_alpha": 16,
+                "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+                "recipe": "bf16",
+                "optimizer": "adamw_8bit",
+                "learning_rate": 5.0e-7,
+                "lr_scheduler_type": "constant",
+                "gpus": 1,
+                "per_device_train_batch_size": 2,
+                "gradient_accumulation_steps": 1,
+                "sequence_len": 256,
+                "max_steps": 3,
+                "save_steps": 2,
+                "logging_steps": 1,
+                "output_dir": str(out),
+                "surogate_metrics_path": str(out / "metrics.jsonl"),
+                "loss": {"type": "dpo", "dpo_beta": 0.1, "length_norm": False},
+                "datasets": [{"path": str(data), "type": "preference"}],
+            }
+        )
+    )
+
+    r = subprocess.run(
+        [SUROGATE, "dpo", str(cfg)],
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    log = r.stdout + r.stderr
+    assert r.returncode == 0, log[-4000:]
+
+    # step-0 identity: pi_theta == pi_ref => dpo_loss == log 2.
+    metrics = [json.loads(line) for line in (out / "metrics.jsonl").read_text().splitlines() if line.strip()]
+    step0 = next(m for m in metrics if m["step"] == 0)
+    assert abs(step0["dpo_loss"] - 0.6931) < 5e-3, step0
+
+    assert (out / "final_adapter").is_dir()
+    # save_checkpoint writes output_dir/step_{:08} (the convention `surogate merge` consumes).
+    ckpts = list(out.glob("step_*"))
+    assert ckpts, "no step checkpoint written"
+    assert (ckpts[0] / "adapter_model.safetensors").is_file()

--- a/tests/dpo/test_e2e_smoke.py
+++ b/tests/dpo/test_e2e_smoke.py
@@ -1,10 +1,10 @@
 """End-to-end DPO smoke test (Tasks 6+7): `surogate dpo <yaml>` runs a real
-2B-LoRA offline DPO over a handful of minimal pairs and:
+lightweight LoRA offline DPO over a handful of minimal pairs and:
   - exits 0,
   - logs step-0 dpo_loss ~= log 2 = 0.693 (pi_theta == pi_ref at LoRA init),
   - writes a step checkpoint + a final adapter.
 
-Needs a GPU and the frontier model on disk, so it is marked slow.
+Needs a GPU and a model checkout/cache, so it is marked slow.
 """
 
 import json
@@ -18,7 +18,7 @@ import yaml
 
 SUROGATE = shutil.which("surogate") or os.path.join(os.path.dirname(sys.executable), "surogate")
 
-MODEL = "ro/train/out_opmix_wordform_s50_a010_eval"
+MODEL = os.environ.get("SUROGATE_DPO_TEST_MODEL", "Qwen/Qwen3.5-0.8B")
 
 
 @pytest.mark.slow

--- a/tests/dpo/test_e2e_smoke.py
+++ b/tests/dpo/test_e2e_smoke.py
@@ -22,7 +22,8 @@ MODEL = "ro/train/out_opmix_wordform_s50_a010_eval"
 
 
 @pytest.mark.slow
-def test_dpo_end_to_end(tmp_path):
+@pytest.mark.parametrize("recipe", ["bf16", "fp8-hybrid"])
+def test_dpo_end_to_end(tmp_path, recipe):
     data = tmp_path / "pairs.jsonl"
     with open(data, "w", encoding="utf-8") as f:
         for _ in range(8):
@@ -47,7 +48,11 @@ def test_dpo_end_to_end(tmp_path):
                 "lora_rank": 8,
                 "lora_alpha": 16,
                 "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
-                "recipe": "bf16",
+                # Both recipes must hit the step-0 identity below. fp8-hybrid is the
+                # regression guard for the inline-reference fix: its current-batch
+                # activation scaling only agrees with the policy forward because the
+                # reference is computed in the SAME micro-batch (not precomputed offline).
+                "recipe": recipe,
                 "optimizer": "adamw_8bit",
                 "learning_rate": 5.0e-7,
                 "lr_scheduler_type": "constant",

--- a/tests/dpo/test_e2e_smoke.py
+++ b/tests/dpo/test_e2e_smoke.py
@@ -54,14 +54,14 @@ def test_dpo_end_to_end(tmp_path, recipe):
                 # reference is computed in the SAME micro-batch (not precomputed offline).
                 "recipe": recipe,
                 "optimizer": "adamw_8bit",
-                "learning_rate": 5.0e-7,
+                "learning_rate": 1.0e-4,  # aggressive: drive the margin off 0 within a few steps
                 "lr_scheduler_type": "constant",
                 "gpus": 1,
                 "per_device_train_batch_size": 2,
                 "gradient_accumulation_steps": 1,
                 "sequence_len": 256,
-                "max_steps": 3,
-                "save_steps": 2,
+                "max_steps": 24,
+                "save_steps": 12,
                 "logging_steps": 1,
                 "output_dir": str(out),
                 "surogate_metrics_path": str(out / "metrics.jsonl"),
@@ -80,10 +80,20 @@ def test_dpo_end_to_end(tmp_path, recipe):
     log = r.stdout + r.stderr
     assert r.returncode == 0, log[-4000:]
 
-    # step-0 identity: pi_theta == pi_ref => dpo_loss == log 2.
     metrics = [json.loads(line) for line in (out / "metrics.jsonl").read_text().splitlines() if line.strip()]
+
+    # (1) step-0 identity: LoRA is zero-init so pi_theta == pi_ref => margin 0, dpo_loss == log 2.
     step0 = next(m for m in metrics if m["step"] == 0)
     assert abs(step0["dpo_loss"] - 0.6931) < 5e-3, step0
+
+    # (2) the reference must be FROZEN, not tracking the policy. As the policy LoRA diverges
+    # the margin must move off 0 and the loss drop below log 2. A ref-tracks-policy bug
+    # (compute_ref_logprobs running the live LoRA-on forward) pins margin == 0 every step
+    # forever — nonzero grad_norm but zero learning — which step-0-only checks cannot catch.
+    margins = [abs(m["dpo_margin"]) for m in metrics]
+    assert max(margins) > 0.05, f"DPO margin never separated from 0 (frozen ref broken?): {margins}"
+    late_loss = min(m["dpo_loss"] for m in metrics if m["step"] >= len(metrics) // 2)
+    assert late_loss < 0.6931, f"DPO loss never dropped below log 2 (no learning signal): {late_loss}"
 
     assert (out / "final_adapter").is_dir()
     # save_checkpoint writes output_dir/step_{:08} (the convention `surogate merge` consumes).

--- a/tests/dpo/test_preference_loader.py
+++ b/tests/dpo/test_preference_loader.py
@@ -1,0 +1,47 @@
+import json
+
+from surogate.dpo.trainer import _load_pref_datasets, _load_pref_rows
+
+
+def test_load_pref_rows_preserves_optional_thinking_mode(tmp_path):
+    path = tmp_path / "pairs.jsonl"
+    row = {
+        "prompt": [{"role": "user", "content": "Răspunde direct."}],
+        "chosen": "Da",
+        "rejected": "Nu",
+        "enable_thinking": False,
+        "ignored_metadata": "x",
+    }
+    path.write_text(json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    assert _load_pref_rows(str(path)) == [
+        {
+            "prompt": row["prompt"],
+            "chosen": "Da",
+            "rejected": "Nu",
+            "enable_thinking": False,
+        }
+    ]
+
+
+def test_load_pref_datasets_concatenates_shards_in_order(tmp_path):
+    paths = []
+    for index in range(2):
+        path = tmp_path / f"pairs-{index}.jsonl"
+        path.write_text(
+            json.dumps({"prompt": f"p{index}", "chosen": f"c{index}", "rejected": f"r{index}"}) + "\n",
+            encoding="utf-8",
+        )
+        paths.append(str(path))
+
+    assert _load_pref_datasets(paths) == [
+        {"prompt": "p0", "chosen": "c0", "rejected": "r0"},
+        {"prompt": "p1", "chosen": "c1", "rejected": "r1"},
+    ]
+
+
+def test_load_pref_datasets_requires_at_least_one_path():
+    import pytest
+
+    with pytest.raises(ValueError, match="at least one preference dataset"):
+        _load_pref_datasets([])

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -1,0 +1,70 @@
+"""Preference-pair tokenization: response-only masks, shifted targets, pairing."""
+
+import numpy as np
+import pytest
+
+from surogate.dpo.data import tokenize_preference_pairs
+
+
+class FakeTok:
+    """Minimal whitespace tokenizer: token id = ord-sum of the word, +1/+2 specials."""
+
+    pad_token_id = 0
+    eos_token_id = 0
+
+    def __call__(self, text, add_special_tokens=True):
+        ids = [(abs(hash(w)) % 5000) + 10 for w in text.split()]
+        if add_special_tokens:
+            ids = [1] + ids  # a BOS-like token
+        return {"input_ids": ids}
+
+
+def test_masks_and_targets_and_pairing():
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=32)
+
+    assert b.n_pairs == 1
+    assert b.n_seq == 2
+    assert b.input_ids.shape == (2, 32)
+
+    for k in range(2):
+        L = int(b.seq_len[k])
+        # response tokens (the 2-word continuation) are scored; prompt + pad are not.
+        assert b.loss_mask[k, :L].sum() == 2
+        assert b.loss_mask[k, L:].sum() == 0  # padding unscored
+        assert b.loss_mask[k, 0] == 0  # first (prompt/BOS) token unscored
+        assert b.loss_mask[k, L - 1] == 1  # LAST response token IS scored
+        # targets are input_ids shifted left by one within the real span.
+        assert np.array_equal(b.targets[k, : L - 1], b.input_ids[k, 1:L])
+        # position ids restart at 0 per row.
+        assert b.position_ids[k, 0] == 0 and b.position_ids[k, L - 1] == L - 1
+
+    # chosen (row 0) and rejected (row 1) differ on the changed word.
+    assert not np.array_equal(b.input_ids[0], b.input_ids[1])
+
+
+def test_drops_rows_that_do_not_fit():
+    tok = FakeTok()
+    rows = [
+        {
+            "prompt": "a b c d e f",
+            "chosen": "x",
+            "rejected": "y",
+        },  # fits in max_len=4? prompt too long -> response kept via left-trunc
+        {"prompt": "p", "chosen": "ok", "rejected": "no"},
+    ]
+    # max_len=3 forces left-truncation; response (1 token) must survive.
+    b = tokenize_preference_pairs(rows, tok, max_len=3)
+    assert b.n_pairs >= 1
+    for k in range(b.n_seq):
+        L = int(b.seq_len[k])
+        assert b.loss_mask[k, :L].sum() >= 1  # at least one response token survives
+
+
+def test_raises_when_response_empty():
+    tok = FakeTok()
+    # An empty response leaves no scored token, so the pair is dropped; with every
+    # row dropped, tokenization raises rather than emit a zero-pair batch.
+    with pytest.raises(ValueError, match="no preference pair"):
+        tokenize_preference_pairs([{"prompt": "hello world", "chosen": "", "rejected": ""}], tok, max_len=32)

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -19,6 +19,21 @@ class FakeTok:
         return {"input_ids": ids}
 
 
+class FakeChatTok(FakeTok):
+    def __init__(self):
+        self.rendered_modes = []
+
+    def apply_chat_template(self, messages, add_generation_prompt, tokenize, enable_thinking=None):
+        assert add_generation_prompt and tokenize
+        self.rendered_modes.append(enable_thinking)
+        return [1, 101 if enable_thinking else 102]
+
+
+class FakeMappingChatTok(FakeChatTok):
+    def apply_chat_template(self, messages, add_generation_prompt, tokenize, enable_thinking=None):
+        return {"input_ids": [[1, 101 if enable_thinking else 102]]}
+
+
 def test_masks_and_targets_and_pairing():
     tok = FakeTok()
     rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
@@ -68,3 +83,77 @@ def test_raises_when_response_empty():
     # row dropped, tokenization raises rather than emit a zero-pair batch.
     with pytest.raises(ValueError, match="no preference pair"):
         tokenize_preference_pairs([{"prompt": "hello world", "chosen": "", "rejected": ""}], tok, max_len=32)
+
+
+def test_chat_pair_can_request_thinking_generation_prefix():
+    tok = FakeChatTok()
+    rows = [
+        {
+            "prompt": [{"role": "user", "content": "Calculează."}],
+            "chosen": "corect",
+            "rejected": "greșit",
+            "enable_thinking": True,
+        }
+    ]
+    batch = tokenize_preference_pairs(rows, tok, max_len=16)
+
+    assert batch.n_pairs == 1
+    assert tok.rendered_modes == [True, True]
+
+
+def test_chat_template_mapping_output_is_normalized_to_token_ids():
+    tok = FakeMappingChatTok()
+    rows = [
+        {
+            "prompt": [{"role": "user", "content": "Calculează."}],
+            "chosen": "corect",
+            "rejected": "greșit",
+            "enable_thinking": True,
+        }
+    ]
+    batch = tokenize_preference_pairs(rows, tok, max_len=16)
+
+    assert batch.n_pairs == 1
+    assert batch.input_ids[0, :2].tolist() == [1, 101]
+
+
+def test_span_mask_scores_only_disjoint_edits():
+    tok = FakeTok()
+    rows = [
+        {
+            "prompt": "cerere",
+            "chosen": "text corect între formă bună final",
+            "rejected": "text greșit între formă rea final",
+        }
+    ]
+
+    batch = tokenize_preference_pairs(rows, tok, max_len=32, span_mask=True)
+
+    expected = [3, 6]
+    for row in range(2):
+        assert np.flatnonzero(batch.loss_mask[row]).tolist() == expected
+
+
+def test_span_mask_keeps_surviving_edits_after_left_truncation():
+    tok = FakeTok()
+    rows = [
+        {
+            "prompt": "prompt foarte lung care va dispărea",
+            "chosen": "unu corect trei bun",
+            "rejected": "unu greșit trei rău",
+        }
+    ]
+
+    batch = tokenize_preference_pairs(rows, tok, max_len=4, span_mask=True)
+
+    for row in range(2):
+        assert batch.seq_len[row] == 4
+        assert np.flatnonzero(batch.loss_mask[row]).tolist() == [1, 3]
+
+
+def test_span_mask_drops_pair_when_only_one_side_has_surviving_edit_tokens():
+    tok = FakeTok()
+    rows = [{"prompt": "p", "chosen": "shared", "rejected": "extra shared"}]
+
+    with pytest.raises(ValueError, match="no preference pair"):
+        tokenize_preference_pairs(rows, tok, max_len=8, span_mask=True)

--- a/tests/dpo/test_ref_precompute.py
+++ b/tests/dpo/test_ref_precompute.py
@@ -24,6 +24,7 @@ def test_rows_digest_is_content_sensitive():
     b = [{"prompt": "p", "chosen": "c", "rejected": "DIFFERENT"}]
     assert rows_digest(a) != rows_digest(b)
     assert rows_digest(a) == rows_digest(list(a))
+    assert rows_digest(a) != rows_digest([{**a[0], "enable_thinking": True}])
 
 
 def test_sidecar_roundtrip_and_key_mismatch(tmp_path):

--- a/tests/dpo/test_ref_precompute.py
+++ b/tests/dpo/test_ref_precompute.py
@@ -1,0 +1,40 @@
+"""Reference-logprob sidecar: cache key invalidation + save/load roundtrip.
+
+(The full precompute needs a built trainer + GPU; it is exercised by the
+end-to-end smoke test in Task 7.)
+"""
+
+import numpy as np
+
+from surogate.dpo.data import load_ref_sidecar, rows_digest, save_ref_sidecar, sidecar_hash
+
+
+def test_hash_changes_with_model_maxlen_and_rows():
+    base = dict(model="A", max_len=64, n_rows=10, rows_digest="d1")
+    h = sidecar_hash(**base)
+    assert h != sidecar_hash(**{**base, "model": "B"})
+    assert h != sidecar_hash(**{**base, "max_len": 128})
+    assert h != sidecar_hash(**{**base, "n_rows": 11})
+    assert h != sidecar_hash(**{**base, "rows_digest": "d2"})
+    assert h == sidecar_hash(**base)  # deterministic
+
+
+def test_rows_digest_is_content_sensitive():
+    a = [{"prompt": "p", "chosen": "c", "rejected": "r"}]
+    b = [{"prompt": "p", "chosen": "c", "rejected": "DIFFERENT"}]
+    assert rows_digest(a) != rows_digest(b)
+    assert rows_digest(a) == rows_digest(list(a))
+
+
+def test_sidecar_roundtrip_and_key_mismatch(tmp_path):
+    ref = np.random.RandomState(0).randn(6, 8).astype(np.float32)
+    path = str(tmp_path / "ref.npz")
+    save_ref_sidecar(path, "key123", ref)
+
+    got = load_ref_sidecar(path, "key123")
+    assert got is not None and np.allclose(got, ref)
+
+    # wrong key => None (forces recompute), never silently wrong references.
+    assert load_ref_sidecar(path, "OTHER") is None
+    # missing file => None.
+    assert load_ref_sidecar(str(tmp_path / "nope.npz"), "key123") is None

--- a/tests/dpo/test_reference_free.py
+++ b/tests/dpo/test_reference_free.py
@@ -1,0 +1,50 @@
+"""Reference-free DPO synthetic-margin construction."""
+
+import numpy as np
+
+from surogate.dpo.trainer import _reference_free_logprobs
+
+
+def _batch():
+    return {
+        "loss_mask": np.array(
+            [
+                0,
+                0,
+                1,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+            ],
+            dtype=np.uint8,
+        ),
+        "pair_chosen": np.array([0], dtype=np.int32),
+    }
+
+
+def test_target_margin_is_distributed_in_sum_mode():
+    refs = _reference_free_logprobs([_batch()], B=2, T=6, beta=0.5, target_margin=1.0, length_norm=False)
+
+    assert refs.shape == (2, 6)
+    # Two chosen tokens share target_margin / beta = 2.0.
+    assert refs[0].tolist() == [0.0, 1.0, 0.0, 1.0, 0.0, 0.0]
+    assert refs[1].tolist() == [0.0] * 6
+
+
+def test_target_margin_is_per_token_in_length_normalized_mode():
+    refs = _reference_free_logprobs([_batch()], B=2, T=6, beta=0.5, target_margin=1.0, length_norm=True)
+
+    # The native kernel averages reference log-probs in length-normalized mode.
+    assert refs[0].tolist() == [0.0, 2.0, 0.0, 2.0, 0.0, 0.0]
+
+
+def test_reference_free_zero_margin_is_all_zero():
+    refs = _reference_free_logprobs([_batch()], B=2, T=6, beta=0.3, target_margin=0.0, length_norm=False)
+
+    assert not refs.any()

--- a/tests/dpo/test_step_dpo_binding.py
+++ b/tests/dpo/test_step_dpo_binding.py
@@ -1,0 +1,18 @@
+"""The native DPO step + metrics must be exposed on the trainer extension.
+
+A full forward/backward needs a model + GPU (covered by the end-to-end smoke
+test in Task 7); here we assert the binding surface exists after `make build`.
+"""
+
+import pytest
+
+pytest.importorskip("surogate")
+from surogate import _surogate  # noqa: E402
+
+
+def test_step_dpo_native_is_bound():
+    assert hasattr(_surogate.SurogateTrainer, "step_dpo_native")
+
+
+def test_get_dpo_native_metrics_is_bound():
+    assert hasattr(_surogate.SurogateTrainer, "get_dpo_native_metrics")

--- a/tests/grpo/test_lora_compat.py
+++ b/tests/grpo/test_lora_compat.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import torch
+from safetensors.torch import load_file, save_file
+
+from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
+
+
+def _write_base(path: Path, architecture: str) -> None:
+    path.mkdir()
+    (path / "config.json").write_text(
+        json.dumps({"architectures": [architecture]}),
+        encoding="utf-8",
+    )
+
+
+def _write_adapter(path: Path) -> None:
+    path.mkdir()
+    save_file(
+        {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.ones(2, 3),
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight": torch.ones(4, 2),
+        },
+        str(path / "adapter_model.safetensors"),
+        metadata={"format": "pt"},
+    )
+
+
+def test_qwen35_conditional_adapter_keys_are_remapped(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    adapter = tmp_path / "adapter"
+    _write_base(base, "Qwen3_5ForConditionalGeneration")
+    _write_adapter(adapter)
+
+    assert ensure_vllm_lora_compat(adapter, base)
+    tensors = load_file(str(adapter / "adapter_model.safetensors"))
+    assert set(tensors) == {
+        "base_model.model.model.language_model.layers.0.self_attn.q_proj.lora_A.weight",
+        "base_model.model.model.language_model.layers.0.self_attn.q_proj.lora_B.weight",
+    }
+    assert not ensure_vllm_lora_compat(adapter, base)
+
+    assert ensure_surogate_lora_compat(adapter, base)
+    tensors = load_file(str(adapter / "adapter_model.safetensors"))
+    assert set(tensors) == {
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight",
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight",
+    }
+    assert not ensure_surogate_lora_compat(adapter, base)
+
+
+def test_text_only_architecture_is_not_remapped(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    adapter = tmp_path / "adapter"
+    _write_base(base, "Qwen3_5ForCausalLM")
+    _write_adapter(adapter)
+
+    assert not ensure_vllm_lora_compat(adapter, base)
+    assert not ensure_surogate_lora_compat(adapter, base)
+    tensors = load_file(str(adapter / "adapter_model.safetensors"))
+    assert all("language_model" not in key for key in tensors)

--- a/tests/train/test_adapter_merge.py
+++ b/tests/train/test_adapter_merge.py
@@ -1,0 +1,43 @@
+import pytest
+import torch
+
+from surogate.utils.adapter_merge import _build_lora_lookup
+
+
+def _adapter_pair(module: str):
+    return {
+        f"base_model.model.{module}.lora_A.weight": torch.ones(2, 3),
+        f"base_model.model.{module}.lora_B.weight": torch.ones(4, 2),
+    }
+
+
+def test_lora_lookup_prefers_qwen_language_model_over_mtp():
+    adapter = _adapter_pair("model.layers.0.mlp.down_proj")
+    base_keys = [
+        "mtp.layers.0.mlp.down_proj.weight",
+        "model.language_model.layers.0.mlp.down_proj.weight",
+    ]
+
+    lookup = _build_lora_lookup(adapter, base_keys)
+
+    assert list(lookup) == ["model.language_model.layers.0.mlp.down_proj.weight"]
+
+
+def test_lora_lookup_keeps_unambiguous_prefix_remap():
+    adapter = _adapter_pair("model.layers.3.self_attn.q_proj")
+    base_keys = ["language_model.model.layers.3.self_attn.q_proj.weight"]
+
+    lookup = _build_lora_lookup(adapter, base_keys)
+
+    assert list(lookup) == ["language_model.model.layers.3.self_attn.q_proj.weight"]
+
+
+def test_lora_lookup_rejects_ambiguous_suffix_matches():
+    adapter = _adapter_pair("other.layers.0.mlp.down_proj")
+    base_keys = [
+        "model.layers.0.mlp.down_proj.weight",
+        "mtp.layers.0.mlp.down_proj.weight",
+    ]
+
+    with pytest.raises(ValueError, match="ambiguous LoRA target"):
+        _build_lora_lookup(adapter, base_keys)


### PR DESCRIPTION
## Summary

- add a native CUDA DPO loss path, nanobind runtime integration, reference-logprob precomputation, checkpoint resume, and the `surogate dpo` CLI
- add preference dataset loading/tokenization, reference-free DPO, span masking, thinking/final-only masking, and multi-file input support
- normalize Qwen3.5 LoRA names across SFT, GRPO, DPO, inherited adapters, and adapter merge
- document the DPO workflow and configuration

## Validation

- `make build PARALLEL_JOBS=16`
- Python: 30 passed, 2 deselected (`tests/dpo`, LoRA compatibility, adapter merge; excluding slow)
- native DPO CUDA: 142 assertions in 4 cases
- native chat-template/masking: 4 assertions in 4 cases
- `pre-commit run`

## Scope

Trainer/runtime/tests/docs only. RO model scripts, datasets, configs, evaluation assets, and checkpoints are intentionally excluded.