### PR TITLE
feat(datasets): add preference dataset type to the core dataset framework

### DIFF
--- a/docs/getting-started/quickstart-dpo.md
+++ b/docs/getting-started/quickstart-dpo.md
@@ -7,13 +7,20 @@ rejected}` triples and run a single command.
 
 ## 1) Prepare preference data
 
-A `type: preference` dataset is JSONL with three required fields per row. `prompt` may be a
+A `type: preference` dataset has three required fields per row. `prompt` may be a
 string or a chat `messages` list; `chosen`/`rejected` are the two competing assistant
 continuations. Chat rows may also set `enable_thinking`:
 
 ```json
 {"prompt": "Scrie corect în limba română.", "chosen": "Ei mergeau acasă.", "rejected": "Ei mergerăm acasă."}
 ```
+
+Like the other dataset types (`text`, `instruction`, `conversation`), preference data
+loads through the shared dataset pipeline: `path` may be a local JSONL/JSON/parquet/CSV
+file, a dataset directory, or a HuggingFace hub repo, and `subset`/`split`/`samples`
+work as usual. Datasets with different column names map via `prompt_field`,
+`chosen_field`, and `rejected_field` (see the
+[config reference](../reference/config.md#preference-dataset-options-type-preference)).
 
 Loss is applied only to the response tokens. Minimal pairs — where `chosen` and
 `rejected` differ in as little as a single word — give the cleanest signal, because

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -336,11 +336,21 @@ datasets:
 
 #### Preference Dataset Options (`type: "preference"`)
 
-For offline DPO. Each JSONL row has `prompt` (a string or a chat `messages` list),
+For offline DPO. Each row has `prompt` (a string or a chat `messages` list),
 `chosen`, and `rejected` (the two competing assistant continuations). Chat rows may
 also set `enable_thinking` to control the generation prefix. Loss is applied only
 on the response tokens. Used by the
 `surogate dpo` command together with the [DPO loss block](#dpo-settings).
+Preference datasets load through the same pipeline as the other types, so `path`
+may be a local JSONL/JSON/parquet/CSV file, a dataset directory, or a HuggingFace
+hub repo, and `subset`/`split`/`samples` apply as usual.
+
+| Option                  | Type   | Default             | Description                                                                     |
+| ----------------------- | ------ | ------------------- | ------------------------------------------------------------------------------- |
+| `prompt_field`          | string | `"prompt"`          | Name of the column containing the prompt (string or chat messages list).        |
+| `chosen_field`          | string | `"chosen"`          | Name of the column containing the preferred response.                           |
+| `rejected_field`        | string | `"rejected"`        | Name of the column containing the dispreferred response.                        |
+| `enable_thinking_field` | string | `"enable_thinking"` | Name of the optional column controlling the chat-template thinking prefix.      |
 
 ```json
 {"prompt": "...", "chosen": "preferred response", "rejected": "dispreferred response"}
@@ -351,6 +361,11 @@ on the response tokens. Used by the
 datasets:
   - path: ./pairs.jsonl
 	type: preference
+  - path: "org/hf-preference-dataset"
+	type: preference
+	split: train
+	chosen_field: preferred
+	rejected_field: dispreferred
 ```
 
 ## DPO Settings

--- a/surogate/core/config/dataset_config.py
+++ b/surogate/core/config/dataset_config.py
@@ -14,7 +14,7 @@ class DatasetConfig:
         path (Optional[str]): HuggingFace dataset repo | s3:// | gs:// | path to local file or directory.
         subset (Optional[str]): HuggingFace subset of dataset to load
         split (Optional[str]): Name of dataset split to load from. Defaults to 'train'.
-        type (Optional[Literal['text', 'instruction', 'conversation']]): The type of dataset.
+        type (Optional[Literal['text', 'instruction', 'conversation', 'preference']]): The type of dataset.
         samples (Optional[int]): Number of samples to use.
     """
 
@@ -26,6 +26,7 @@ class DatasetConfig:
             SurogateDatasetType.text,
             SurogateDatasetType.instruction,
             SurogateDatasetType.conversation,
+            SurogateDatasetType.preference,
             SurogateDatasetType.auto,
         ]
         | None
@@ -198,7 +199,49 @@ class ConversationDatasetConfig(DatasetConfig):
             )
 
 
-SurogateDatasetConfig = TextDatasetConfig | InstructionDatasetConfig | ConversationDatasetConfig
+class PreferenceDatasetConfig(DatasetConfig):
+    """
+    PreferenceDatasetConfig class is a dataclass that holds configuration parameters for a preference-pair
+    dataset ({prompt, chosen, rejected} rows) used by offline DPO.
+
+    Args:
+        prompt_field (str): The name of the column that contains the prompt (a string or a chat messages list). Defaults to "prompt".
+        chosen_field (str): The name of the column that contains the preferred response. Defaults to "chosen".
+        rejected_field (str): The name of the column that contains the dispreferred response. Defaults to "rejected".
+        enable_thinking_field (str): The name of the optional column that controls the chat-template thinking prefix. Defaults to "enable_thinking".
+    """
+
+    prompt_field: str | None = None
+    chosen_field: str | None = None
+    rejected_field: str | None = None
+    enable_thinking_field: str | None = None
+
+    def __init__(self, cfg: DictDefault):
+        super().__init__(cfg)
+        self.prompt_field = cfg["prompt_field"] or "prompt"
+        self.chosen_field = cfg["chosen_field"] or "chosen"
+        self.rejected_field = cfg["rejected_field"] or "rejected"
+        # Only require the enable_thinking column when the user explicitly asked for it.
+        self._enable_thinking_field_explicit = cfg["enable_thinking_field"] is not None
+        self.enable_thinking_field = cfg["enable_thinking_field"] or "enable_thinking"
+        self.__post_init__()
+
+    def validate_columns(self, columns: list[str]):
+        for name, field in [
+            ("Prompt", self.prompt_field),
+            ("Chosen", self.chosen_field),
+            ("Rejected", self.rejected_field),
+        ]:
+            if field not in columns:
+                raise ValueError(f"{name} field '{field}' is missing from the dataset. Dataset columns: {columns}.")
+        if self._enable_thinking_field_explicit and self.enable_thinking_field not in columns:
+            raise ValueError(
+                f"Enable-thinking field '{self.enable_thinking_field}' is missing from the dataset. "
+                f"Dataset columns: {columns}."
+            )
+
+
+SurogateDatasetConfig = TextDatasetConfig | InstructionDatasetConfig | ConversationDatasetConfig | PreferenceDatasetConfig
 
 
 def create_dataset_config(ds_cfg: DictDefault):
@@ -209,5 +252,7 @@ def create_dataset_config(ds_cfg: DictDefault):
         return InstructionDatasetConfig(ds_cfg)
     elif ds_type == "conversation":
         return ConversationDatasetConfig(ds_cfg)
+    elif ds_type == "preference":
+        return PreferenceDatasetConfig(ds_cfg)
     else:
         return DatasetConfig(ds_cfg)

--- a/surogate/core/datasets/datasets.py
+++ b/surogate/core/datasets/datasets.py
@@ -15,6 +15,7 @@ from surogate.core.config.dataset_config import (
     ConversationDatasetConfig,
     DatasetConfig,
     InstructionDatasetConfig,
+    PreferenceDatasetConfig,
     TextDatasetConfig,
 )
 from surogate.core.config.enums import SurogateDatasetType
@@ -22,6 +23,7 @@ from surogate.core.datasets.loader import load_dataset_with_config
 from surogate.core.datasets.lock import FileLockLoader
 from surogate.core.datasets.preprocessor.conversation import ConversationPreprocessor
 from surogate.core.datasets.preprocessor.instruction import InstructionPreprocessor
+from surogate.core.datasets.preprocessor.preference import PreferencePreprocessor
 from surogate.core.datasets.preprocessor.text import TextPreprocessor
 from surogate.utils.dict import DictDefault
 from surogate.utils.logger import get_logger
@@ -85,6 +87,9 @@ def wrap_dataset(ds_cfg: DatasetConfig, dataset: Dataset | IterableDataset) -> D
     elif ds_cfg.type == SurogateDatasetType.text:
         ds_cfg = ds_cfg if isinstance(ds_cfg, TextDatasetConfig) else TextDatasetConfig(**ds_cfg.__dict__)
         processor = TextPreprocessor(ds_cfg)
+    elif ds_cfg.type == SurogateDatasetType.preference:
+        ds_cfg = ds_cfg if isinstance(ds_cfg, PreferenceDatasetConfig) else PreferenceDatasetConfig(**ds_cfg.__dict__)
+        processor = PreferencePreprocessor(ds_cfg)
     else:
         raise ValueError(f"Unsupported dataset type: {ds_cfg.type}")
 

--- a/surogate/core/datasets/loader.py
+++ b/surogate/core/datasets/loader.py
@@ -19,6 +19,7 @@ from surogate.core.config.enums import SurogateDatasetType
 from surogate.core.datasets.preprocessor.auto import AutoPreprocessor
 from surogate.core.datasets.preprocessor.conversation import ConversationPreprocessor
 from surogate.core.datasets.preprocessor.instruction import InstructionPreprocessor
+from surogate.core.datasets.preprocessor.preference import PreferencePreprocessor
 from surogate.core.datasets.preprocessor.text import TextPreprocessor
 from surogate.core.datasets.utils import DATASET_TYPE, sample_dataset
 from surogate.utils.logger import get_logger
@@ -219,6 +220,8 @@ def pre_process(
         preprocessor = ConversationPreprocessor(ds_config)
     elif ds_config.type == SurogateDatasetType.text:
         preprocessor = TextPreprocessor(ds_config)
+    elif ds_config.type == SurogateDatasetType.preference:
+        preprocessor = PreferencePreprocessor(ds_config)
 
     preprocessor.dataset_sample = ds_config.samples
     return preprocessor(dataset, num_proc=num_proc, load_from_cache_file=load_from_cache_file, strict=strict)

--- a/surogate/core/datasets/preprocessor/preference.py
+++ b/surogate/core/datasets/preprocessor/preference.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from surogate.core.config.dataset_config import PreferenceDatasetConfig
+from surogate.core.datasets.preprocessor.row import RowPreprocessor
+from surogate.utils.logger import get_logger
+
+logger = get_logger()
+
+
+class PreferencePreprocessor(RowPreprocessor):
+    """Normalize preference-pair rows for offline DPO.
+
+    Each output row is `{prompt, chosen, rejected}` plus the optional
+    `enable_thinking` flag. `prompt` is a string or a chat messages list;
+    `chosen`/`rejected` are the two competing assistant continuations
+    (see surogate/dpo/data.py for the downstream tokenization). All other
+    columns are dropped so every shard yields a uniform schema.
+    """
+
+    def __init__(self, dataset_config: PreferenceDatasetConfig):
+        super().__init__()
+        self.ds_cfg = dataset_config
+        self.columns[dataset_config.prompt_field] = "prompt"
+        self.columns[dataset_config.chosen_field] = "chosen"
+        self.columns[dataset_config.rejected_field] = "rejected"
+        self.columns[dataset_config.enable_thinking_field] = "enable_thinking"
+
+    def preprocess(self, row: dict[str, Any]) -> dict[str, Any] | None:
+        prompt = row.get("prompt")
+        if not isinstance(prompt, (str, list)) or len(prompt) == 0:
+            raise ValueError(f"'prompt' must be a non-empty string or messages list. Row: {row}")
+
+        result = {"prompt": prompt}
+        for key in ("chosen", "rejected"):
+            response = row.get(key)
+            if not isinstance(response, str) or response == "":
+                raise ValueError(f"'{key}' must be a non-empty string. Row: {row}")
+            result[key] = response
+
+        enable_thinking = row.get("enable_thinking")
+        if enable_thinking is not None:
+            result["enable_thinking"] = bool(enable_thinking)
+        return result
+
+    def preprocess_batch(self, rows: list[dict[str, Any]]) -> list[dict[str, Any] | None]:
+        """Process a batch of preference rows.
+
+        Raises on the first invalid row; RowPreprocessor then falls back to
+        row-by-row processing, which drops only the offending rows.
+        """
+        return [self.preprocess(row) for row in rows]

--- a/surogate/dpo/config.py
+++ b/surogate/dpo/config.py
@@ -9,6 +9,7 @@ GRPO, DPO keeps `datasets` (it reads static preference pairs of the form
 from dataclasses import dataclass, fields
 from typing import Literal
 
+from surogate.core.config.enums import SurogateDatasetType
 from surogate.core.config.sft_config import SFTConfig
 from surogate.utils.dict import DictDefault
 from surogate.utils.logger import get_logger
@@ -76,7 +77,19 @@ class DPOTrainConfig(SFTConfig):
         if "lmhead_drop_ignored_rows" not in cfg:
             cfg["lmhead_drop_ignored_rows"] = True
 
+        # `surogate dpo` consumes {prompt, chosen, rejected} pairs, so a bare
+        # `- path: pairs.jsonl` entry means `type: preference`.
+        for ds_cfg in cfg.get("datasets") or []:
+            if not ds_cfg.get("type"):
+                ds_cfg["type"] = "preference"
+
         super().__init__(cfg)
+
+        for ds_cfg in self.datasets or []:
+            if ds_cfg.type != SurogateDatasetType.preference:
+                raise ValueError(
+                    f"DPO datasets must be 'type: preference'; got type '{ds_cfg.type}' for '{ds_cfg.path}'"
+                )
 
         loss_cfg = cfg.get("loss", {})
         if isinstance(loss_cfg, DPOLossConfig):

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -33,6 +33,9 @@ from pathlib import Path
 import numpy as np
 
 from surogate import _surogate
+from surogate.core.config.dataset_config import PreferenceDatasetConfig
+from surogate.core.datasets.datasets import disable_datasets_caching
+from surogate.core.datasets.loader import load_dataset_with_config, pre_process
 from surogate.dpo.config import DPOTrainConfig
 from surogate.dpo.data import tokenize_preference_pairs
 from surogate.train.lr_schedule import LRSchedule
@@ -44,31 +47,32 @@ from surogate.utils.tensor import to_surogate_dtype
 logger = get_logger()
 
 
-def _load_pref_rows(path: str) -> list[dict]:
-    rows = []
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            r = json.loads(line)
-            if "prompt" in r and "chosen" in r and "rejected" in r:
-                row = {"prompt": r["prompt"], "chosen": r["chosen"], "rejected": r["rejected"]}
-                if "enable_thinking" in r:
-                    row["enable_thinking"] = r["enable_thinking"]
-                rows.append(row)
-    if not rows:
-        raise ValueError(f"no {{prompt, chosen, rejected}} rows in {path}")
-    return rows
+def _normalize_pref_row(row: dict) -> dict:
+    """Strip the Arrow round-trip artifacts (all-columns rows with None fills)
+    back to the minimal {prompt, chosen, rejected[, enable_thinking]} dict the
+    tokenizer and the ref-sidecar digest expect."""
+    out = {"prompt": row["prompt"], "chosen": row["chosen"], "rejected": row["rejected"]}
+    if row.get("enable_thinking") is not None:
+        out["enable_thinking"] = bool(row["enable_thinking"])
+    return out
 
 
-def _load_pref_datasets(paths: list[str]) -> list[dict]:
-    """Load configured preference shards in declaration order."""
-    if not paths:
+def _load_pref_datasets(dataset_configs: list[PreferenceDatasetConfig], num_workers: int = 1) -> list[dict]:
+    """Load configured `type: preference` datasets in declaration order through the
+    shared dataset framework (local json/jsonl/parquet/csv files, dataset
+    directories, or HF hub repos; honors subset/split/samples and the
+    prompt/chosen/rejected field mappings)."""
+    if not dataset_configs:
         raise ValueError("DPO requires at least one preference dataset")
-    rows = []
-    for path in paths:
-        rows.extend(_load_pref_rows(path))
+    rows: list[dict] = []
+    with disable_datasets_caching():
+        for ds_cfg in dataset_configs:
+            dataset = load_dataset_with_config(ds_cfg, num_workers=num_workers)
+            ds_cfg.validate_columns(dataset.column_names)
+            dataset = pre_process(dataset, ds_cfg, num_proc=num_workers, load_from_cache_file=False)
+            if len(dataset) == 0:
+                raise ValueError(f"no {{prompt, chosen, rejected}} rows in {ds_cfg.path}")
+            rows.extend(_normalize_pref_row(row) for row in dataset.to_list())
     return rows
 
 
@@ -205,7 +209,7 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
             logger.info("No DPO checkpoint found; starting from step 0")
 
     # --- tokenize preference pairs -----------------------------------------
-    rows = _load_pref_datasets([dataset.path for dataset in (config.datasets or [])])
+    rows = _load_pref_datasets(config.datasets or [], num_workers=config.dataloader_num_workers or 1)
     batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T, span_mask=config.loss.span_mask)
     logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
     Path(config.output_dir).mkdir(parents=True, exist_ok=True)

--- a/tests/dpo/test_config.py
+++ b/tests/dpo/test_config.py
@@ -90,3 +90,40 @@ def test_inherits_sft_fields(tmp_path):
     assert cfg.lora_rank == 16
     # DPO bypasses SFT packing and disables CUDA graphs.
     assert cfg.use_cuda_graphs is False
+
+
+def test_dataset_type_defaults_to_preference(tmp_path):
+    from surogate.core.config.dataset_config import PreferenceDatasetConfig
+
+    p = tmp_path / "dpo.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": MODEL,
+                "lora": True,
+                "recipe": "bf16",
+                "gpus": 1,
+                "datasets": [{"path": "x.jsonl"}],
+            }
+        )
+    )
+    cfg = load_config(DPOTrainConfig, str(p))
+    assert isinstance(cfg.datasets[0], PreferenceDatasetConfig)
+    assert cfg.datasets[0].type == "preference"
+
+
+def test_rejects_non_preference_dataset_type(tmp_path):
+    p = tmp_path / "dpo.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": MODEL,
+                "lora": True,
+                "recipe": "bf16",
+                "gpus": 1,
+                "datasets": [{"path": "x.jsonl", "type": "conversation"}],
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="must be 'type: preference'"):
+        load_config(DPOTrainConfig, str(p))

--- a/tests/dpo/test_preference_loader.py
+++ b/tests/dpo/test_preference_loader.py
@@ -1,47 +1,129 @@
+"""`type: preference` datasets load through the shared dataset framework."""
+
 import json
 
-from surogate.dpo.trainer import _load_pref_datasets, _load_pref_rows
+import pytest
+
+from surogate.core.config.dataset_config import PreferenceDatasetConfig, create_dataset_config
+from surogate.dpo.trainer import _load_pref_datasets
+from surogate.utils.dict import DictDefault
 
 
-def test_load_pref_rows_preserves_optional_thinking_mode(tmp_path):
+def _pref_cfg(path, **overrides) -> PreferenceDatasetConfig:
+    return create_dataset_config(DictDefault({"path": str(path), "type": "preference", **overrides}))
+
+
+def _write_jsonl(path, rows):
+    path.write_text("".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows), encoding="utf-8")
+    return str(path)
+
+
+def test_create_dataset_config_returns_preference_config():
+    cfg = _pref_cfg("x.jsonl")
+    assert isinstance(cfg, PreferenceDatasetConfig)
+    assert cfg.prompt_field == "prompt"
+    assert cfg.chosen_field == "chosen"
+    assert cfg.rejected_field == "rejected"
+
+
+def test_load_preserves_optional_thinking_mode_and_drops_metadata(tmp_path):
     path = tmp_path / "pairs.jsonl"
-    row = {
-        "prompt": [{"role": "user", "content": "Răspunde direct."}],
-        "chosen": "Da",
-        "rejected": "Nu",
-        "enable_thinking": False,
-        "ignored_metadata": "x",
-    }
-    path.write_text(json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
+    _write_jsonl(
+        path,
+        [
+            {
+                "prompt": [{"role": "user", "content": "Răspunde direct."}],
+                "chosen": "Da",
+                "rejected": "Nu",
+                "enable_thinking": False,
+                "ignored_metadata": "x",
+            },
+            {
+                "prompt": [{"role": "user", "content": "Încă una."}],
+                "chosen": "Merge",
+                "rejected": "Nu merge",
+            },
+        ],
+    )
 
-    assert _load_pref_rows(str(path)) == [
+    rows = _load_pref_datasets([_pref_cfg(path)])
+    assert rows == [
         {
-            "prompt": row["prompt"],
+            "prompt": [{"role": "user", "content": "Răspunde direct."}],
             "chosen": "Da",
             "rejected": "Nu",
             "enable_thinking": False,
-        }
+        },
+        {
+            "prompt": [{"role": "user", "content": "Încă una."}],
+            "chosen": "Merge",
+            "rejected": "Nu merge",
+        },
     ]
 
 
-def test_load_pref_datasets_concatenates_shards_in_order(tmp_path):
-    paths = []
+def test_load_concatenates_shards_in_declaration_order(tmp_path):
+    cfgs = []
     for index in range(2):
         path = tmp_path / f"pairs-{index}.jsonl"
-        path.write_text(
-            json.dumps({"prompt": f"p{index}", "chosen": f"c{index}", "rejected": f"r{index}"}) + "\n",
-            encoding="utf-8",
-        )
-        paths.append(str(path))
+        _write_jsonl(path, [{"prompt": f"p{index}", "chosen": f"c{index}", "rejected": f"r{index}"}])
+        cfgs.append(_pref_cfg(path))
 
-    assert _load_pref_datasets(paths) == [
+    assert _load_pref_datasets(cfgs) == [
         {"prompt": "p0", "chosen": "c0", "rejected": "r0"},
         {"prompt": "p1", "chosen": "c1", "rejected": "r1"},
     ]
 
 
-def test_load_pref_datasets_requires_at_least_one_path():
-    import pytest
-
+def test_load_requires_at_least_one_dataset():
     with pytest.raises(ValueError, match="at least one preference dataset"):
         _load_pref_datasets([])
+
+
+def test_load_honors_field_mappings(tmp_path):
+    path = tmp_path / "pairs.jsonl"
+    _write_jsonl(path, [{"question": "p", "better": "c", "worse": "r"}])
+
+    rows = _load_pref_datasets(
+        [_pref_cfg(path, prompt_field="question", chosen_field="better", rejected_field="worse")]
+    )
+    assert rows == [{"prompt": "p", "chosen": "c", "rejected": "r"}]
+
+
+def test_load_rejects_missing_required_column(tmp_path):
+    path = tmp_path / "pairs.jsonl"
+    _write_jsonl(path, [{"prompt": "p", "chosen": "c"}])
+
+    with pytest.raises(ValueError, match="Rejected field 'rejected' is missing"):
+        _load_pref_datasets([_pref_cfg(path)])
+
+
+def test_load_drops_invalid_rows(tmp_path):
+    path = tmp_path / "pairs.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {"prompt": "p0", "chosen": "c0", "rejected": "r0"},
+            {"prompt": "p1", "chosen": None, "rejected": "r1"},
+        ],
+    )
+
+    assert _load_pref_datasets([_pref_cfg(path)]) == [{"prompt": "p0", "chosen": "c0", "rejected": "r0"}]
+
+
+def test_load_supports_parquet(tmp_path):
+    from datasets import Dataset
+
+    path = tmp_path / "pairs.parquet"
+    Dataset.from_list([{"prompt": "p", "chosen": "c", "rejected": "r"}]).to_parquet(str(path))
+
+    assert _load_pref_datasets([_pref_cfg(path)]) == [{"prompt": "p", "chosen": "c", "rejected": "r"}]
+
+
+def test_load_honors_samples_limit(tmp_path):
+    path = tmp_path / "pairs.jsonl"
+    _write_jsonl(path, [{"prompt": f"p{i}", "chosen": f"c{i}", "rejected": f"r{i}"} for i in range(4)])
+
+    rows = _load_pref_datasets([_pref_cfg(path, samples=2)])
+    assert len(rows) == 2
+    assert all(row["prompt"].startswith("p") for row in rows)


### PR DESCRIPTION
## Summary

The dataset framework supported `text`, `instruction`, `conversation`, and `auto`; this adds `preference` (`{prompt, chosen, rejected}` pairs for offline DPO, per `docs/getting-started/quickstart-dpo.md`) as a first-class type and routes `surogate dpo` through it.

- **`PreferenceDatasetConfig`** (`surogate/core/config/dataset_config.py`): `prompt_field`/`chosen_field`/`rejected_field` mappings (defaults `prompt`/`chosen`/`rejected`), optional `enable_thinking_field`, column validation with clear errors; registered in `create_dataset_config`.
- **`PreferencePreprocessor`** (`surogate/core/datasets/preprocessor/preference.py`): normalizes rows to `{prompt, chosen, rejected[, enable_thinking]}`, validates prompt (string or messages list) and both responses, drops invalid rows with logged warnings, strips metadata columns.
- **Framework dispatch**: `pre_process` (loader.py) and `wrap_dataset` (datasets.py) handle `SurogateDatasetType.preference`.
- **DPO trainer**: replaces the raw JSONL-only reader with the shared pipeline — preference data now loads from local jsonl/json/parquet/csv, dataset directories, or HF hub repos, honoring `subset`/`split`/`samples` and field mappings. Declaration order preserved (the trainer still shuffles pairs with `train_seed`).
- **`DPOTrainConfig`**: bare `- path: pairs.jsonl` entries default to `type: preference`; non-preference types are rejected.
- Docs: preference options table in the config reference; quickstart updated.

**Caveat**: a single file mixing string prompts and messages-list prompts no longer loads (pyarrow needs one column type per file); mixing across separate files still works.

## Test plan

- `tests/dpo` loader/config/tokenize: 33 passed (loader tests rewritten for the framework path: field mapping, missing-column error, invalid-row dropping, parquet, samples, order, enable_thinking round-trip; 2 new config tests).
- e2e smoke: bf16 and fp8-hybrid pass. Verified the new loader produces byte-identical rows/tokenized batches/sidecar digest to the old reader, so training numerics are untouched. (One fp8 flake observed only when both e2e tests ran on two GPUs concurrently; passed 3 consecutive reruns incl. same GPU — pre-existing test flakiness, not this change.)
- `tests/distill` + `tests/grpo`: 42 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)