### PR TITLE
docs(datasets): list preference type in the datasets guide

### DIFF
--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -6,7 +6,13 @@ Dataset `type` can be:
 - `text` (pretraining / raw text)
 - `instruction` (instruction/output)
 - `conversation` (chat messages)
+- `preference` (`{prompt, chosen, rejected}` pairs for offline DPO)
 - `auto` (auto-detect)
+
+Every type loads through the same pipeline: `path` may be a local JSONL/JSON/parquet/CSV
+file, a dataset directory, or a HuggingFace hub repo, and `subset`/`split`/`samples`
+apply uniformly. Column names that differ from the defaults are mapped with per-type
+field options (e.g. `text_field`, `messages_field`, `chosen_field`).
 
 See the full schema and examples in the config reference.
 
@@ -14,4 +20,5 @@ See the full schema and examples in the config reference.
 
 - [Config reference: datasets](../reference/config.md)
 - [Quickstart: SFT](../getting-started/quickstart-sft.md)
+- [Quickstart: DPO](../getting-started/quickstart-dpo.md)
 - [Back to docs index](../index.mdx)


### PR DESCRIPTION
Follow-up to #62: the datasets guide (`docs/guides/datasets.md`) still listed only `text`/`instruction`/`conversation`/`auto`. Adds `preference`, a note that all types share the same loading pipeline (local jsonl/json/parquet/csv, dataset directories, HF hub; `subset`/`split`/`samples`; per-type field mappings), and a link to the DPO quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)