### PR TITLE
feat(runtime): Laguna-S 117B SFT on 8 GPUs — LLEP for cpu_training + perf pass

### DIFF
--- a/csrc/src/binding/binding.cpp
+++ b/csrc/src/binding/binding.cpp
@@ -517,6 +517,9 @@ NB_MODULE(_surogate, m) {
             },
             "Enable activation recomputation: 'true' or 'false'.")
         .def_rw("offload_residual", &RuntimeOptions::OffloadResidual, "Offload residual stream buffers.")
+        .def_rw("offload_saved_tensors",
+                &RuntimeOptions::OffloadSavedTensors,
+                "Offload per-layer saved-for-backward tensors to pinned host (requires recompute)")
         .def_rw("lmhead_chunks", &RuntimeOptions::LMHeadChunks, "Split LM head computation into this many chunks.")
         .def_rw("skip_ignored_lmhead_rows",
                 &RuntimeOptions::SkipIgnoredLMHeadRows,

--- a/csrc/src/binding/py_train.cpp
+++ b/csrc/src/binding/py_train.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <cstdlib>
 #include <cstring>
@@ -282,20 +283,47 @@ MultiGPUPyTrainer::MultiGPUPyTrainer(int ngpus,
 MultiGPUPyTrainer::~MultiGPUPyTrainer() {
     mIsRunning = false;
 
-    // make sure all work has finished
-    // Use local_rank() for cudaSetDevice, and don't throw from destructor
-    for (auto& ctx : mContexts) {
-        if (ctx.Communicator) {
-            cudaError_t err = cudaSetDevice(ctx.Communicator->local_rank());
-            if (err == cudaSuccess) {
-                cudaDeviceSynchronize();
+    const bool crashed = mHasCrashed.load() || (mThreads && mThreads->has_exception());
+    if (crashed) {
+        // Workers may be stuck in NCCL collectives waiting for a crashed rank,
+        // and their pending kernels would also make cudaDeviceSynchronize hang.
+        // Abort the comms so everyone can exit, and skip the device syncs. If
+        // they stay wedged (driver-lock deadlocks inside NCCL), force-exit: a
+        // dead process releases its GPUs, a deadlocked one pins them forever.
+        mThreads->abort_async();
+        if (!mThreads->wait_exit_for(15000)) {
+            fprintf(stderr,
+                    "FATAL: MultiGPUPyTrainer workers wedged in NCCL teardown after a crash; "
+                    "forcing process exit to avoid a deadlocked trainer\n");
+            fflush(nullptr);
+            std::_Exit(134);
+        }
+    } else {
+        // make sure all work has finished
+        // Use local_rank() for cudaSetDevice, and don't throw from destructor
+        for (auto& ctx : mContexts) {
+            if (ctx.Communicator) {
+                cudaError_t err = cudaSetDevice(ctx.Communicator->local_rank());
+                if (err == cudaSuccess) {
+                    cudaDeviceSynchronize();
+                }
+                // Ignore errors - we're in destructor, possibly after a crash
             }
-            // Ignore errors - we're in destructor, possibly after a crash
         }
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    mThreads->join();
+    try {
+        mThreads->join();
+    } catch (const std::exception& e) {
+        // The exception was already surfaced to the caller via run_work/wait_gpu;
+        // rethrowing from a destructor would terminate the process.
+        fprintf(stderr, "MultiGPUPyTrainer teardown after error: %s\n", e.what());
+        fflush(stderr);
+    } catch (...) {
+        fprintf(stderr, "MultiGPUPyTrainer teardown after unknown error\n");
+        fflush(stderr);
+    }
 
     // Free the cross-GPU shared base masters (after all streaming work has finished).
     dsl::shared_master_store().clear();
@@ -1436,6 +1464,10 @@ void MultiGPUPyTrainer::init_async_slots(std::size_t n) {
 // GPU picks it up via fetch_work and bumps mCtxDone when finished. Blocks only if that
 // GPU still has an outstanding async item (the natural is_idle backpressure).
 void MultiGPUPyTrainer::dispatch_async(std::function<void(sThreadContext& ctx)> work, int gpu) {
+    if (mHasCrashed.load()) {
+        throw std::runtime_error(
+            "MultiGPUPyTrainer: a worker crashed earlier; the trainer is defunct (restart the process)");
+    }
     wait_gpu(gpu);  // ensure the previous async item on this GPU has completed
     {
         std::lock_guard<std::mutex> lock(mGlobalMutex);
@@ -1451,7 +1483,19 @@ void MultiGPUPyTrainer::wait_gpu(int gpu) {
     while (mCtxDone[g].load(std::memory_order_acquire) < mCtxPending[g].load(std::memory_order_acquire)) {
         if (mThreads->has_exception()) {
             stop();
-            mThreads->join();  // will throw, ending the loop
+            // Surviving ranks may be blocked in NCCL collectives waiting for the
+            // crashed rank; abort the comms (detached — ncclCommAbort can wedge on
+            // driver locks) so they can exit, then surface the root-cause error.
+            mThreads->abort_async();
+            if (mThreads->wait_exit_for(15000)) {
+                mThreads->join();  // will throw, ending the loop
+            } else {
+                fprintf(stderr,
+                        "MultiGPUPyTrainer: workers still wedged after NCCL abort; "
+                        "surfacing stored error without join\n");
+                fflush(stderr);
+                mThreads->rethrow_exception();  // will throw, ending the loop
+            }
         }
         std::this_thread::yield();
     }
@@ -1472,6 +1516,13 @@ void MultiGPUPyTrainer::wait_gpu(int gpu) {
  * @throws Rethrows any exception encountered in worker threads.
  */
 void MultiGPUPyTrainer::run_work(std::function<void(sThreadContext& ctx)> work, int idx) {
+    if (mHasCrashed.load()) {
+        // A worker died (its exception was already rethrown to the caller once);
+        // the surviving workers may be wedged in NCCL and will never process new
+        // work — fail fast instead of spinning on mWorkDone forever.
+        throw std::runtime_error(
+            "MultiGPUPyTrainer: a worker crashed earlier; the trainer is defunct (restart the process)");
+    }
     static int work_id = 0;
     int current_work_id = work_id++;
     {
@@ -1492,10 +1543,38 @@ void MultiGPUPyTrainer::run_work(std::function<void(sThreadContext& ctx)> work, 
         }
     }
 
+    auto last_progress = std::chrono::steady_clock::now();
+    std::size_t last_done = mWorkDone.load();
     while (mWorkDone.load() < mContexts.size()) {
         if (mThreads->has_exception()) {
             stop();
-            mThreads->join();  // will throw, ending the loop
+            // Surviving ranks may be blocked in NCCL collectives waiting for the
+            // crashed rank; abort the comms (detached — ncclCommAbort can wedge on
+            // driver locks) so they can exit, then surface the root-cause error.
+            mThreads->abort_async();
+            if (mThreads->wait_exit_for(15000)) {
+                mThreads->join();  // will throw, ending the loop
+            } else {
+                fprintf(stderr,
+                        "MultiGPUPyTrainer: workers still wedged after NCCL abort; "
+                        "surfacing stored error without join\n");
+                fflush(stderr);
+                mThreads->rethrow_exception();  // will throw, ending the loop
+            }
+        }
+        // Lost-wakeup watchdog: a worker occasionally misses a driver/futex wakeup
+        // under heavy multi-threaded CUDA load and waits forever on an already-met
+        // condition. A no-op signal forces EINTR + recheck. 45s is far above any
+        // legitimate op; poking a healthy worker is harmless.
+        const std::size_t done_now = mWorkDone.load();
+        if (done_now != last_done) {
+            last_done = done_now;
+            last_progress = std::chrono::steady_clock::now();
+        } else if (std::chrono::steady_clock::now() - last_progress > std::chrono::seconds(45)) {
+            fprintf(stderr, "MultiGPUPyTrainer: no worker progress for 45s; poking workers (lost-wakeup recovery)\n");
+            fflush(stderr);
+            mThreads->poke_workers();
+            last_progress = std::chrono::steady_clock::now();
         }
         std::this_thread::yield();
     }
@@ -1642,6 +1721,22 @@ void MultiGPUPyTrainer::main_loop(NCCLCommunicator& comm) {
         }
         loop_iteration++;
     }
+    if (mHasCrashed.load()) {
+        // A peer crashed: it will never reach the barrier, and this device may
+        // hold aborted collective kernels — skip the syncs and free best-effort.
+        try {
+            if (ctx.FullStepGraph) {
+                ctx.FullStepGraph->reset_capture();
+                ctx.FullStepGraph.reset();
+            }
+            ctx.Model.reset();
+            ctx.GPUUtil.reset();
+        } catch (...) {
+            // Teardown after a crash; the root cause is already recorded.
+        }
+        return;
+    }
+
     CUDA_CHECK(cudaDeviceSynchronize());
     comm.barrier();
 

--- a/csrc/src/runtime/dsl/buffer_plan.cpp
+++ b/csrc/src/runtime/dsl/buffer_plan.cpp
@@ -1018,9 +1018,13 @@ qwen3_hybrid_lora_floor(const BufferPlan& plan, const PretrainedConfig& cfg, con
 [[nodiscard]] long moe_op_internal_estimate(const BufferPlan& plan) {
     if (!plan.has_moe()) return 0;
     // Matches `moe_extra` in the pre-refactor heuristic, but in plan units.
+    // With expert parallelism only the local expert shard can appear in any
+    // op-internal temp — sizing this at the global count adds GBs of phantom
+    // stack for large-expert models (Laguna-S: 4.8 GB at E=256, ep=8).
     constexpr long kBytesBF16 = 2;
-    const long expert_gate_up = plan.NumExperts * plan.MoeMUp * plan.C * kBytesBF16;
-    const long expert_down = plan.NumExperts * plan.MoeM * plan.C * kBytesBF16;
+    const long local_experts = std::max(1L, plan.NumExperts / static_cast<long>(std::max(plan.EPSize, 1)));
+    const long expert_gate_up = local_experts * plan.MoeMUp * plan.C * kBytesBF16;
+    const long expert_down = local_experts * plan.MoeM * plan.C * kBytesBF16;
     const long permuted_tokens = 2L * plan.B * plan.T * plan.TopK * plan.C * kBytesBF16;
     const long moe_bwd_act = 2L * plan.B * plan.T * plan.TopK * plan.MoeMUp * kBytesBF16;
     return expert_gate_up + expert_down + permuted_tokens + moe_bwd_act;

--- a/csrc/src/runtime/dsl/dsl_model.cpp
+++ b/csrc/src/runtime/dsl/dsl_model.cpp
@@ -1371,6 +1371,12 @@ DslModel::DslModel(const PretrainedConfig& config,
                                            ? mModelConfig.moe_config->moe_intermediate_size
                                            : mModelConfig.IntermediateSize;
             wm.train_router = mLoRAConfig->train_router;
+            // EP: grouped expert-LoRA holds only this rank's expert shard
+            // (13.6 GB/GPU -> 1.7 GB at Laguna-S scale). Router LoRA stays global.
+            if (mOptions.EPSize > 1 && wm.num_experts % mOptions.EPSize == 0) {
+                wm.num_grouped_experts = wm.num_experts / mOptions.EPSize;
+                wm.grouped_expert_base = (mShardIdx % mOptions.EPSize) * wm.num_grouped_experts;
+            }
         }
         mLoRAWeights = std::make_unique<modules::ModularLoRAWeightsManager>(wm, *mAllocator);
 
@@ -1396,6 +1402,10 @@ DslModel::DslModel(const PretrainedConfig& config,
                                            ? mModelConfig.moe_config->moe_intermediate_size
                                            : mModelConfig.IntermediateSize;
             gm.train_router = mLoRAConfig->train_router;
+            if (mOptions.EPSize > 1 && gm.num_experts % mOptions.EPSize == 0) {
+                gm.num_grouped_experts = gm.num_experts / mOptions.EPSize;
+                gm.grouped_expert_base = (mShardIdx % mOptions.EPSize) * gm.num_grouped_experts;
+            }
         }
         mLoRAGrads = std::make_unique<modules::ModularLoRAGradsManager>(gm, mAllocator);
         std::vector<std::string> lora_grad_hook_schema_ids(

--- a/csrc/src/runtime/dsl/dsl_model_lora.cpp
+++ b/csrc/src/runtime/dsl/dsl_model_lora.cpp
@@ -124,6 +124,18 @@ void DslModel::load_lora_checkpoint(const std::string& checkpoint_dir, NCCLCommu
         import_adapter(adapter_file.string(), comm);
     }
 
+    if (mLoRAWeights && mLoRAWeights->has_ep_local_grouped()) {
+        // Expert adapters (and their optimizer moments) are EP-sharded per rank,
+        // but the optimizer state file holds only rank 0's flat blob — loading it
+        // would corrupt the other ranks' moments. Restart the optimizer instead.
+        if (comm.rank() == 0) {
+            fprintf(stderr,
+                    "[lora] EP-sharded expert adapters: skipping optimizer state restore "
+                    "(optimizer restarts fresh)\n");
+        }
+        return;
+    }
+
     fs::path opt_file = fs::path(checkpoint_dir) / "lora_optimizer.safetensors";
     fs::path opt_meta_file = fs::path(checkpoint_dir) / "lora_optimizer.json";
     if (!fs::exists(opt_file) || !fs::exists(opt_meta_file)) {

--- a/csrc/src/runtime/dsl/dsl_model_weights.cpp
+++ b/csrc/src/runtime/dsl/dsl_model_weights.cpp
@@ -6,7 +6,9 @@
 #include "runtime/dsl/dsl_model.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 #include <string_view>
@@ -208,11 +210,43 @@ void DslModel::import_weights(const std::string& file_name, bool allow_cast, NCC
         adapter_merger = std::make_unique<qlora::AdapterMerger>(mAdapterPath, mHfMapping, reader, shard_config);
     }
 
+    // Progress reporting (rank 0 only): importing a 100B+ model pages hundreds of GB
+    // into pinned memory and can take minutes — without output it looks hung. Rank 0
+    // sweeps the same ordered param list as every other rank and waits on the shared
+    // master store for names other ranks claimed, so its loop position tracks global
+    // progress.
+    const bool report_progress = comm.rank() == 0;
+    const std::size_t progress_total = mParams->param_names().size();
+    std::size_t progress_done = 0;
+    std::size_t progress_bytes = 0;
+    const auto progress_start = std::chrono::steady_clock::now();
+    auto progress_last = progress_start;
+
     for (const auto& name : mParams->param_names()) {
+        if (report_progress) {
+            ++progress_done;
+            const auto now = std::chrono::steady_clock::now();
+            if (now - progress_last >= std::chrono::seconds(5)) {
+                progress_last = now;
+                const double gb = static_cast<double>(progress_bytes) / 1e9;
+                const double secs = std::chrono::duration<double>(now - progress_start).count();
+                fprintf(stderr,
+                        "[import] %zu/%zu tensors | %.1f GB | %.0fs elapsed | %.2f GB/s\n",
+                        progress_done,
+                        progress_total,
+                        gb,
+                        secs,
+                        gb / std::max(secs, 1e-9));
+                fflush(stderr);
+            }
+        }
         if (mParams->is_external(name)) {
             continue;
         }
         Tensor& param = mWeightManager ? mWeightManager->get_master(name) : mParams->get(name);
+        if (report_progress) {
+            progress_bytes += param.bytes();
+        }
 
         // Cross-GPU shared frozen base master: populate (read + page-lock) exactly once.
         // The first GPU manager to reach `name` claims it and reads/registers below; the
@@ -221,7 +255,11 @@ void DslModel::import_weights(const std::string& file_name, bool allow_cast, NCC
         // matter which mapping branch does the read.
         const bool shared_master = mWeightManager && mWeightManager->is_shared_master(name);
         if (shared_master && !dsl::shared_master_store().try_claim(name)) {
-            dsl::shared_master_store().wait_populated(name);
+            // Another rank is reading this shared master. Don't wait here — keep
+            // sweeping so the rank threads read + page-lock DIFFERENT tensors in
+            // parallel (pinning is the import bottleneck, ~1.4 GB/s per thread).
+            // A completion pass after the loop waits for stragglers before the
+            // tied-weight copies, which read these buffers.
             continue;
         }
         struct FinishGuard {
@@ -716,6 +754,29 @@ void DslModel::import_weights(const std::string& file_name, bool allow_cast, NCC
         }
 
         throw std::runtime_error("DSL model: unsupported HF mapping for " + name);
+    }
+
+    // Completion pass: shared masters claimed by other ranks may still be mid-read
+    // (the main loop skips instead of waiting so ranks read in parallel). Every
+    // name was claim-attempted above, so each has exactly one reader to wait for.
+    if (mWeightManager) {
+        for (const auto& name : mParams->param_names()) {
+            if (!mParams->is_external(name) && mWeightManager->is_shared_master(name)) {
+                dsl::shared_master_store().wait_populated(name);
+            }
+        }
+    }
+
+    if (report_progress) {
+        const double gb = static_cast<double>(progress_bytes) / 1e9;
+        const double secs = std::chrono::duration<double>(std::chrono::steady_clock::now() - progress_start).count();
+        fprintf(stderr,
+                "[import] complete: %zu tensors | %.1f GB in %.0fs (%.2f GB/s)\n",
+                progress_done,
+                gb,
+                secs,
+                gb / std::max(secs, 1e-9));
+        fflush(stderr);
     }
 
     for (const auto& tie : tied_params) {

--- a/csrc/src/runtime/dsl/dsl_param_store.cpp
+++ b/csrc/src/runtime/dsl/dsl_param_store.cpp
@@ -281,6 +281,21 @@ bool DslParamStore::is_external(const std::string& name) const {
     return it->second.external;
 }
 
+bool DslParamStore::work_is_transient(const std::string& name) const {
+    auto it = mParams.find(name);
+    if (it == mParams.end()) return false;
+    if (!it->second.managed_by_weight_manager || !mWeightManager) return false;
+    return mWeightManager->work_is_transient(name);
+}
+
+Tensor* DslParamStore::master_tensor(const std::string& name) const {
+    auto it = mParams.find(name);
+    if (it == mParams.end()) return nullptr;
+    if (!it->second.managed_by_weight_manager || !mWeightManager || !mWeightManager->has(name)) return nullptr;
+    Tensor& master = mWeightManager->get_master(name);
+    return master.Data ? &master : nullptr;
+}
+
 const Tensor& DslParamStore::template_tensor(const std::string& name) const {
     auto it = mParams.find(name);
     if (it == mParams.end()) {

--- a/csrc/src/runtime/dsl/dsl_param_store.h
+++ b/csrc/src/runtime/dsl/dsl_param_store.h
@@ -61,6 +61,14 @@ public:
     bool has(const std::string& name) const;
     bool is_trainable(const std::string& name) const;
     bool is_external(const std::string& name) const;
+    /// True when the weight's GPU buffer is refilled between uses (streamed /
+    /// gathered-on-demand weights). See DslWeightManager::work_is_transient.
+    bool work_is_transient(const std::string& name) const;
+    /// The (possibly host-pinned) master tensor for a weight-manager-managed
+    /// param, or nullptr when the param has no weight-manager master. Used by
+    /// LLEP under cpu_training to fetch foreign expert rows from the shared
+    /// global pinned masters.
+    Tensor* master_tensor(const std::string& name) const;
     /// Return a template tensor (shape + dtype) without forcing provider resolution.
     const Tensor& template_tensor(const std::string& name) const;
 

--- a/csrc/src/runtime/dsl/dsl_weight_manager.cpp
+++ b/csrc/src/runtime/dsl/dsl_weight_manager.cpp
@@ -199,6 +199,8 @@ DslWeightManager::DslWeightManager(const Module& module,
     mConfig.shard_idx = shard_idx;
     mConfig.num_shards = num_shards;
     mConfig.shard_weights = options.ShardWeights;
+    mConfig.ep_size = std::max(options.EPSize, 1);
+    mConfig.ep_rank = (mConfig.ep_size > 1) ? (shard_idx % mConfig.ep_size) : 0;
     mConfig.offload_master = options.OffloadMaster;
     mConfig.offload_quants = options.OffloadQuants;
     mConfig.persistent_quants = options.PersistentQuants;
@@ -288,6 +290,17 @@ void DslWeightManager::allocate_weights(const Module& module,
 
         // Cache global (unsharded) shape
         entry.global_shape = shape;
+
+        // Expert Parallelism: a frozen stacked-expert weight only feeds this rank's
+        // local experts (the grouped GEMMs run post-dispatch on local expert ids), so
+        // its prefetch buffer + H2D copy can carry just the ep_rank row block. The
+        // pinned master stays global. Rank>=3 excludes shared-expert weights (2-D)
+        // and matches the QLoRA pipeline's spec-slicing rule.
+        if (mConfig.ep_size > 1 && !sharded_master && entry.is_block && !entry.trainable && shape.size() >= 3 &&
+            shape[0] % mConfig.ep_size == 0 && tensor_role_is_expert_weight_name(name) &&
+            !tensor_role_is_shared_expert_name(name)) {
+            entry.ep_sliced = true;
+        }
 
         // Determine allocation location for master weights
         EAllocationType master_alloc = EAllocationType::ON_DEVICE;
@@ -429,6 +442,23 @@ void DslWeightManager::allocate_weights(const Module& module,
     }
 }
 
+bool DslWeightManager::work_is_transient(const std::string& name) const {
+    auto it = mWeights.find(name);
+    if (it == mWeights.end()) {
+        return false;
+    }
+    const auto& entry = it->second;
+    if (entry.is_block) {
+        return mStreamWeights || mConfig.offload_master;
+    }
+    if (mConfig.cpu_training) {
+        // Embedding and lm_head share one GPU staging buffer; each gather
+        // overwrites it with the tensor about to be consumed.
+        return is_primary_embedding_name(name) || is_lm_head_name(name);
+    }
+    return false;
+}
+
 const DslWeightEntry* DslWeightManager::find_entry_by_name(const std::string& name) const {
     auto it = mWeights.find(name);
     if (it == mWeights.end()) {
@@ -511,6 +541,10 @@ void DslWeightManager::allocate_prefetch_buffers() {
                 std::vector<long> shape = entry.global_shape;
                 if (shape.empty()) {
                     shape.assign(entry.master.Sizes.begin(), entry.master.Sizes.begin() + entry.master.Rank);
+                }
+                // EP-local streaming: the buffer only holds this rank's expert rows.
+                if (entry.ep_sliced) {
+                    shape[0] /= mConfig.ep_size;
                 }
                 // FP8-streamed matmul weights get an FP8 prefetch buffer (half the device
                 // footprint, fed straight to the FP8 GEMM) plus a 2-float device scale slot.
@@ -764,6 +798,20 @@ void DslWeightManager::gather_block(int layer_idx, NCCLCommunicator& comm, cudaS
             }
             TensorShard local(staging, mConfig.shard_idx, mConfig.num_shards, global_shape);
             comm.schedule_all_gather(local, work);
+        } else if (entry.ep_sliced) {
+            // EP-local streaming: copy only this rank's expert row block out of the
+            // global pinned master (dim0 is outermost, so the block is contiguous).
+            std::vector<long> local_shape(entry.master.Sizes.begin(), entry.master.Sizes.begin() + entry.master.Rank);
+            const long local_rows = local_shape[0] / mConfig.ep_size;
+            local_shape[0] = local_rows;
+            std::size_t row_bytes = get_dtype_size(entry.master.DType);
+            for (std::size_t d = 1; d < local_shape.size(); ++d) {
+                row_bytes *= static_cast<std::size_t>(local_shape[d]);
+            }
+            std::byte* src = static_cast<std::byte*>(entry.master.Data) +
+                             static_cast<std::size_t>(mConfig.ep_rank) * static_cast<std::size_t>(local_rows) * row_bytes;
+            Tensor local_master = Tensor::from_pointer(src, entry.master.Device, entry.master.DType, local_shape);
+            convert_to_work(local_master, work, stream);
         } else {
             // Not sharded or single GPU: just copy/convert
             convert_to_work(entry.master, work, stream);

--- a/csrc/src/runtime/dsl/dsl_weight_manager.h
+++ b/csrc/src/runtime/dsl/dsl_weight_manager.h
@@ -59,6 +59,12 @@ struct DslWeightManagerConfig {
     int num_shards = 1;
     bool shard_weights = false;  ///< Enable weight sharding across GPUs
 
+    // Expert Parallelism: when ep_size > 1, frozen stacked-expert weights stream
+    // only this rank's expert rows (dim0 / ep_size at row block ep_rank) into
+    // local-sized prefetch buffers. The pinned master stays global (and shared).
+    int ep_size = 1;
+    int ep_rank = 0;
+
     // Offloading
     bool offload_master = false;     ///< Offload master weights to CPU
     bool offload_quants = false;     ///< Offload quantized weights to CPU
@@ -88,6 +94,7 @@ struct DslWeightEntry {
     bool master_sharded = false;     ///< Whether master tensor is sharded across ranks
     bool trainable = true;           ///< Whether this weight is trainable
     bool is_block = false;           ///< Whether this is a per-layer block weight
+    bool ep_sliced = false;          ///< Stream only this rank's expert rows (EP-local prefetch)
     int layer_idx = -1;              ///< Layer index for block weights (-1 for non-block)
 };
 
@@ -120,6 +127,11 @@ public:
     const Tensor& get(const std::string& name) const;
     bool has(const std::string& name) const;
     bool is_trainable(const std::string& name) const;
+
+    /// True when this weight's work buffer is refilled between uses (streamed
+    /// block weights, and the shared embedding/lm_head staging buffer under
+    /// cpu_training). Quantize-once caches must not snapshot such buffers.
+    bool work_is_transient(const std::string& name) const;
 
     // Layer-based weight streaming protocol
     void gather_block(int layer_idx, NCCLCommunicator& comm, cudaStream_t stream);

--- a/csrc/src/runtime/dsl/graph_compiler.cpp
+++ b/csrc/src/runtime/dsl/graph_compiler.cpp
@@ -6437,6 +6437,26 @@ CompiledGraph GraphCompiler::compile(const Graph& graph, long B, long T, bool is
                             ref.shape = compiled.inputs[0].shape;
                         }
                     }
+                } else if (compiled.type == CompiledOpType::RepeatInterleaveHeads) {
+                    // output[0] = y [B, T, H*repeats, D] — input x [B, T, H, D] with
+                    // the head dim replicated (GQA head expansion for gated-delta q/k).
+                    // Without this, the output falls into the {B,T,C} default below,
+                    // the runtime candidate never matches, and dispatch needs a
+                    // persistent fallback buffer mid-capture (which throws). It also
+                    // starves ChunkGatedDeltaRule's q-input shape right after this op.
+                    if (!compiled.inputs.empty()) {
+                        ref.dtype = compiled.inputs[0].dtype;
+                        if (ref.shape.empty() && compiled.inputs[0].shape.size() == 4) {
+                            long repeats = 1;
+                            if (auto* attr = find_attr(op.attrs, "repeats")) {
+                                if (auto v = attr_int(*attr)) {
+                                    repeats = std::max<long>(1, *v);
+                                }
+                            }
+                            const auto& x_shape = compiled.inputs[0].shape;
+                            ref.shape = {x_shape[0], x_shape[1], x_shape[2] * repeats, x_shape[3]};
+                        }
+                    }
                 } else if (compiled.type == CompiledOpType::ChunkGatedDeltaRule) {
                     // output[0] = out [B, T, H, V] (match value dtype)
                     // output[1] = final_state [B, H, K, V] (kept in FP32 for cache stability)

--- a/csrc/src/runtime/ep/ep_state.h
+++ b/csrc/src/runtime/ep/ep_state.h
@@ -126,6 +126,15 @@ struct LLEPLayerState {
     // Must stay alive as long as weight pointers reference them.
     std::vector<void*> owned_foreign_ptrs;
 
+    /// True when the merged set contains foreign (received) experts. The ops'
+    /// native-refresh heuristic must use THIS, not owned_foreign_ptrs.empty():
+    /// arena-backed foreign buffers leave owned_foreign_ptrs empty.
+    bool has_foreign_experts = false;
+
+    /// Ring-arena slot backing the foreign buffers above (-1 when they were
+    /// cudaMalloc'd instead). Released by EPStrategy, not by free_foreign_gpu.
+    int arena_slot = -1;
+
     void free_lora_gpu() {
         for (void* p : owned_lora_ptrs) {
             if (p) cudaFree(p);

--- a/csrc/src/runtime/ep/ep_state.h
+++ b/csrc/src/runtime/ep/ep_state.h
@@ -15,6 +15,7 @@
 
 #include <cuda_runtime.h>
 
+#include "runtime/ep/lpt_planner.h"
 #include "runtime/lora/lora_types.h"
 #include "utilities/dtype.h"
 #include "utilities/tensor.h"
@@ -24,6 +25,23 @@ namespace ep {
 /// Per-layer EP state: token splits, reorder mappings, persistent GPU buffers.
 /// One instance per (layer_idx, replay_slot) key; see EPStrategy::ep_state_key().
 struct EpLayerState {
+    // Forward-pass dispatch plan cached for recompute replay. Replay must NOT
+    // re-run the imbalance all-reduce / splits exchanges: those collectives
+    // interleave with backward's combine a2a's in the shared launch queue and
+    // intermittently deadlock the issue order. Routing is deterministic, so the
+    // forward plan is bit-identical — replay restores it instead.
+    bool plan_cached = false;
+    bool cached_use_llep = false;
+    int cached_total_send = 0;
+    int cached_total_recv = 0;
+    std::vector<int> cached_send_splits;
+    std::vector<int> cached_recv_splits;
+    std::vector<int> cached_recv_all_counts;
+    std::vector<int> cached_expert_to_gpu;
+    std::vector<int> cached_merged_experts;
+    std::vector<int> cached_global_to_merged;
+    LPTPlan cached_plan;
+
     std::vector<int> send_splits;      // tokens sent to each EP peer
     std::vector<int> recv_splits;      // tokens received from each EP peer
     int total_send = 0;                // sum of send_splits
@@ -133,6 +151,10 @@ struct EPLayerMeta {
     int native_start = 0;               // first native expert's global ID
     int num_local = 0;                  // number of native experts
     std::vector<int> merged_to_global;  // merged_idx → global expert ID
+    // Full expert→primary-GPU map for this layer's plan. Needed by the
+    // backward LoRA-wgrad exchange: every rank derives the same symmetric
+    // helper→owner send/recv schedule from it.
+    std::vector<int> expert_to_gpu;
 };
 
 }  // namespace ep

--- a/csrc/src/runtime/ep/ep_strategy.cpp
+++ b/csrc/src/runtime/ep/ep_strategy.cpp
@@ -22,12 +22,14 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <numeric>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -89,10 +91,37 @@ void permute_tokens_dtyped(Tensor& dst,
 /// Ensure a cudaMalloc'd buffer is at least `need` bytes. Reallocates
 /// (cudaFree → cudaMalloc) when the current capacity is insufficient.
 /// Returns true when the buffer grew.
+/// Poll-wait for a stream instead of cudaStreamSynchronize. The blocking driver
+/// wait showed rare lost-wakeup stalls (minutes; any signal resolved them) under
+/// this process's 8-worker-thread CUDA load; a query loop cannot miss completion.
+void stream_wait_spin(cudaStream_t stream) {
+    while (true) {
+        const cudaError_t st = cudaStreamQuery(stream);
+        if (st == cudaSuccess) {
+            return;
+        }
+        if (st != cudaErrorNotReady) {
+            CUDA_CHECK(st);
+        }
+        (void)cudaGetLastError();  // clear the sticky NotReady
+        std::this_thread::yield();
+    }
+}
+
 bool alloc_or_resize(void*& ptr, std::size_t& cur_bytes, std::size_t need) {
     if (cur_bytes >= need) return false;
     if (ptr) CUDA_CHECK(cudaFree(ptr));
-    CUDA_CHECK(cudaMalloc(&ptr, need));
+    const cudaError_t err = cudaMalloc(&ptr, need);
+    if (err != cudaSuccess) {
+        (void)cudaGetLastError();
+        ptr = nullptr;
+        cur_bytes = 0;
+        std::size_t free_b = 0, total_b = 0;
+        cudaMemGetInfo(&free_b, &total_b);
+        throw std::runtime_error("EP alloc_or_resize: cudaMalloc(" + std::to_string(need) +
+                                 ") failed: " + cudaGetErrorString(err) + " (device free " + std::to_string(free_b) +
+                                 "/" + std::to_string(total_b) + ")");
+    }
     cur_bytes = need;
     return true;
 }
@@ -204,6 +233,24 @@ EPStrategy::EPStrategy(const RuntimeOptions& options)
 
 EPStrategy::~EPStrategy() {
     cleanup_all();
+    for (auto& [slot, buf] : mPinnedScratch) {
+        if (buf.first) {
+            cudaFreeHost(buf.first);
+        }
+    }
+    mPinnedScratch.clear();
+}
+
+void* EPStrategy::pinned_scratch(int slot, std::size_t bytes) {
+    auto& buf = mPinnedScratch[slot];
+    if (buf.second < bytes) {
+        if (buf.first) {
+            CUDA_CHECK(cudaFreeHost(buf.first));
+        }
+        CUDA_CHECK(cudaHostAlloc(&buf.first, bytes, cudaHostAllocDefault));
+        buf.second = bytes;
+    }
+    return buf.first;
 }
 
 cudaStream_t EPStrategy::weight_transfer_stream() {
@@ -228,6 +275,17 @@ void EPStrategy::free_all_llep_layers() {
 }
 
 void EPStrategy::cleanup_all() {
+    // During process teardown the CUDA context may already be unusable (the
+    // NCCL-termination helper can be detached mid-shutdown); freeing then
+    // segfaults. Probe once — leaking at exit is harmless.
+    if (cudaFree(nullptr) != cudaSuccess) {
+        (void)cudaGetLastError();
+        mEpStates.clear();
+        mLLEPStates.clear();
+        mEPLayerMeta.clear();
+        mWeightTransferStream = nullptr;
+        return;
+    }
     for (auto& [layer, state] : mEpStates) {
         state.free_gpu();
     }
@@ -246,12 +304,11 @@ void EPStrategy::cleanup_all() {
 // ============================================================================
 
 bool LLEP::enable_llep_for_layer(bool separate_up_projection) const {
-    // LLEP transfers expert weights between EP peers and keeps merged
-    // per-expert device pointers for the MoE kernels. CPU-training /
-    // offload-master mode streams base weights through transient buffers, so
-    // those pointers are not stable enough for the LLEP transfer path. Static
-    // EP remains valid because it resolves only local experts at use time.
-    if (mOptions.CpuTraining || mOptions.OffloadMaster) {
+    // cpu_training: foreign expert weights are fetched straight from the shared
+    // GLOBAL pinned host masters (fetch_expert_weights_from_host) — always-valid
+    // pointers, no dependence on transient prefetch buffers. Bare offload_master
+    // (dispatch-PP) has no such shared global master and stays on static EP.
+    if (mOptions.OffloadMaster && !mOptions.CpuTraining) {
         return false;
     }
 
@@ -355,10 +412,10 @@ void EPStrategy::parse_forward_layout(CompiledExecutor& exec,
             printed_marker = true;
         }
     }
-    if ((mOptions.CpuTraining || mOptions.OffloadMaster) && supports_llep() && !ctx.llep_supported_for_layer) {
+    if ((mOptions.OffloadMaster && !mOptions.CpuTraining) && supports_llep() && !ctx.llep_supported_for_layer) {
         static bool warned = false;
         if (!warned && exec.mComm && exec.mComm->rank() == 0) {
-            fprintf(stderr, "[EP] LLEP disabled by cpu_training / offload_master.\n");
+            fprintf(stderr, "[EP] LLEP disabled by offload_master (dispatch-PP).\n");
             warned = true;
         }
     } else if (ctx.separate_up_projection && supports_llep() && !ctx.llep_supported_for_layer) {
@@ -394,20 +451,26 @@ void EPStrategy::detect_llep_imbalance(CompiledExecutor& exec, DispatchForwardCt
 
     Tensor counts_gpu =
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.num_experts)}, "ep_expert_counts");
+    // Pageable async copies can block inside the driver's staging pool and
+    // convoy across worker threads — stage all count copies through pinned.
+    int* pin_counts = static_cast<int*>(pinned_scratch(1, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
+    std::memcpy(pin_counts, ctx.local_expert_counts.data(), ctx.num_experts * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(counts_gpu.Data,
-                               ctx.local_expert_counts.data(),
+                               pin_counts,
                                ctx.num_experts * sizeof(int),
                                cudaMemcpyHostToDevice,
                                exec.mRunState.MainStream));
     exec.mComm->all_reduce_sum_int_ep(counts_gpu.get<int>(), ctx.num_experts, exec.mRunState.MainStream);
 
     ctx.global_expert_counts.assign(ctx.num_experts, 0);
-    CUDA_CHECK(cudaMemcpyAsync(ctx.global_expert_counts.data(),
+    int* pin_gcounts = static_cast<int*>(pinned_scratch(2, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
+    CUDA_CHECK(cudaMemcpyAsync(pin_gcounts,
                                counts_gpu.Data,
                                ctx.num_experts * sizeof(int),
                                cudaMemcpyDeviceToHost,
                                exec.mRunState.MainStream));
-    CUDA_CHECK(cudaStreamSynchronize(exec.mRunState.MainStream));
+    stream_wait_spin(exec.mRunState.MainStream);
+    std::memcpy(ctx.global_expert_counts.data(), pin_gcounts, ctx.num_experts * sizeof(int));
     exec.mTemps.push_back(counts_gpu);
 
     const float imbalance =
@@ -445,6 +508,7 @@ void EPStrategy::plan_expert_mapping(DispatchForwardCtx& ctx) {
     meta.native_start = ctx.ep_rank * ctx.num_local;
     meta.num_local = ctx.num_local;
     meta.merged_to_global = ctx.merged_experts;
+    meta.expert_to_gpu = ctx.expert_to_gpu;
 
     ctx.send_splits.assign(ctx.ep_size, 0);
     for (int e = 0; e < ctx.num_experts; ++e) {
@@ -459,15 +523,20 @@ Tensor EPStrategy::apply_llep_send_reorder(CompiledExecutor& exec,
     // H2D uploads for the fused kernel.
     Tensor offsets_gpu =
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.num_experts + 1)}, "ep_offsets_gpu");
+    int* pin_offsets =
+        static_cast<int*>(pinned_scratch(7, static_cast<std::size_t>(ctx.num_experts + 1) * sizeof(int)));
+    std::memcpy(pin_offsets, ctx.expert_offsets.data(), (ctx.num_experts + 1) * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(offsets_gpu.Data,
-                               ctx.expert_offsets.data(),
+                               pin_offsets,
                                (ctx.num_experts + 1) * sizeof(int),
                                cudaMemcpyHostToDevice,
                                exec.mRunState.MainStream));
 
     Tensor e2g_gpu = exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.num_experts)}, "ep_e2g_gpu");
+    int* pin_e2g = static_cast<int*>(pinned_scratch(8, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
+    std::memcpy(pin_e2g, ctx.expert_to_gpu.data(), ctx.num_experts * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(e2g_gpu.Data,
-                               ctx.expert_to_gpu.data(),
+                               pin_e2g,
                                ctx.num_experts * sizeof(int),
                                cudaMemcpyHostToDevice,
                                exec.mRunState.MainStream));
@@ -526,8 +595,13 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.ep_size)}, "ep_send_splits_gpu");
     Tensor recv_splits_gpu =
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.ep_size)}, "ep_recv_splits_gpu");
+    // All small host<->device count copies below go through PINNED staging:
+    // pageable async copies can block in the driver's staging pool and convoy
+    // across worker threads into a cross-rank deadlock (observed under LLEP).
+    int* pin_send_splits = static_cast<int*>(pinned_scratch(3, static_cast<std::size_t>(ctx.ep_size) * sizeof(int)));
+    std::memcpy(pin_send_splits, ctx.send_splits.data(), ctx.ep_size * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(send_splits_gpu.Data,
-                               ctx.send_splits.data(),
+                               pin_send_splits,
                                ctx.ep_size * sizeof(int),
                                cudaMemcpyHostToDevice,
                                exec.mRunState.MainStream));
@@ -546,10 +620,12 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
     Tensor recv_ec_gpu = exec.mRunState.temp_alloc(ETensorDType::INT32,
                                                    {static_cast<long>(ctx.num_experts * ctx.ep_size)},
                                                    "ep_recv_ec_gpu");
+    int* pin_ec = static_cast<int*>(pinned_scratch(4, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
+    std::memcpy(pin_ec, ctx.local_expert_counts.data(), ctx.num_experts * sizeof(int));
     for (int p = 0; p < ctx.ep_size; ++p) {
         CUDA_CHECK(cudaMemcpyAsync(static_cast<std::byte*>(send_ec_gpu.Data) +
                                        static_cast<std::size_t>(p) * ctx.num_experts * sizeof(int),
-                                   ctx.local_expert_counts.data(),
+                                   pin_ec,
                                    ctx.num_experts * sizeof(int),
                                    cudaMemcpyHostToDevice,
                                    exec.mRunState.MainStream));
@@ -564,18 +640,23 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                   exec.mRunState.MainStream);
 
     ctx.recv_splits.assign(ctx.ep_size, 0);
-    CUDA_CHECK(cudaMemcpyAsync(ctx.recv_splits.data(),
+    int* pin_recv_splits = static_cast<int*>(pinned_scratch(5, static_cast<std::size_t>(ctx.ep_size) * sizeof(int)));
+    CUDA_CHECK(cudaMemcpyAsync(pin_recv_splits,
                                recv_splits_gpu.Data,
                                ctx.ep_size * sizeof(int),
                                cudaMemcpyDeviceToHost,
                                exec.mRunState.MainStream));
     ctx.recv_all_counts.assign(ctx.num_experts * ctx.ep_size, 0);
-    CUDA_CHECK(cudaMemcpyAsync(ctx.recv_all_counts.data(),
+    int* pin_recv_ec = static_cast<int*>(
+        pinned_scratch(6, static_cast<std::size_t>(ctx.num_experts) * ctx.ep_size * sizeof(int)));
+    CUDA_CHECK(cudaMemcpyAsync(pin_recv_ec,
                                recv_ec_gpu.Data,
                                ctx.num_experts * ctx.ep_size * sizeof(int),
                                cudaMemcpyDeviceToHost,
                                exec.mRunState.MainStream));
-    CUDA_CHECK(cudaStreamSynchronize(exec.mRunState.MainStream));
+    stream_wait_spin(exec.mRunState.MainStream);
+    std::memcpy(ctx.recv_splits.data(), pin_recv_splits, ctx.ep_size * sizeof(int));
+    std::memcpy(ctx.recv_all_counts.data(), pin_recv_ec, ctx.num_experts * ctx.ep_size * sizeof(int));
     exec.mTemps.push_back(send_splits_gpu);
     exec.mTemps.push_back(recv_splits_gpu);
     exec.mTemps.push_back(send_ec_gpu);
@@ -606,6 +687,12 @@ bool EPStrategy::launch_llep_transfers(CompiledExecutor& exec,
     CUDA_CHECK(cudaStreamWaitEvent(wt_stream, wt_start));
     CUDA_CHECK(cudaEventDestroy(wt_start));
 
+    // cpu_training: helpers self-serve foreign experts from the shared GLOBAL
+    // pinned host masters — no peer transfer for base weights at all.
+    Tensor* master_gu =
+        mOptions.CpuTraining ? exec.mWeights.master_tensor(ctx.layer_prefix + ctx.up_weight_name) : nullptr;
+    Tensor* master_dn = mOptions.CpuTraining ? exec.mWeights.master_tensor(ctx.layer_prefix + "experts_down") : nullptr;
+
     // Prefer quantized transfer (2-8× less P2P bandwidth) when available.
     auto* provider = exec.mWeights.qlora_provider();
     const qlora::QuantizedTensor* qt_gu =
@@ -614,7 +701,9 @@ bool EPStrategy::launch_llep_transfers(CompiledExecutor& exec,
         provider ? provider->try_get_quantized(ctx.layer_prefix + "experts_down") : nullptr;
     qlora::IQuantizer* quantizer = provider ? provider->get_quantizer() : nullptr;
 
-    if (qt_gu && qt_dn && qt_gu->is_quantized() && qt_dn->is_quantized() && quantizer && !qt_gu->is_on_host()) {
+    if (master_gu && master_dn && master_gu->Rank >= 3 && master_dn->Rank >= 3) {
+        ep::fetch_expert_weights_from_host(ctx.plan, wt_stream, ctx.foreign_weights, *master_gu, *master_dn);
+    } else if (qt_gu && qt_dn && qt_gu->is_quantized() && qt_dn->is_quantized() && quantizer && !qt_gu->is_on_host()) {
         ep::transfer_expert_weights_quantized(ctx.plan,
                                               *exec.mComm,
                                               exec.mRunState,
@@ -808,12 +897,14 @@ void EPStrategy::permute_recv_tokens(CompiledExecutor& exec,
 
     // Cache host offsets for grouped GEMM fast-path lookup.
     std::vector<int> merged_offsets_host(ctx.num_merged + 1);
-    CUDA_CHECK(cudaMemcpyAsync(merged_offsets_host.data(),
+    int* pin_moff = static_cast<int*>(pinned_scratch(9, static_cast<std::size_t>(ctx.num_merged + 1) * sizeof(int)));
+    CUDA_CHECK(cudaMemcpyAsync(pin_moff,
                                merged_offsets_t.get<int>(),
                                (ctx.num_merged + 1) * sizeof(int),
                                cudaMemcpyDeviceToHost,
                                exec.mRunState.MainStream));
-    CUDA_CHECK(cudaStreamSynchronize(exec.mRunState.MainStream));
+    stream_wait_spin(exec.mRunState.MainStream);
+    std::memcpy(merged_offsets_host.data(), pin_moff, (ctx.num_merged + 1) * sizeof(int));
     exec.mMoEHostOffsetsCache[ctx.ep_key] = std::move(merged_offsets_host);
 
     // Persist send_order (local_gather) and recv_reorder (local_scatter)
@@ -1050,12 +1141,14 @@ Tensor EPStrategy::apply_llep_inverse_reorder(CompiledExecutor& exec,
                                               std::size_t& out_bytes) {
     const int N = ep_state.total_send;
     std::vector<int> send_order_host(N);
-    CUDA_CHECK(cudaMemcpyAsync(send_order_host.data(),
+    int* pin_order = static_cast<int*>(pinned_scratch(10, static_cast<std::size_t>(N) * sizeof(int)));
+    CUDA_CHECK(cudaMemcpyAsync(pin_order,
                                ep_state.llep_send_reorder_gpu,
                                N * sizeof(int),
                                cudaMemcpyDeviceToHost,
                                exec.mRunState.MainStream));
-    CUDA_CHECK(cudaStreamSynchronize(exec.mRunState.MainStream));
+    stream_wait_spin(exec.mRunState.MainStream);
+    std::memcpy(send_order_host.data(), pin_order, static_cast<std::size_t>(N) * sizeof(int));
 
     std::vector<int> inverse_order(N);
     for (int i = 0; i < N; ++i)
@@ -1063,8 +1156,10 @@ Tensor EPStrategy::apply_llep_inverse_reorder(CompiledExecutor& exec,
 
     const std::size_t inv_gpu_bytes = static_cast<std::size_t>(N) * sizeof(int);
     void* inv_gpu_ptr = mBufferPool.acquire(inv_gpu_bytes);
+    int* pin_inv = static_cast<int*>(pinned_scratch(11, static_cast<std::size_t>(N) * sizeof(int)));
+    std::memcpy(pin_inv, inverse_order.data(), static_cast<std::size_t>(N) * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(inv_gpu_ptr,
-                               inverse_order.data(),
+                               pin_inv,
                                N * sizeof(int),
                                cudaMemcpyHostToDevice,
                                exec.mRunState.MainStream));
@@ -1115,6 +1210,25 @@ void EPStrategy::finalize_native_only_state(CompiledExecutor& exec, DispatchForw
 // dispatch_forward — orchestrator
 // ============================================================================
 
+namespace {
+bool ep_trace_enabled() {
+    static const bool on = [] {
+        const char* env = std::getenv("SUROGATE_EP_TRACE");
+        return env && std::string(env) == "1";
+    }();
+    return on;
+}
+}  // namespace
+
+#define EP_TRACE(exec_, ctx_, fmt_, ...)                                                                     \
+    do {                                                                                                     \
+        if (ep_trace_enabled()) {                                                                            \
+            fprintf(stderr, "[ep-trace r%d L%d] " fmt_ "\n", (exec_).mComm ? (exec_).mComm->rank() : -1,     \
+                    (ctx_).layer_idx, ##__VA_ARGS__);                                                        \
+            fflush(stderr);                                                                                  \
+        }                                                                                                    \
+    } while (0)
+
 void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) {
     Tensor& permuted_input = exec.resolve_tensor(op.inputs[0]);
     Tensor& routing_indices = exec.resolve_tensor(op.inputs[1]);
@@ -1131,7 +1245,51 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
 
     DispatchForwardCtx ctx;
     parse_forward_layout(exec, op, permuted_input, ctx);
-    detect_llep_imbalance(exec, ctx);
+
+    // Recompute replay: restore the forward pass's dispatch plan instead of
+    // re-running the imbalance all-reduce + splits exchanges (collectives in
+    // backward intermittently deadlock the shared launch queue's issue order,
+    // and the results are identical — routing is deterministic).
+    bool reused_plan = false;
+    if (exec.mInReplay) {
+        auto fwd_it = mEpStates.find(ep_state_key(ctx.layer_idx, /*in_replay=*/false));
+        if (fwd_it != mEpStates.end() && fwd_it->second.plan_cached) {
+            const auto& c = fwd_it->second;
+            long total_now = 0;
+            for (int v : ctx.local_expert_counts) total_now += v;
+            if (total_now != c.cached_total_send) {
+                throw std::runtime_error("ep_dispatch replay: routing diverged from forward at layer " +
+                                         std::to_string(ctx.layer_idx) + " (fwd total_send " +
+                                         std::to_string(c.cached_total_send) + ", replay " +
+                                         std::to_string(total_now) + ")");
+            }
+            ctx.use_llep = c.cached_use_llep;
+            ctx.plan = c.cached_plan;
+            ctx.expert_to_gpu = c.cached_expert_to_gpu;
+            ctx.merged_experts = c.cached_merged_experts;
+            ctx.global_to_merged = c.cached_global_to_merged;
+            ctx.num_merged = static_cast<int>(c.cached_merged_experts.size());
+            ctx.send_splits = c.cached_send_splits;
+            ctx.recv_splits = c.cached_recv_splits;
+            ctx.recv_all_counts = c.cached_recv_all_counts;
+            ctx.total_send = c.cached_total_send;
+            ctx.total_recv = c.cached_total_recv;
+            reused_plan = true;
+            // Backward ops resolve EPLayerMeta by key — mirror what
+            // plan_expert_mapping would have written for this (replay) key.
+            auto& rmeta = mEPLayerMeta[ctx.ep_key];
+            rmeta.num_merged = ctx.num_merged;
+            rmeta.native_start = ctx.ep_rank * ctx.num_local;
+            rmeta.num_local = ctx.num_local;
+            rmeta.merged_to_global = ctx.merged_experts;
+            rmeta.expert_to_gpu = ctx.expert_to_gpu;
+            EP_TRACE(exec, ctx, "replay reusing forward plan use_llep=%d", ctx.use_llep ? 1 : 0);
+        }
+    }
+    if (!reused_plan) {
+        detect_llep_imbalance(exec, ctx);
+        EP_TRACE(exec, ctx, "detect done use_llep=%d", ctx.use_llep ? 1 : 0);
+    }
 
     // Drop any stale LLEP state from earlier layers. Foreign expert weight
     // buffers are ~20 MB each and accumulate across MoE layers, causing OOM
@@ -1143,9 +1301,27 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
         ep_state.llep_send_reorder_gpu = nullptr;
         ep_state.llep_send_reorder_bytes = 0;
     }
-    free_all_llep_layers();
+    // Keep earlier layers' merged LoRA for this step's backward (the LoRA dx/wgrad
+    // paths need it on EVERY rebalanced layer, not just the last). Free their large
+    // FOREIGN BASE buffers (backward re-fetches from host masters under cpu_training;
+    // resident mode falls back to the case-2 reconstruct) and drop their stale
+    // weight pointers. This layer's own previous state is recycled in full.
+    for (auto& [k_st, st] : mLLEPStates) {
+        st.free_foreign_gpu();
+        st.gate_up_weight_ptrs.clear();
+        st.down_weight_ptrs.clear();
+        st.active = false;
+    }
+    if (auto self_it = mLLEPStates.find(ctx.ep_key); self_it != mLLEPStates.end()) {
+        self_it->second.free_lora_gpu();
+        mLLEPStates.erase(self_it);
+    }
 
-    plan_expert_mapping(ctx);
+    if (!reused_plan) {
+        plan_expert_mapping(ctx);
+        EP_TRACE(exec, ctx, "plan done merged=%d send=%zu recv=%zu", ctx.num_merged,
+                 ctx.plan.weights_to_send.size(), ctx.plan.weights_to_receive.size());
+    }
 
     // Token buffer — either the caller's permuted input, or a LLEP-reordered copy.
     Tensor llep_send_buf;
@@ -1155,7 +1331,23 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
         send_ptr = &llep_send_buf;
     }
 
-    exchange_token_splits(exec, ctx);
+    if (!reused_plan) {
+        exchange_token_splits(exec, ctx);
+        EP_TRACE(exec, ctx, "splits done total_send=%d total_recv=%d", ctx.total_send, ctx.total_recv);
+        // Cache the plan for this layer's recompute replay.
+        auto& st = mEpStates[ctx.ep_key];
+        st.plan_cached = true;
+        st.cached_use_llep = ctx.use_llep;
+        st.cached_plan = ctx.plan;
+        st.cached_expert_to_gpu = ctx.expert_to_gpu;
+        st.cached_merged_experts = ctx.merged_experts;
+        st.cached_global_to_merged = ctx.global_to_merged;
+        st.cached_send_splits = ctx.send_splits;
+        st.cached_recv_splits = ctx.recv_splits;
+        st.cached_recv_all_counts = ctx.recv_all_counts;
+        st.cached_total_send = ctx.total_send;
+        st.cached_total_recv = ctx.total_recv;
+    }
 
     // Launch LLEP base + LoRA transfers on a separate stream (overlaps the
     // token A2A below). Returns pointers to the native weights (needed later
@@ -1163,11 +1355,13 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     Tensor* native_gate_up_ptr = nullptr;
     Tensor* native_down_ptr = nullptr;
     launch_llep_transfers(exec, ctx, native_gate_up_ptr, native_down_ptr);
+    EP_TRACE(exec, ctx, "transfers launched");
 
     // Token A2A.
     void* recv_hidden_ptr = nullptr;
     std::size_t recv_hidden_bytes = 0;
     Tensor recv_hidden = run_token_a2a(exec, ctx, *send_ptr, recv_hidden_ptr, recv_hidden_bytes);
+    EP_TRACE(exec, ctx, "token a2a done");
     dsl::CommunicationHookPayload comm_payload;
     comm_payload.send_tensor = send_ptr;
     comm_payload.recv_tensor = &recv_hidden;

--- a/csrc/src/runtime/ep/ep_strategy.cpp
+++ b/csrc/src/runtime/ep/ep_strategy.cpp
@@ -253,6 +253,13 @@ void* EPStrategy::pinned_scratch(int slot, std::size_t bytes) {
     return buf.first;
 }
 
+cudaStream_t EPStrategy::control_stream() {
+    if (!mControlStream) {
+        CUDA_CHECK(cudaStreamCreateWithFlags(&mControlStream, cudaStreamNonBlocking));
+    }
+    return mControlStream;
+}
+
 cudaStream_t EPStrategy::weight_transfer_stream() {
     if (!mWeightTransferStream) {
         CUDA_CHECK(cudaStreamCreateWithFlags(&mWeightTransferStream, cudaStreamNonBlocking));
@@ -267,7 +274,13 @@ int EPStrategy::ep_state_key(int layer_idx, bool in_replay) const {
 }
 
 void EPStrategy::free_all_llep_layers() {
+    if (mPrefetched) {
+        mForeignArena.release(mPrefetched->arena_slot, nullptr);
+        mPrefetched.reset();
+    }
     for (auto& [_, state] : mLLEPStates) {
+        mForeignArena.release(state.arena_slot, nullptr);
+        state.arena_slot = -1;
         state.free_lora_gpu();
         state.free_foreign_gpu();
     }
@@ -284,6 +297,7 @@ void EPStrategy::cleanup_all() {
         mLLEPStates.clear();
         mEPLayerMeta.clear();
         mWeightTransferStream = nullptr;
+        mControlStream = nullptr;
         return;
     }
     for (auto& [layer, state] : mEpStates) {
@@ -293,9 +307,14 @@ void EPStrategy::cleanup_all() {
     free_all_llep_layers();
     mEPLayerMeta.clear();
     mBufferPool.clear_all();
+    mForeignArena.free_all();
     if (mWeightTransferStream) {
         cudaStreamDestroy(mWeightTransferStream);
         mWeightTransferStream = nullptr;
+    }
+    if (mControlStream) {
+        cudaStreamDestroy(mControlStream);
+        mControlStream = nullptr;
     }
 }
 
@@ -335,6 +354,8 @@ std::unique_ptr<EPStrategy> create_strategy(const RuntimeOptions& options) {
 
 struct EPStrategy::DispatchForwardCtx {
     int layer_idx = -1;
+    int arena_slot = -1;
+    bool reuse_fwd_merged_lora = false;
     int ep_size = 1;
     int ep_rank = 0;
     int ep_key = -1;
@@ -449,18 +470,21 @@ void EPStrategy::detect_llep_imbalance(CompiledExecutor& exec, DispatchForwardCt
     const float threshold = mOptions.EPLoadBalanceThreshold;
     if (!ctx.llep_supported_for_layer || threshold >= 100.0f) return;
 
+    // The imbalance detection depends ONLY on host-side routing counts — run
+    // it on the dedicated EP control stream so its completion wait covers four
+    // tiny ops instead of the whole MainStream pipeline backlog (profiled as a
+    // dominant cost: full-stream waits per layer).
+    cudaStream_t cstream = control_stream();
     Tensor counts_gpu =
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.num_experts)}, "ep_expert_counts");
-    // Pageable async copies can block inside the driver's staging pool and
-    // convoy across worker threads — stage all count copies through pinned.
     int* pin_counts = static_cast<int*>(pinned_scratch(1, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
     std::memcpy(pin_counts, ctx.local_expert_counts.data(), ctx.num_experts * sizeof(int));
     CUDA_CHECK(cudaMemcpyAsync(counts_gpu.Data,
                                pin_counts,
                                ctx.num_experts * sizeof(int),
                                cudaMemcpyHostToDevice,
-                               exec.mRunState.MainStream));
-    exec.mComm->all_reduce_sum_int_ep(counts_gpu.get<int>(), ctx.num_experts, exec.mRunState.MainStream);
+                               cstream));
+    exec.mComm->all_reduce_sum_int_ep(counts_gpu.get<int>(), ctx.num_experts, cstream);
 
     ctx.global_expert_counts.assign(ctx.num_experts, 0);
     int* pin_gcounts = static_cast<int*>(pinned_scratch(2, static_cast<std::size_t>(ctx.num_experts) * sizeof(int)));
@@ -468,8 +492,8 @@ void EPStrategy::detect_llep_imbalance(CompiledExecutor& exec, DispatchForwardCt
                                counts_gpu.Data,
                                ctx.num_experts * sizeof(int),
                                cudaMemcpyDeviceToHost,
-                               exec.mRunState.MainStream));
-    stream_wait_spin(exec.mRunState.MainStream);
+                               cstream));
+    stream_wait_spin(cstream);
     std::memcpy(ctx.global_expert_counts.data(), pin_gcounts, ctx.num_experts * sizeof(int));
     exec.mTemps.push_back(counts_gpu);
 
@@ -590,6 +614,10 @@ Tensor EPStrategy::apply_llep_send_reorder(CompiledExecutor& exec,
 }
 
 void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCtx& ctx) {
+    // Count exchanges depend only on host-side routing counts — run them on
+    // the dedicated EP control stream so the completion wait below covers a
+    // few tiny ops instead of the whole MainStream pipeline backlog.
+    cudaStream_t cstream = control_stream();
     // A2A #1: per-GPU token splits (1 int per peer).
     Tensor send_splits_gpu =
         exec.mRunState.temp_alloc(ETensorDType::INT32, {static_cast<long>(ctx.ep_size)}, "ep_send_splits_gpu");
@@ -604,14 +632,14 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                pin_send_splits,
                                ctx.ep_size * sizeof(int),
                                cudaMemcpyHostToDevice,
-                               exec.mRunState.MainStream));
+                               cstream));
     std::vector<int> ones(ctx.ep_size, 1);
     exec.mComm->all_to_all_single(reinterpret_cast<const std::byte*>(send_splits_gpu.Data),
                                   reinterpret_cast<std::byte*>(recv_splits_gpu.Data),
                                   ones.data(),
                                   ones.data(),
                                   sizeof(int),
-                                  exec.mRunState.MainStream);
+                                  cstream);
 
     // A2A #2: per-expert counts (num_experts ints per peer).
     Tensor send_ec_gpu = exec.mRunState.temp_alloc(ETensorDType::INT32,
@@ -628,7 +656,7 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                    pin_ec,
                                    ctx.num_experts * sizeof(int),
                                    cudaMemcpyHostToDevice,
-                                   exec.mRunState.MainStream));
+                                   cstream));
     }
     std::vector<int> ec_send_splits(ctx.ep_size, ctx.num_experts);
     std::vector<int> ec_recv_splits(ctx.ep_size, ctx.num_experts);
@@ -637,7 +665,7 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                   ec_send_splits.data(),
                                   ec_recv_splits.data(),
                                   sizeof(int),
-                                  exec.mRunState.MainStream);
+                                  cstream);
 
     ctx.recv_splits.assign(ctx.ep_size, 0);
     int* pin_recv_splits = static_cast<int*>(pinned_scratch(5, static_cast<std::size_t>(ctx.ep_size) * sizeof(int)));
@@ -645,7 +673,7 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                recv_splits_gpu.Data,
                                ctx.ep_size * sizeof(int),
                                cudaMemcpyDeviceToHost,
-                               exec.mRunState.MainStream));
+                               cstream));
     ctx.recv_all_counts.assign(ctx.num_experts * ctx.ep_size, 0);
     int* pin_recv_ec = static_cast<int*>(
         pinned_scratch(6, static_cast<std::size_t>(ctx.num_experts) * ctx.ep_size * sizeof(int)));
@@ -653,8 +681,8 @@ void EPStrategy::exchange_token_splits(CompiledExecutor& exec, DispatchForwardCt
                                recv_ec_gpu.Data,
                                ctx.num_experts * ctx.ep_size * sizeof(int),
                                cudaMemcpyDeviceToHost,
-                               exec.mRunState.MainStream));
-    stream_wait_spin(exec.mRunState.MainStream);
+                               cstream));
+    stream_wait_spin(cstream);
     std::memcpy(ctx.recv_splits.data(), pin_recv_splits, ctx.ep_size * sizeof(int));
     std::memcpy(ctx.recv_all_counts.data(), pin_recv_ec, ctx.num_experts * ctx.ep_size * sizeof(int));
     exec.mTemps.push_back(send_splits_gpu);
@@ -677,6 +705,28 @@ bool EPStrategy::launch_llep_transfers(CompiledExecutor& exec,
 
     native_gate_up_out = &exec.mWeights.get(ctx.layer_prefix + ctx.up_weight_name);
     native_down_out = &exec.mWeights.get(ctx.layer_prefix + "experts_down");
+
+    // Foreign receive buffers come from the ring arena (opened here, released
+    // at the next dispatch's cleanup). The wt stream inherits the slot's
+    // reuse guard transitively through the wt_start wait on MainStream below.
+    // Backward: adopt the buffers prefetched during the previous replay layer
+    // when they cover exactly this plan's receive set.
+    bool adopted_prefetch = false;
+    if (mPrefetched && mPrefetched->layer_idx == ctx.layer_idx) {
+        if (mPrefetched->receive_set == ctx.plan.weights_to_receive) {
+            ctx.foreign_weights = std::move(mPrefetched->weights);
+            ctx.arena_slot = mPrefetched->arena_slot;
+            mForeignArena.reopen(ctx.arena_slot);
+            adopted_prefetch = true;
+        } else {
+            mForeignArena.release(mPrefetched->arena_slot, mWeightTransferStream);
+        }
+        mPrefetched.reset();
+    }
+    if (!adopted_prefetch) {
+        ctx.arena_slot = mForeignArena.begin(exec.mRunState.MainStream);
+    }
+    ctx.foreign_weights.arena_alloc = [this](std::size_t bytes) { return mForeignArena.alloc(bytes); };
 
     cudaStream_t wt_stream = weight_transfer_stream();
     // Make the weight-transfer stream wait for MainStream (native dequant
@@ -701,7 +751,10 @@ bool EPStrategy::launch_llep_transfers(CompiledExecutor& exec,
         provider ? provider->try_get_quantized(ctx.layer_prefix + "experts_down") : nullptr;
     qlora::IQuantizer* quantizer = provider ? provider->get_quantizer() : nullptr;
 
-    if (master_gu && master_dn && master_gu->Rank >= 3 && master_dn->Rank >= 3) {
+    if (adopted_prefetch) {
+        // Base weights already resident (prefetched during the previous replay
+        // layer's backward compute) — nothing to fetch.
+    } else if (master_gu && master_dn && master_gu->Rank >= 3 && master_dn->Rank >= 3) {
         ep::fetch_expert_weights_from_host(ctx.plan, wt_stream, ctx.foreign_weights, *master_gu, *master_dn);
     } else if (qt_gu && qt_dn && qt_gu->is_quantized() && qt_dn->is_quantized() && quantizer && !qt_gu->is_on_host()) {
         ep::transfer_expert_weights_quantized(ctx.plan,
@@ -728,8 +781,21 @@ bool EPStrategy::launch_llep_transfers(CompiledExecutor& exec,
                                     ctx.ep_rank);
     }
 
+    // Replay: forward's merged LoRA tensors are still alive (kept for the
+    // backward pass) and the adapters can't have changed within the step —
+    // skip the per-layer NCCL LoRA exchange and reuse them in finalize.
+    // Uniform across ranks: every rank derives both merged sets from the same
+    // cached forward plan, so all ranks skip (or run) the exchange together.
+    if (exec.mInReplay) {
+        auto fwd_it = mLLEPStates.find(ep_state_key(ctx.layer_idx, /*in_replay=*/false));
+        if (fwd_it != mLLEPStates.end() && fwd_it->second.has_merged_lora &&
+            fwd_it->second.merged_to_global == ctx.merged_experts) {
+            ctx.reuse_fwd_merged_lora = true;
+        }
+    }
+
     // Transfer per-expert LoRA adapters alongside base weights.
-    if (exec.mLoRAConfig && exec.mLoRAWeights && exec.mLoRAConfig->enabled() && exec.mLoRAWeights->enabled()) {
+    if (!ctx.reuse_fwd_merged_lora && exec.mLoRAConfig && exec.mLoRAWeights && exec.mLoRAConfig->enabled() && exec.mLoRAWeights->enabled()) {
         auto& lora_block = exec.mLoRAWeights->get_block(ctx.layer_idx, wt_stream);
         if (lora_block.moe.use_grouped) {
             const auto& g = lora_block.moe.grouped;
@@ -959,11 +1025,17 @@ void EPStrategy::finalize_llep_state(CompiledExecutor& exec,
     }
 
     auto& llep = mLLEPStates[ctx.ep_key];
+    llep.has_foreign_experts = !ctx.foreign_weights.weights.empty();
     populate_llep_weight_pointers(llep, ctx, native_gate_up, native_down, &ctx.foreign_weights);
     const int native_start = ctx.ep_rank * ctx.num_local;
 
     // Build merged LoRA tensors (native + foreign adapters concatenated).
-    if (exec.mLoRAConfig && exec.mLoRAWeights && exec.mLoRAConfig->enabled() && exec.mLoRAWeights->enabled()) {
+    if (ctx.reuse_fwd_merged_lora) {
+        const auto& fwd = mLLEPStates.at(ep_state_key(ctx.layer_idx, /*in_replay=*/false));
+        llep.merged_lora = fwd.merged_lora;
+        llep.has_merged_lora = true;
+        // owned_lora_ptrs stays empty — the forward state owns the buffers.
+    } else if (exec.mLoRAConfig && exec.mLoRAWeights && exec.mLoRAConfig->enabled() && exec.mLoRAWeights->enabled()) {
         auto& lora_block = exec.mLoRAWeights->get_block(ctx.layer_idx, exec.mRunState.MainStream);
         if (lora_block.moe.use_grouped && lora_block.moe.grouped.has_any()) {
             const auto& g = lora_block.moe.grouped;
@@ -1080,6 +1152,7 @@ void EPStrategy::finalize_llep_state(CompiledExecutor& exec,
     // they must stay alive until the LLEP state is cleared.
     llep.owned_foreign_ptrs = std::move(ctx.foreign_weights.owned_gpu_ptrs);
     ctx.foreign_weights.owned_gpu_ptrs.clear();  // prevent double-free
+    llep.arena_slot = ctx.arena_slot;
 }
 
 void EPStrategy::populate_llep_weight_pointers(LLEPLayerState& llep,
@@ -1220,6 +1293,32 @@ bool ep_trace_enabled() {
 }
 }  // namespace
 
+bool ep_prof_enabled() {
+    static const bool on = [] {
+        const char* env = std::getenv("SUROGATE_EP_PROF");
+        return env && std::string(env) == "1";
+    }();
+    return on;
+}
+
+/// Host-side phase timing for the EP dispatch path (launch + host-sync cost).
+struct EpPhaseProf {
+    double ms[8] = {0};
+    long count = 0;
+    static constexpr const char* names[8] =
+        {"detect", "plan", "reorder", "splits", "transfers", "a2a", "permute", "finalize"};
+};
+EpPhaseProf g_ep_prof;
+
+struct EpPhaseTimer {
+    int slot;
+    std::chrono::steady_clock::time_point t0;
+    explicit EpPhaseTimer(int s) : slot(s), t0(std::chrono::steady_clock::now()) {}
+    ~EpPhaseTimer() {
+        g_ep_prof.ms[slot] += std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    }
+};
+
 #define EP_TRACE(exec_, ctx_, fmt_, ...)                                                                     \
     do {                                                                                                     \
         if (ep_trace_enabled()) {                                                                            \
@@ -1287,8 +1386,16 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
         }
     }
     if (!reused_plan) {
+        EpPhaseTimer prof_detect(0);
         detect_llep_imbalance(exec, ctx);
         EP_TRACE(exec, ctx, "detect done use_llep=%d", ctx.use_llep ? 1 : 0);
+    }
+
+    // A pending backward prefetch never survives into the next forward pass
+    // (next step's plans may differ). Its only writers ran on the wt stream.
+    if (!exec.mInReplay && mPrefetched) {
+        mForeignArena.release(mPrefetched->arena_slot, mWeightTransferStream);
+        mPrefetched.reset();
     }
 
     // Drop any stale LLEP state from earlier layers. Foreign expert weight
@@ -1307,6 +1414,8 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     // resident mode falls back to the case-2 reconstruct) and drop their stale
     // weight pointers. This layer's own previous state is recycled in full.
     for (auto& [k_st, st] : mLLEPStates) {
+        mForeignArena.release(st.arena_slot, exec.mRunState.MainStream);
+        st.arena_slot = -1;
         st.free_foreign_gpu();
         st.gate_up_weight_ptrs.clear();
         st.down_weight_ptrs.clear();
@@ -1318,6 +1427,7 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     }
 
     if (!reused_plan) {
+        EpPhaseTimer prof_plan(1);
         plan_expert_mapping(ctx);
         EP_TRACE(exec, ctx, "plan done merged=%d send=%zu recv=%zu", ctx.num_merged,
                  ctx.plan.weights_to_send.size(), ctx.plan.weights_to_receive.size());
@@ -1327,11 +1437,13 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     Tensor llep_send_buf;
     const Tensor* send_ptr = &permuted_input;
     if (ctx.use_llep) {
+        EpPhaseTimer prof_reorder(2);
         llep_send_buf = apply_llep_send_reorder(exec, ctx, permuted_input, ep_state);
         send_ptr = &llep_send_buf;
     }
 
     if (!reused_plan) {
+        EpPhaseTimer prof_splits(3);
         exchange_token_splits(exec, ctx);
         EP_TRACE(exec, ctx, "splits done total_send=%d total_recv=%d", ctx.total_send, ctx.total_recv);
         // Cache the plan for this layer's recompute replay.
@@ -1354,13 +1466,19 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     // for merged-pointer bookkeeping).
     Tensor* native_gate_up_ptr = nullptr;
     Tensor* native_down_ptr = nullptr;
-    launch_llep_transfers(exec, ctx, native_gate_up_ptr, native_down_ptr);
+    {
+        EpPhaseTimer prof_transfers(4);
+        launch_llep_transfers(exec, ctx, native_gate_up_ptr, native_down_ptr);
+    }
     EP_TRACE(exec, ctx, "transfers launched");
 
     // Token A2A.
     void* recv_hidden_ptr = nullptr;
     std::size_t recv_hidden_bytes = 0;
-    Tensor recv_hidden = run_token_a2a(exec, ctx, *send_ptr, recv_hidden_ptr, recv_hidden_bytes);
+    Tensor recv_hidden = [&] {
+        EpPhaseTimer prof_a2a(5);
+        return run_token_a2a(exec, ctx, *send_ptr, recv_hidden_ptr, recv_hidden_bytes);
+    }();
     EP_TRACE(exec, ctx, "token a2a done");
     dsl::CommunicationHookPayload comm_payload;
     comm_payload.send_tensor = send_ptr;
@@ -1376,7 +1494,10 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     Tensor sorted_recv;
     Tensor local_scatter;
     Tensor merged_offsets_t;
-    permute_recv_tokens(exec, ctx, recv_hidden, sorted_recv, local_scatter, merged_offsets_t);
+    {
+        EpPhaseTimer prof_permute(6);
+        permute_recv_tokens(exec, ctx, recv_hidden, sorted_recv, local_scatter, merged_offsets_t);
+    }
     mBufferPool.release(recv_hidden_ptr, recv_hidden_bytes);
 
     // Persist merged_offsets to the MoE saved-buffers map and bind as
@@ -1394,13 +1515,54 @@ void EPStrategy::dispatch_forward(CompiledExecutor& exec, const CompiledOp& op) 
     // Build the LLEP merged-weight view, or fall back to native-only pointers
     // when no foreign weights were transferred.
     if (ctx.wt_started) {
+        EpPhaseTimer prof_finalize(7);
         finalize_llep_state(exec, ctx, *native_gate_up_ptr, *native_down_ptr);
     } else {
         finalize_native_only_state(exec, ctx);
     }
+    if (ep_prof_enabled() && ++g_ep_prof.count % 200 == 0 && exec.mComm && exec.mComm->rank() == 0) {
+        fprintf(stderr, "[ep-prof %ld]", g_ep_prof.count);
+        for (int i = 0; i < 8; ++i) fprintf(stderr, " %s=%.0fms", EpPhaseProf::names[i], g_ep_prof.ms[i]);
+        fprintf(stderr, "\n");
+        fflush(stderr);
+    }
+
+    // Launched after finalize so its wt_done event does not wait on the
+    // prefetch H2D — the prefetch overlaps this layer's backward compute.
+    maybe_prefetch_next_replay_layer(exec, ctx);
 
     exec.store_tensor(op.outputs[0], sorted_recv);
     exec.store_tensor(op.outputs[1], local_scatter);
+}
+
+void EPStrategy::maybe_prefetch_next_replay_layer(CompiledExecutor& exec, const DispatchForwardCtx& ctx) {
+    if (!exec.mInReplay || !mOptions.CpuTraining || mPrefetched.has_value()) return;
+    // The next replay dispatch is the next-lower layer with a cached forward
+    // plan; prefetch only when that plan actually receives foreign experts.
+    int next_layer = -1;
+    for (const auto& [key, st] : mEpStates) {
+        if (!st.plan_cached || (key & 1)) continue;
+        const int layer = key >> 1;
+        if (layer < ctx.layer_idx && layer > next_layer && st.cached_use_llep &&
+            !st.cached_plan.weights_to_receive.empty()) {
+            next_layer = layer;
+        }
+    }
+    if (next_layer < 0) return;
+    const auto& st = mEpStates.at(ep_state_key(next_layer, /*in_replay=*/false));
+    const std::string prefix = "blocks[" + std::to_string(next_layer) + "].";
+    Tensor* mgu = exec.mWeights.master_tensor(prefix + ctx.up_weight_name);
+    Tensor* mdn = exec.mWeights.master_tensor(prefix + "experts_down");
+    if (!mgu || !mdn || mgu->Rank < 3 || mdn->Rank < 3) return;
+
+    cudaStream_t wt = weight_transfer_stream();
+    PrefetchedForeign pf;
+    pf.layer_idx = next_layer;
+    pf.arena_slot = mForeignArena.begin(wt);
+    pf.weights.arena_alloc = [this](std::size_t bytes) { return mForeignArena.alloc(bytes); };
+    ep::fetch_expert_weights_from_host(st.cached_plan, wt, pf.weights, *mgu, *mdn);
+    pf.receive_set = st.cached_plan.weights_to_receive;
+    mPrefetched.emplace(std::move(pf));
 }
 
 // ============================================================================

--- a/csrc/src/runtime/ep/ep_strategy.h
+++ b/csrc/src/runtime/ep/ep_strategy.h
@@ -20,12 +20,18 @@
 #define SUROGATE_SRC_RUNTIME_EP_EP_STRATEGY_H
 
 #include <memory>
+#include <optional>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <cuda_runtime.h>
 
 #include "runtime/ep/ep_buffer_pool.h"
 #include "runtime/ep/ep_state.h"
+#include "runtime/ep/ring_arena.h"
+#include "runtime/ep/weight_transfer.h"
 
 struct RuntimeOptions;
 
@@ -35,8 +41,6 @@ struct CompiledOp;
 }  // namespace dsl
 
 namespace ep {
-
-struct ForeignExpertWeights;  // defined in runtime/ep/weight_transfer.h
 
 /// Abstract EP strategy. Owns all per-layer EP/LLEP state, the shared GPU
 /// buffer pool, the (lazy) weight-transfer stream, and the cross-layer
@@ -96,6 +100,12 @@ public:
     /// Lazily-created CUDA stream used for P2P expert weight transfer (LLEP).
     /// Returns nullptr for strategies that never transfer weights.
     cudaStream_t weight_transfer_stream();
+
+    /// Lazily-created CUDA stream for the tiny EP control exchanges (imbalance
+    /// all-reduce + token-split A2As). These depend only on host-side routing
+    /// counts, so running them off MainStream keeps their completion waits from
+    /// covering the whole pipeline backlog.
+    cudaStream_t control_stream();
 
     /// Returns the replay-aware cache key used to distinguish forward vs.
     /// replay-forward EP state. Mirrors the historical CompiledExecutor
@@ -165,6 +175,12 @@ private:
                              const Tensor& native_down);
     void finalize_native_only_state(dsl::CompiledExecutor& exec, DispatchForwardCtx& ctx);
 
+    /// Backward-only: prefetch the next replay layer's foreign expert weights
+    /// (its forward plan is cached) on the weight-transfer stream so the H2D
+    /// overlaps this layer's backward compute instead of serializing at the
+    /// next dispatch.
+    void maybe_prefetch_next_replay_layer(dsl::CompiledExecutor& exec, const DispatchForwardCtx& ctx);
+
     /// Invert `ep_state.llep_send_reorder_gpu` and gather `input` rows
     /// through it into a persistent [total_send, hidden] buffer. Caller
     /// supplies the persistent buffer (field on `EpLayerState`) so the
@@ -201,6 +217,21 @@ private:
     std::unordered_map<int, std::pair<void*, std::size_t>> mPinnedScratch;
 
     cudaStream_t mWeightTransferStream = nullptr;
+    cudaStream_t mControlStream = nullptr;
+
+    /// Ring-slab arena backing foreign-expert weight staging (base weights +
+    /// received LoRA slices). Replaces the per-expert cudaMalloc/cudaFree storm
+    /// on the LLEP dispatch path.
+    RingSlabArena mForeignArena;
+
+    /// One in-flight backward prefetch (see maybe_prefetch_next_replay_layer).
+    struct PrefetchedForeign {
+        int layer_idx = -1;
+        int arena_slot = -1;
+        ForeignExpertWeights weights;
+        std::vector<std::pair<int, int>> receive_set;
+    };
+    std::optional<PrefetchedForeign> mPrefetched;
 };
 
 /// Classic 1:1 expert→GPU mapping. No rebalancing, no P2P weight transfer.

--- a/csrc/src/runtime/ep/ep_strategy.h
+++ b/csrc/src/runtime/ep/ep_strategy.h
@@ -192,6 +192,14 @@ private:
     std::unordered_map<int, EPLayerMeta> mEPLayerMeta;
     EPBufferPool mBufferPool;
 
+    /// Reusable PINNED host staging for the small count/split copies in the
+    /// dispatch path. Async copies to/from PAGEABLE memory can block inside the
+    /// driver's staging pool when all worker threads copy at once — with NCCL
+    /// kernels at the stream heads this convoys into a cross-rank deadlock.
+    /// Pinned staging never blocks the enqueue. Grow-only, keyed by call site.
+    void* pinned_scratch(int slot, std::size_t bytes);
+    std::unordered_map<int, std::pair<void*, std::size_t>> mPinnedScratch;
+
     cudaStream_t mWeightTransferStream = nullptr;
 };
 

--- a/csrc/src/runtime/ep/ring_arena.h
+++ b/csrc/src/runtime/ep/ring_arena.h
@@ -1,0 +1,167 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ring-slab arena for LLEP foreign-expert weight staging.
+//
+// Foreign expert weights (base + received LoRA slices) are fetched fresh at
+// every LLEP dispatch and released at the next one. Allocating them with
+// cudaMalloc/cudaFree costs ~200 driver-lock round-trips per layer per pass;
+// with 8 in-process ranks that serializes into seconds per step. This arena
+// replaces those with pointer bumps over a small ring of persistent slabs:
+//
+//   begin(stream)   opens a scope on the least-recently-used slot and makes
+//                   `stream` wait until the slot's previous contents are dead
+//   alloc(bytes)    bump-allocates in the open scope (grows by whole chunks;
+//                   chunk count converges after the first pass, then zero
+//                   driver calls in steady state)
+//   release(slot,s) closes a scope: contents are dead once all work enqueued
+//                   on `s` so far completes (event-guarded reuse). Pass a
+//                   null stream only when the device is known idle (teardown).
+//
+// Single-threaded by design: one arena per EPStrategy, driven by one worker.
+
+#ifndef SUROGATE_SRC_RUNTIME_EP_RING_ARENA_H
+#define SUROGATE_SRC_RUNTIME_EP_RING_ARENA_H
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "utilities/utils.h"
+
+namespace ep {
+
+class RingSlabArena {
+public:
+    static constexpr int kNumSlots = 4;
+    static constexpr std::size_t kMinChunkBytes = 32ull << 20;
+    static constexpr std::size_t kAlign = 256;
+
+    RingSlabArena() = default;
+    RingSlabArena(const RingSlabArena&) = delete;
+    RingSlabArena& operator=(const RingSlabArena&) = delete;
+
+    /// Open an allocation scope. Returns the slot id the caller must later
+    /// pass to release(). `stream` is ordered after the slot's prior release.
+    int begin(cudaStream_t stream) {
+        int slot = -1;
+        for (int i = 1; i <= kNumSlots; ++i) {
+            const int cand = (mCur + i) % kNumSlots;
+            if (!mSlots[cand].active) {
+                slot = cand;
+                break;
+            }
+        }
+        if (slot < 0) {
+            throw std::runtime_error("RingSlabArena: all slots active (scope leak)");
+        }
+        Slot& s = mSlots[slot];
+        if (s.released_valid) {
+            CUDA_CHECK(cudaStreamWaitEvent(stream, s.released));
+            s.released_valid = false;
+        }
+        s.chunk_idx = 0;
+        s.off = 0;
+        s.active = true;
+        mCur = slot;
+        return slot;
+    }
+
+    /// Redirect alloc() to an already-active slot (adoption of a prefetched
+    /// scope). Bump state is preserved — allocation continues where the
+    /// prefetch left off.
+    void reopen(int slot) {
+        if (slot < 0 || slot >= kNumSlots || !mSlots[slot].active) {
+            throw std::runtime_error("RingSlabArena: reopen of inactive slot");
+        }
+        mCur = slot;
+    }
+
+    /// Bump-allocate in the currently open scope.
+    void* alloc(std::size_t bytes) {
+        if (mCur < 0 || !mSlots[mCur].active) {
+            throw std::runtime_error("RingSlabArena: alloc with no open scope");
+        }
+        Slot& s = mSlots[mCur];
+        bytes = (bytes + kAlign - 1) & ~(kAlign - 1);
+        while (s.chunk_idx < s.chunks.size()) {
+            Chunk& c = s.chunks[s.chunk_idx];
+            if (s.off + bytes <= c.cap) {
+                void* p = static_cast<std::byte*>(c.base) + s.off;
+                s.off += bytes;
+                return p;
+            }
+            ++s.chunk_idx;
+            s.off = 0;
+        }
+        Chunk c;
+        c.cap = bytes > kMinChunkBytes ? bytes : kMinChunkBytes;
+        CUDA_CHECK(cudaMalloc(&c.base, c.cap));
+        s.chunks.push_back(c);
+        s.chunk_idx = s.chunks.size() - 1;
+        s.off = bytes;
+        return c.base;
+    }
+
+    /// Close a scope. With a stream, reuse is deferred (via event) until all
+    /// work enqueued on it so far completes; with nullptr the slot is reusable
+    /// immediately (caller guarantees the device is idle).
+    void release(int slot, cudaStream_t stream) {
+        if (slot < 0 || slot >= kNumSlots) return;
+        Slot& s = mSlots[slot];
+        if (!s.active) return;
+        s.active = false;
+        if (stream) {
+            if (!s.released) {
+                CUDA_CHECK(cudaEventCreateWithFlags(&s.released, cudaEventDisableTiming));
+            }
+            CUDA_CHECK(cudaEventRecord(s.released, stream));
+            s.released_valid = true;
+        } else {
+            s.released_valid = false;
+        }
+    }
+
+    /// Free all slabs and events. Call only when the device is safe to touch;
+    /// the destructor deliberately performs no CUDA calls (teardown may run
+    /// with a dead context).
+    void free_all() {
+        for (Slot& s : mSlots) {
+            for (Chunk& c : s.chunks) {
+                if (c.base) cudaFree(c.base);
+            }
+            s.chunks.clear();
+            if (s.released) {
+                cudaEventDestroy(s.released);
+                s.released = nullptr;
+            }
+            s.released_valid = false;
+            s.active = false;
+            s.chunk_idx = 0;
+            s.off = 0;
+        }
+        mCur = -1;
+    }
+
+private:
+    struct Chunk {
+        void* base = nullptr;
+        std::size_t cap = 0;
+    };
+    struct Slot {
+        std::vector<Chunk> chunks;
+        std::size_t chunk_idx = 0;
+        std::size_t off = 0;
+        cudaEvent_t released = nullptr;
+        bool released_valid = false;
+        bool active = false;
+    };
+    Slot mSlots[kNumSlots];
+    int mCur = -1;
+};
+
+}  // namespace ep
+
+#endif  // SUROGATE_SRC_RUNTIME_EP_RING_ARENA_H

--- a/csrc/src/runtime/ep/weight_transfer.cpp
+++ b/csrc/src/runtime/ep/weight_transfer.cpp
@@ -171,8 +171,12 @@ Tensor alloc_foreign_tensor(ForeignExpertWeights& received, ETensorDType dtype, 
         bytes *= static_cast<size_t>(s);
     if (bytes == 0) return Tensor{};
     void* ptr = nullptr;
-    CUDA_CHECK(cudaMalloc(&ptr, bytes));
-    received.owned_gpu_ptrs.push_back(ptr);
+    if (received.arena_alloc) {
+        ptr = received.arena_alloc(bytes);
+    } else {
+        CUDA_CHECK(cudaMalloc(&ptr, bytes));
+        received.owned_gpu_ptrs.push_back(ptr);
+    }
     return make_tensor_from_ptr(ptr, dtype, shape, 0);
 }
 

--- a/csrc/src/runtime/ep/weight_transfer.cpp
+++ b/csrc/src/runtime/ep/weight_transfer.cpp
@@ -232,6 +232,47 @@ void transfer_expert_weights(const LPTPlan& plan,
     comm.weight_transfer_group_end();
 }
 
+void fetch_expert_weights_from_host(const LPTPlan& plan,
+                                    cudaStream_t stream,
+                                    ForeignExpertWeights& received,
+                                    const Tensor& master_gate_up,
+                                    const Tensor& master_down) {
+    received.free_gpu();
+    if (plan.weights_to_receive.empty()) {
+        return;
+    }
+
+    // Masters are the GLOBAL [num_experts, rows, cols] pinned host tensors
+    // (shared across ranks under cpu_training) — every helper self-serves its
+    // foreign experts with an H2D copy; no peer communication involved.
+    const long gu_rows = master_gate_up.Sizes[1];
+    const long gu_cols = master_gate_up.Sizes[2];
+    const long dn_rows = master_down.Sizes[1];
+    const long dn_cols = master_down.Sizes[2];
+    const std::size_t gu_expert_bytes =
+        static_cast<std::size_t>(gu_rows * gu_cols) * get_dtype_size(master_gate_up.DType);
+    const std::size_t dn_expert_bytes = static_cast<std::size_t>(dn_rows * dn_cols) * get_dtype_size(master_down.DType);
+
+    for (const auto& [expert_id, src_rank] : plan.weights_to_receive) {
+        (void)src_rank;
+        auto& pair = received.weights[expert_id];
+        pair.gate_up = alloc_foreign_tensor(received, master_gate_up.DType, {gu_rows, gu_cols});
+        pair.down = alloc_foreign_tensor(received, master_down.DType, {dn_rows, dn_cols});
+        CUDA_CHECK(cudaMemcpyAsync(pair.gate_up.Data,
+                                   static_cast<const std::byte*>(master_gate_up.Data) +
+                                       static_cast<std::size_t>(expert_id) * gu_expert_bytes,
+                                   gu_expert_bytes,
+                                   cudaMemcpyHostToDevice,
+                                   stream));
+        CUDA_CHECK(cudaMemcpyAsync(pair.down.Data,
+                                   static_cast<const std::byte*>(master_down.Data) +
+                                       static_cast<std::size_t>(expert_id) * dn_expert_bytes,
+                                   dn_expert_bytes,
+                                   cudaMemcpyHostToDevice,
+                                   stream));
+    }
+}
+
 void transfer_expert_weights_quantized(const LPTPlan& plan,
                                        NCCLCommunicator& comm,
                                        dsl::DslRunState& run_state,

--- a/csrc/src/runtime/ep/weight_transfer.h
+++ b/csrc/src/runtime/ep/weight_transfer.h
@@ -104,6 +104,21 @@ void transfer_expert_weights(const LPTPlan& plan,
                              int num_local_experts,
                              int ep_rank);
 
+/// cpu_training variant: helpers copy their foreign experts' rows directly from
+/// the GLOBAL pinned host masters (shared across ranks) via H2D — no peer
+/// communication, no dependence on transient prefetch buffers. Owners do nothing.
+///
+/// @param plan            LPT plan (only weights_to_receive is used)
+/// @param stream          CUDA stream for the H2D copies
+/// @param[out] received   Received foreign expert weights on this GPU
+/// @param master_gate_up  GLOBAL pinned host gate_up master [E, rows, cols]
+/// @param master_down     GLOBAL pinned host down master [E, rows, cols]
+void fetch_expert_weights_from_host(const LPTPlan& plan,
+                                    cudaStream_t stream,
+                                    ForeignExpertWeights& received,
+                                    const Tensor& master_gate_up,
+                                    const Tensor& master_down);
+
 /// Transfer expert weights using quantized format for reduced P2P bandwidth.
 ///
 /// Sends raw quantized data + scales instead of dequantized BF16, achieving

--- a/csrc/src/runtime/ep/weight_transfer.h
+++ b/csrc/src/runtime/ep/weight_transfer.h
@@ -12,6 +12,7 @@
 #ifndef SUROGATE_SRC_RUNTIME_EP_WEIGHT_TRANSFER_H
 #define SUROGATE_SRC_RUNTIME_EP_WEIGHT_TRANSFER_H
 
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -60,6 +61,11 @@ struct ForeignExpertWeights {
     /// GPU pointers allocated with cudaMalloc (tracked for cleanup).
     /// Populated when use_cuda_malloc=true in transfer functions.
     std::vector<void*> owned_gpu_ptrs;
+
+    /// Optional bump allocator (ring-slab arena). When set, receive buffers
+    /// draw from it instead of cudaMalloc and owned_gpu_ptrs stays empty —
+    /// the arena scope owner is responsible for the memory's lifetime.
+    std::function<void*(std::size_t)> arena_alloc;
 
     void clear() {
         weights.clear();

--- a/csrc/src/runtime/executor/compiled_ops.cpp
+++ b/csrc/src/runtime/executor/compiled_ops.cpp
@@ -399,6 +399,11 @@ CompiledExecutor::~CompiledExecutor() {
         mMoEExpertOffsetsGPU = nullptr;
         mMoEExpertOffsetsGPUSize = 0;
     }
+    if (mMoEOffsetsPinned) {
+        cudaFreeHost(mMoEOffsetsPinned);
+        mMoEOffsetsPinned = nullptr;
+        mMoEOffsetsPinnedBytes = 0;
+    }
     if (mReplayPersistArena) {
         cudaFree(mReplayPersistArena);
         mReplayPersistArena = nullptr;
@@ -974,6 +979,11 @@ const Tensor* CompiledExecutor::try_get_tensor_fuzzy(const std::string& name) {
 }
 
 void CompiledExecutor::handle_layer_start(int layer_idx) {
+    // Saved-tensor offload: bring this layer's offloaded saves back before any
+    // of its backward/replay ops read them (stream-ordered on MainStream).
+    if (mOptions.OffloadSavedTensors && !mCapturing && mInBackwardPass) {
+        mSavedCache.restore_layer(layer_idx, mRunState.MainStream);
+    }
     BeforeConsumeHookPayload before_consume_payload;
     before_consume_payload.weight_manager = mWeightManager;
     before_consume_payload.comm = mComm;
@@ -1018,6 +1028,11 @@ void CompiledExecutor::handle_layer_start(int layer_idx) {
 }
 
 void CompiledExecutor::handle_layer_end(int layer_idx) {
+    // Saved-tensor offload: after the forward layer completes, its saves are
+    // final — move them to pinned host and recycle the device buffers.
+    if (mOptions.OffloadSavedTensors && !mCapturing && !mInBackwardPass) {
+        mSavedCache.offload_layer(layer_idx, mRunState.MainStream);
+    }
     AfterConsumeHookPayload after_consume_payload;
     after_consume_payload.weight_manager = mWeightManager;
     after_consume_payload.release_stream = mRunState.MainStream;

--- a/csrc/src/runtime/executor/compiled_ops.h
+++ b/csrc/src/runtime/executor/compiled_ops.h
@@ -1027,6 +1027,12 @@ private:
     Tensor mMoEExpertOffsets;              // Views into mMoEExpertOffsetsData
     void* mMoEExpertOffsetsGPU = nullptr;  // Persistent GPU buffer (not stack-allocated)
     size_t mMoEExpertOffsetsGPUSize = 0;   // Size in bytes
+    // Pinned staging for the offsets D2H: pageable async D2H can block inside
+    // the driver's staging pool when all worker threads copy at once, which
+    // convoys with in-stream NCCL kernels into a cross-rank deadlock.
+    bool mInBackwardPass = false;  // true while execute_backward runs (incl. replay)
+    void* mMoEOffsetsPinned = nullptr;
+    size_t mMoEOffsetsPinnedBytes = 0;
 
     // Host-side MoE expert offsets cache.
     // Key is layer_idx for non-EP, ep_state_key(layer_idx) for EP.

--- a/csrc/src/runtime/executor/compiled_ops_execute_backward.cpp
+++ b/csrc/src/runtime/executor/compiled_ops_execute_backward.cpp
@@ -592,6 +592,15 @@ void CompiledExecutor::execute_backward(const CompiledGraph& graph,
                                         int micro_step,
                                         const modules::BackwardHook* hook,
                                         bool skip_zeroing) {
+    struct BackwardPassGuard {
+        bool& flag;
+        explicit BackwardPassGuard(bool& f) : flag(f) {
+            flag = true;
+        }
+        ~BackwardPassGuard() {
+            flag = false;
+        }
+    } backward_pass_guard{mInBackwardPass};
     // dispatch-PP: a resumed sub-range segment shares the prior segment's
     // backward state. Skip only the steps that would discard it — clearing the
     // live tensors (initialize), overwriting them with the forward snapshot

--- a/csrc/src/runtime/executor/graph_executor_weight_cache.cpp
+++ b/csrc/src/runtime/executor/graph_executor_weight_cache.cpp
@@ -147,6 +147,13 @@ const Tensor* GraphExecutor::get_fp8_cached_weight(const std::string& name, Tens
     if (!mWeights.has(name) || mWeights.is_trainable(name)) {
         return nullptr;
     }
+    if (mWeights.work_is_transient(name)) {
+        // Streamed weights are re-gathered into shared/rotating buffers between
+        // uses; a quantize-once cache freezes whatever the buffer held at first
+        // touch (e.g. a not-yet-gathered lm_head → all-zero logits). Let the
+        // recipe quantize on the fly instead.
+        return nullptr;
+    }
     auto it = mFP8WeightCache.find(name);
     if (it == mFP8WeightCache.end()) {
         FP8WeightCacheEntry entry{};
@@ -238,6 +245,10 @@ GraphExecutor::get_fp8_cached_weight_transposed(const std::string& name, Tensor&
         return nullptr;
     }
     if (!mWeights.has(name) || mWeights.is_trainable(name)) {
+        return nullptr;
+    }
+    if (mWeights.work_is_transient(name)) {
+        // Same rule as the forward cache: never snapshot a streamed buffer.
         return nullptr;
     }
 

--- a/csrc/src/runtime/executor/saved_tensor_cache.h
+++ b/csrc/src/runtime/executor/saved_tensor_cache.h
@@ -70,13 +70,28 @@ public:
         if (it != mBuffers.end() && it->second != nullptr && !is_arena_backed(key)) {
             mPool.push_back({it->second, mSizes[key]});
         }
+        if (auto hit = mHostMirror.find(key); hit != mHostMirror.end()) {
+            hit->second.valid = false;  // being rewritten
+        }
         ArenaAlloc a = arena_alloc ? arena_alloc(bytes) : ArenaAlloc{};
         if (a.ptr == nullptr) {
             a.ptr = take_from_pool(bytes);  // reuse a pooled buffer before cudaMalloc
             if (a.ptr != nullptr) bytes = pool_take_bytes_;
         }
         if (a.ptr == nullptr) {
-            CUDA_CHECK(cudaMalloc(&a.ptr, bytes));
+            const cudaError_t err = cudaMalloc(&a.ptr, bytes);
+            if (err != cudaSuccess) {
+                (void)cudaGetLastError();
+                std::size_t free_b = 0, total_b = 0;
+                cudaMemGetInfo(&free_b, &total_b);
+                throw std::runtime_error(std::string(op_name ? op_name : "compiled_op") + ": cudaMalloc(" +
+                                         std::to_string(bytes) + ") for saved tensor '" + key +
+                                         "' failed: " + cudaGetErrorString(err) +
+                                         " (saved-tensor cache already holds " + std::to_string(count()) +
+                                         " buffers / " + std::to_string(total_plain_bytes()) +
+                                         " plain bytes; device free " + std::to_string(free_b) + "/" +
+                                         std::to_string(total_b) + ")");
+            }
             a.arena_backed = false;
         }
         mBuffers[key] = a.ptr;
@@ -88,6 +103,9 @@ public:
     /// Record an externally-produced buffer for `key` (e.g. a slot the caller resolved in
     /// an arena). Frees a prior plain allocation under the same key first.
     void put(const std::string& key, void* ptr, std::size_t bytes, bool arena_backed) {
+        if (auto hit = mHostMirror.find(key); hit != mHostMirror.end()) {
+            hit->second.valid = false;
+        }
         auto it = mBuffers.find(key);
         if (it != mBuffers.end() && it->second != nullptr && it->second != ptr && !is_arena_backed(key)) {
             CUDA_CHECK(cudaFree(it->second));
@@ -146,11 +164,65 @@ public:
         for (auto& [buffer, sz] : mPool) {
             if (buffer != nullptr) cudaFree(buffer);
         }
+        for (auto& [key, hm] : mHostMirror) {
+            if (hm.ptr) cudaFreeHost(hm.ptr);
+        }
+        mHostMirror.clear();
         mBuffers.clear();
         mSizes.clear();
         mArenaBacked.clear();
         mPool.clear();
         mBumpOffset = 0;
+    }
+
+    /// Offload all of layer `layer_idx`'s plain (non-arena) buffers to pinned
+    /// host mirrors and recycle the device buffers into the pool. Stream-ordered
+    /// on `stream`: pool reuse happens via acquire() on the same stream, so the
+    /// D2H completes before any overwrite. Enables seq scaling: saved tensors
+    /// dominate step VRAM (~6.8 GB at seq 256 on Laguna-S, linear in tokens).
+    void offload_layer(int layer_idx, cudaStream_t stream) {
+        const std::string prefix = "blocks[" + std::to_string(layer_idx) + "].";
+        for (auto& [key, buf] : mBuffers) {
+            if (buf == nullptr || is_arena_backed(key) || key.rfind(prefix, 0) != 0) continue;
+            auto& hm = mHostMirror[key];
+            const std::size_t bytes = mSizes[key];
+            if (hm.capacity < bytes) {
+                if (hm.ptr) CUDA_CHECK(cudaFreeHost(hm.ptr));
+                CUDA_CHECK(cudaHostAlloc(&hm.ptr, bytes, cudaHostAllocDefault));
+                hm.capacity = bytes;
+            }
+            CUDA_CHECK(cudaMemcpyAsync(hm.ptr, buf, bytes, cudaMemcpyDeviceToHost, stream));
+            hm.bytes = bytes;
+            hm.valid = true;
+            mPool.push_back({buf, bytes});
+            buf = nullptr;
+        }
+    }
+
+    /// Restore layer `layer_idx`'s offloaded buffers to the device (called at
+    /// backward layer start, before any of the layer's ops read them).
+    void restore_layer(int layer_idx, cudaStream_t stream) {
+        const std::string prefix = "blocks[" + std::to_string(layer_idx) + "].";
+        for (auto& [key, hm] : mHostMirror) {
+            if (!hm.valid || key.rfind(prefix, 0) != 0) continue;
+            auto bit = mBuffers.find(key);
+            if (bit != mBuffers.end() && bit->second != nullptr) {
+                hm.valid = false;  // device copy exists (e.g. replay re-acquired)
+                continue;
+            }
+            std::size_t bytes = hm.bytes;
+            void* dev = take_from_pool(bytes);
+            if (dev != nullptr) {
+                bytes = pool_take_bytes_;
+            } else {
+                CUDA_CHECK(cudaMalloc(&dev, bytes));
+            }
+            CUDA_CHECK(cudaMemcpyAsync(dev, hm.ptr, hm.bytes, cudaMemcpyHostToDevice, stream));
+            mBuffers[key] = dev;
+            mSizes[key] = bytes;
+            mArenaBacked[key] = false;
+            hm.valid = false;
+        }
     }
 
     /// Bump offset into the (caller-owned) arena, for arena allocators that pack many
@@ -208,6 +280,13 @@ private:
     std::unordered_map<std::string, void*> mBuffers;
     std::unordered_map<std::string, std::size_t> mSizes;
     std::unordered_map<std::string, bool> mArenaBacked;
+    struct HostMirror {
+        void* ptr = nullptr;
+        std::size_t bytes = 0;
+        std::size_t capacity = 0;
+        bool valid = false;
+    };
+    std::unordered_map<std::string, HostMirror> mHostMirror;  // pinned offload copies
     std::vector<std::pair<void*, std::size_t>> mPool;  // recycled buffers (dispatch per-stage)
     std::size_t pool_take_bytes_ = 0;
     std::size_t mBumpOffset = 0;

--- a/csrc/src/runtime/lora/lora_grads_manager.cpp
+++ b/csrc/src/runtime/lora/lora_grads_manager.cpp
@@ -49,7 +49,8 @@ void ModularLoRAGradsManager::allocate_gradients() {
     const int global_q_out = mConfig.num_query_heads * mConfig.head_size;
     const int global_kv_out = mConfig.num_kv_heads * mConfig.head_size;
     const int r = mConfig.lora_config.rank;
-    const int E = mConfig.num_experts;
+    // EP: grad buffers mirror the weights manager's local expert shard.
+    const int E = mConfig.effective_grouped_experts();
 
     // For hybrid models, per-layer attention / MLP dims may differ from the
     // global defaults. Resolve Q/K/V/O and MLP sizes per layer to avoid

--- a/csrc/src/runtime/lora/lora_grads_manager.h
+++ b/csrc/src/runtime/lora/lora_grads_manager.h
@@ -46,9 +46,13 @@ public:
         bool is_moe = false;  ///< True for MoE models
 
         // MoE-specific configuration (only used when is_moe = true)
-        int num_experts = 0;            ///< Number of experts per layer
+        int num_experts = 0;            ///< Number of experts per layer (global)
         int moe_intermediate_size = 0;  ///< Per-expert intermediate size (0 = use intermediate_size)
         bool train_router = false;      ///< Train MoE router gate during LoRA fine-tuning
+        // Expert Parallelism: grouped expert-LoRA holds only this rank's expert
+        // shard. 0 -> num_experts (no EP). Router LoRA stays global-sized.
+        int num_grouped_experts = 0;    ///< Local experts for grouped LoRA buffers
+        int grouped_expert_base = 0;    ///< Global id of this rank's first expert
 
         const ModelConfig* model_config = nullptr;  ///< Per-layer block type (hybrid models)
 
@@ -63,6 +67,10 @@ public:
 
         [[nodiscard]] int effective_moe_intermediate() const {
             return moe_intermediate_size > 0 ? moe_intermediate_size : intermediate_size;
+        }
+
+        [[nodiscard]] int effective_grouped_experts() const {
+            return num_grouped_experts > 0 ? num_grouped_experts : num_experts;
         }
     };
 

--- a/csrc/src/runtime/lora/lora_weights_manager.cpp
+++ b/csrc/src/runtime/lora/lora_weights_manager.cpp
@@ -262,7 +262,9 @@ void ModularLoRAWeightsManager::allocate_grouped_moe_weights(LoRAGroupedExpertWe
     const int C = mConfig.hidden_size;
     const int D = mConfig.effective_moe_intermediate();
     const int gate_up_out = 2 * D;
-    const int num_experts = mConfig.num_experts;
+    // EP: only this rank's expert shard gets adapters (kernels accept
+    // local-sized grouped LoRA tensors; grads reduce is already DP-only).
+    const int num_experts = mConfig.effective_grouped_experts();
     const int r = mConfig.lora_config.rank;
     const ETensorDType master_dtype = mConfig.lora_config.dtype;
     const ETensorDType work_dtype = mConfig.work_dtype;
@@ -418,12 +420,116 @@ void ModularLoRAWeightsManager::import_from_file(const std::string& file_name, N
     comm.barrier();
 }
 
+bool ModularLoRAWeightsManager::has_ep_local_grouped() const {
+    if (mConfig.effective_grouped_experts() >= mConfig.num_experts) {
+        return false;
+    }
+    for (const auto& block : mMaster.blocks) {
+        if (!block.moe.use_grouped) continue;
+        const auto& g = block.moe.grouped;
+        if (g.gate.has_value() || g.gate_up.has_value() || g.up.has_value() || g.down.has_value()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ModularLoRAWeightsManager::gather_grouped_for_export(NCCLCommunicator& comm) const {
+    const int local_E = mConfig.effective_grouped_experts();
+    const int global_E = mConfig.num_experts;
+    const int num_shards = global_E / local_E;
+    if (num_shards != comm.world_size()) {
+        throw std::runtime_error(
+            fmt::format("EP adapter export: expert shards ({}) must equal world size ({}) in v1 "
+                        "(ep_size == world_size). Save with dp_size == 1 or merge offline.",
+                        num_shards,
+                        comm.world_size()));
+    }
+    const int shard_idx = mConfig.grouped_expert_base / local_E;
+
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    cudaEvent_t done = nullptr;
+    CUDA_CHECK(cudaEventCreateWithFlags(&done, cudaEventDisableTiming));
+
+    for (int l = 0; l < (int)mMaster.blocks.size(); ++l) {
+        const auto& block = mMaster.blocks[l];
+        if (!block.moe.use_grouped) continue;
+
+        // Collect this layer's grouped tensors, then run one A2A transaction.
+        std::vector<std::pair<std::string, const TensorShard*>> locals;
+        auto add = [&](const std::optional<LoRAGroupedLayerWeights<TensorShard>>& layer, const char* proj) {
+            if (!layer.has_value() || !layer->has_value()) return;
+            locals.emplace_back(fmt::format("{}:{}:A", l, proj), &layer->A);
+            locals.emplace_back(fmt::format("{}:{}:B", l, proj), &layer->B);
+        };
+        // Keys must match the proj names used by iterate_tensors' lookup.
+        add(block.moe.grouped.gate, "gate_proj");
+        add(block.moe.grouped.gate_up, "gate_up_proj");
+        add(block.moe.grouped.up, "up_proj");
+        add(block.moe.grouped.down, "down_proj");
+        if (locals.empty()) continue;
+
+        // Gather this layer into device temps, then stage to HOST and free the
+        // device memory: keeping all layers' global tensors device-resident
+        // (~4.7 GB at Laguna-S scale) OOMs a nearly-full GPU. The writer's
+        // copy from the host staging buffer is host-to-host under UVA.
+        cudaEvent_t ready = nullptr;
+        CUDA_CHECK(cudaEventCreateWithFlags(&ready, cudaEventDisableTiming));
+        CUDA_CHECK(cudaEventRecord(ready, nullptr));
+        comm.begin_transaction(ready);
+        std::vector<std::pair<std::string, Tensor>> device_temps;
+        device_temps.reserve(locals.size());
+        for (auto& [key, local] : locals) {
+            std::vector<long> gshape(local->Sizes.begin(), local->Sizes.begin() + local->Rank);
+            gshape[0] = global_E;
+            std::size_t bytes = get_dtype_size(local->DType);
+            for (long d : gshape) {
+                bytes *= static_cast<std::size_t>(d);
+            }
+            void* ptr = nullptr;
+            CUDA_CHECK(cudaMalloc(&ptr, bytes));
+            Tensor global_t = Tensor::from_pointer(static_cast<std::byte*>(ptr), local->Device, local->DType, gshape);
+            TensorShard src(static_cast<const Tensor&>(*local), shard_idx, num_shards, gshape);
+            comm.schedule_all_gather(src, global_t);
+            device_temps.emplace_back(key, global_t);
+        }
+        comm.execute_transaction(done);
+        CUDA_CHECK(cudaEventSynchronize(done));
+        CUDA_CHECK(cudaEventDestroy(ready));
+
+        for (auto& [key, dev_t] : device_temps) {
+            const std::size_t bytes = dev_t.bytes();
+            auto host_buf = std::make_unique<std::byte[]>(bytes);
+            CUDA_CHECK(cudaMemcpy(host_buf.get(), dev_t.Data, bytes, cudaMemcpyDeviceToHost));
+            std::vector<long> gshape(dev_t.Sizes.begin(), dev_t.Sizes.begin() + dev_t.Rank);
+            mExportGathered.emplace(key, Tensor::from_pointer(host_buf.get(), dev_t.Device, dev_t.DType, gshape));
+            mExportHostBuffers.push_back(std::move(host_buf));
+            CUDA_CHECK(cudaFree(dev_t.Data));
+        }
+    }
+    CUDA_CHECK(cudaEventDestroy(done));
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+void ModularLoRAWeightsManager::release_export_gathered() const {
+    // Gathered tensors point into mExportHostBuffers (host memory) — no cudaFree.
+    mExportGathered.clear();
+    mExportHostBuffers.clear();
+}
+
 void ModularLoRAWeightsManager::export_to_file(const std::string& file_name, NCCLCommunicator& comm) const {
     if (!enabled()) return;
+    if (has_ep_local_grouped()) {
+        // Each rank owns a shard of the experts; assemble the full adapter on
+        // every rank (all_gather), then rank 0 writes it.
+        gather_grouped_for_export(comm);
+    }
     if (comm.rank() == 0) {
         write_safetensors(file_name, const_cast<ModularLoRAWeightsManager&>(*this));
     }
     comm.barrier();
+    release_export_gathered();
 }
 
 LoRABlockWeights<Tensor>& ModularLoRAWeightsManager::get_block(int layer_idx, cudaStream_t stream) {
@@ -758,22 +864,42 @@ void ModularLoRAWeightsManager::iterate_tensors(const std::function<void(std::st
         // MoE expert LoRA
         if (block.moe.use_grouped) {
             // Export grouped tensors in per-expert format for PEFT compatibility
-            // Grouped tensors have shape [num_experts, ...], slice along dim 0
+            // Grouped tensors have shape [num_grouped_experts, ...], slice along
+            // dim 0. Under EP each rank holds a shard of the experts; names use
+            // GLOBAL expert ids so per-rank iteration (optimizer, import) stays
+            // consistent and export_to_file can assemble the full adapter.
             auto& g = block.moe.grouped;
-            const int num_experts = mConfig.num_experts;
+            // During an EP export, gathered global tensors (all experts) stand in
+            // for the local shard; otherwise iterate the local experts under
+            // their global ids.
+            const bool use_gathered = !mExportGathered.empty();
+            const int num_experts = use_gathered ? mConfig.num_experts : mConfig.effective_grouped_experts();
+            const int expert_base = use_gathered ? 0 : mConfig.grouped_expert_base;
 
             auto export_grouped_layer = [&](const std::optional<LoRAGroupedLayerWeights<TensorShard>>& layer,
                                             const char* proj_name) {
                 if (!layer.has_value() || !layer->has_value()) return;
+                TensorShard A_src = layer->A;
+                TensorShard B_src = layer->B;
+                if (use_gathered) {
+                    auto a_it = mExportGathered.find(fmt::format("{}:{}:A", l, proj_name));
+                    auto b_it = mExportGathered.find(fmt::format("{}:{}:B", l, proj_name));
+                    if (a_it == mExportGathered.end() || b_it == mExportGathered.end()) {
+                        throw std::logic_error(fmt::format(
+                            "EP adapter export: missing gathered tensors for layer {} proj {}", l, proj_name));
+                    }
+                    A_src = TensorShard(a_it->second);
+                    B_src = TensorShard(b_it->second);
+                }
                 for (int e = 0; e < num_experts; ++e) {
-                    std::string expert_prefix = fmt::format("{}.mlp.experts.{}", prefix, e);
+                    std::string expert_prefix = fmt::format("{}.mlp.experts.{}", prefix, expert_base + e);
                     // Slice out expert e from dim 0: A[e,:,:] and B[e,:,:]
-                    TensorShard A_slice = TensorShard(slice(layer->A, 0, e, e + 1));
-                    TensorShard B_slice = TensorShard(slice(layer->B, 0, e, e + 1));
+                    TensorShard A_slice = TensorShard(slice(A_src, 0, e, e + 1));
+                    TensorShard B_slice = TensorShard(slice(B_src, 0, e, e + 1));
                     // Remove the leading dimension of size 1 by adjusting shape
                     // A: [1, rank, in] -> [rank, in], B: [1, out, rank] -> [out, rank]
-                    A_slice.Rank = layer->A.Rank - 1;
-                    B_slice.Rank = layer->B.Rank - 1;
+                    A_slice.Rank = A_src.Rank - 1;
+                    B_slice.Rank = B_src.Rank - 1;
                     for (int d = 0; d < A_slice.Rank; ++d)
                         A_slice.Sizes[d] = A_slice.Sizes[d + 1];
                     for (int d = 0; d < B_slice.Rank; ++d)

--- a/csrc/src/runtime/lora/lora_weights_manager.h
+++ b/csrc/src/runtime/lora/lora_weights_manager.h
@@ -47,9 +47,13 @@ public:
         bool is_moe = false;  ///< True for MoE models
 
         // MoE-specific configuration (only used when is_moe = true)
-        int num_experts = 0;            ///< Number of experts per layer
+        int num_experts = 0;            ///< Number of experts per layer (global)
         int moe_intermediate_size = 0;  ///< Per-expert intermediate size (0 = use intermediate_size)
         bool train_router = false;      ///< Train MoE router gate during LoRA fine-tuning
+        // Expert Parallelism: grouped expert-LoRA holds only this rank's expert
+        // shard. 0 -> num_experts (no EP). Router LoRA stays global-sized.
+        int num_grouped_experts = 0;    ///< Local experts for grouped LoRA buffers
+        int grouped_expert_base = 0;    ///< Global id of this rank's first expert
 
         const ModelConfig* model_config = nullptr;  ///< Per-layer block type (hybrid models)
 
@@ -71,6 +75,10 @@ public:
 
         [[nodiscard]] int effective_moe_intermediate() const {
             return moe_intermediate_size > 0 ? moe_intermediate_size : intermediate_size;
+        }
+
+        [[nodiscard]] int effective_grouped_experts() const {
+            return num_grouped_experts > 0 ? num_grouped_experts : num_experts;
         }
     };
 
@@ -94,6 +102,10 @@ public:
      * @brief Export LoRA adapter to safetensors file
      */
     void export_to_file(const std::string& file_name, NCCLCommunicator& comm) const;
+
+    /// True when grouped expert-LoRA holds only an EP-local shard of the experts
+    /// (num_grouped_experts < num_experts and grouped buffers exist).
+    [[nodiscard]] bool has_ep_local_grouped() const;
 
     /**
      * @brief Get block weights for forward/backward pass
@@ -175,6 +187,15 @@ public:
 private:
     Config mConfig;
     TensorAllocator* mAllocator;
+
+    // EP export staging: grouped adapters all-gathered across ranks and staged
+    // into HOST buffers (device temps are per-layer and freed immediately).
+    // Keyed "layer:proj:A|B"; non-empty only inside export_to_file.
+    mutable std::unordered_map<std::string, Tensor> mExportGathered;
+    mutable std::vector<std::unique_ptr<std::byte[]>> mExportHostBuffers;
+
+    void gather_grouped_for_export(NCCLCommunicator& comm) const;
+    void release_export_gathered() const;
 
     // Master weights (sharded for multi-GPU)
     LoRAWeightsSet<TensorShard> mMaster;

--- a/csrc/src/runtime/ops/moe_grouped_gemm.cpp
+++ b/csrc/src/runtime/ops/moe_grouped_gemm.cpp
@@ -132,7 +132,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm(const CompiledOp& op) {
             is_llep_active = true;
             std::string_view wname = op.inputs[1].name;
             const auto meta_it = mEPLayerMeta.find(ep_key_any);
-            const bool refresh_native_only_ptrs = llep.owned_foreign_ptrs.empty() && meta_it != mEPLayerMeta.end() &&
+            const bool refresh_native_only_ptrs = !llep.has_foreign_experts && meta_it != mEPLayerMeta.end() &&
                                                   meta_it->second.num_merged == meta_it->second.num_local &&
                                                   llep.num_merged_experts == meta_it->second.num_local &&
                                                   weights.Rank >= 3;
@@ -618,7 +618,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_backward(const CompiledOp& op) 
             auto& llep = llep_it->second;
             std::string_view wname = op.inputs[2].name;
             const auto meta_it = mEPLayerMeta.find(ep_key_any);
-            const bool refresh_native_only_ptrs = llep.owned_foreign_ptrs.empty() && meta_it != mEPLayerMeta.end() &&
+            const bool refresh_native_only_ptrs = !llep.has_foreign_experts && meta_it != mEPLayerMeta.end() &&
                                                   meta_it->second.num_merged == meta_it->second.num_local &&
                                                   llep.num_merged_experts == meta_it->second.num_local &&
                                                   weights.Rank >= 3;

--- a/csrc/src/runtime/ops/moe_grouped_gemm_down.cpp
+++ b/csrc/src/runtime/ops/moe_grouped_gemm_down.cpp
@@ -581,7 +581,9 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
     std::vector<const void*> refreshed_native_weight_ptrs;
     {
         auto llep_it = mLLEPStates.find(ep_key);
-        if (llep_it != mLLEPStates.end() && llep_it->second.active) {
+        // cpu_training: stored native pointers reference a forward-time prefetch
+        // buffer that has been recycled — always reconstruct with fresh pointers.
+        if (llep_it != mLLEPStates.end() && llep_it->second.active && !mOptions.CpuTraining) {
             auto& llep = llep_it->second;
             is_llep_active = true;
             num_experts = llep.num_merged_experts;
@@ -616,7 +618,15 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
             }
         } else if (mOptions.EPSize > 1 && layer_idx >= 0) {
             auto meta_it = mEPLayerMeta.find(ep_key);
-            if (meta_it != mEPLayerMeta.end() && meta_it->second.num_merged != meta_it->second.num_local) {
+            auto merged_set_differs = [](const auto& meta) {
+                if (meta.num_merged != meta.num_local) return true;
+                for (int m = 0; m < meta.num_merged; ++m) {
+                    const int li = meta.merged_to_global[m] - meta.native_start;
+                    if (li < 0 || li >= meta.num_local) return true;
+                }
+                return false;
+            };
+            if (meta_it != mEPLayerMeta.end() && merged_set_differs(meta_it->second)) {
                 const auto& meta = meta_it->second;
                 is_llep_active = true;
                 num_experts = meta.num_merged;
@@ -624,10 +634,49 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
 
                 const size_t elem_sz = get_dtype_size(weights.DType);
                 const size_t expert_bytes = static_cast<size_t>(hidden_size) * intermediate_size * elem_sz;
-                std::vector<long> zw_shape = {1L, static_cast<long>(hidden_size), static_cast<long>(intermediate_size)};
-                Tensor zero_weight = mRunState.temp_alloc(weights.DType, zw_shape, "moe_grouped_gemm_down_zero_weight");
-                fill_zero(zero_weight, mRunState.MainStream);
-                mTemps.push_back(zero_weight);
+
+                // Foreign experts: under cpu_training re-fetch rows from the GLOBAL
+                // pinned host master (exact dgrad); otherwise fall back to zeros.
+                std::vector<std::pair<int, int>> foreign_slot;
+                for (int m = 0; m < meta.num_merged; ++m) {
+                    const int e = meta.merged_to_global[m];
+                    const int li = e - meta.native_start;
+                    if (li < 0 || li >= meta.num_local) {
+                        foreign_slot.emplace_back(e, static_cast<int>(foreign_slot.size()));
+                    }
+                }
+                Tensor foreign_stage;
+                bool have_foreign_stage = false;
+                if (!foreign_slot.empty() && mOptions.CpuTraining) {
+                    Tensor* master = mWeights.master_tensor("blocks[" + std::to_string(layer_idx) + "].experts_down");
+                    if (master && master->Rank >= 3 && master->DType == weights.DType) {
+                        foreign_stage = mRunState.temp_alloc(weights.DType,
+                                                             {static_cast<long>(foreign_slot.size()),
+                                                              static_cast<long>(hidden_size),
+                                                              static_cast<long>(intermediate_size)},
+                                                             "moe_grouped_gemm_down_foreign_stage");
+                        mTemps.push_back(foreign_stage);
+                        for (const auto& [e, slot] : foreign_slot) {
+                            CUDA_CHECK(cudaMemcpyAsync(static_cast<std::byte*>(foreign_stage.Data) +
+                                                           static_cast<size_t>(slot) * expert_bytes,
+                                                       static_cast<const std::byte*>(master->Data) +
+                                                           static_cast<size_t>(e) * expert_bytes,
+                                                       expert_bytes,
+                                                       cudaMemcpyHostToDevice,
+                                                       mRunState.MainStream));
+                        }
+                        have_foreign_stage = true;
+                    }
+                }
+                Tensor zero_weight;
+                if (!foreign_slot.empty() && !have_foreign_stage) {
+                    std::vector<long> zw_shape = {
+                        1L, static_cast<long>(hidden_size), static_cast<long>(intermediate_size)};
+                    zero_weight =
+                        mRunState.temp_alloc(weights.DType, zw_shape, "moe_grouped_gemm_down_zero_weight");
+                    fill_zero(zero_weight, mRunState.MainStream);
+                    mTemps.push_back(zero_weight);
+                }
 
                 reconstructed_weight_ptrs.resize(meta.num_merged);
                 for (int m = 0; m < meta.num_merged; ++m) {
@@ -636,6 +685,16 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                     if (local_idx >= 0 && local_idx < meta.num_local) {
                         reconstructed_weight_ptrs[m] =
                             static_cast<const std::byte*>(weights.Data) + static_cast<size_t>(local_idx) * expert_bytes;
+                    } else if (have_foreign_stage) {
+                        int slot = 0;
+                        for (const auto& [e, s2] : foreign_slot) {
+                            if (e == global_e) {
+                                slot = s2;
+                                break;
+                            }
+                        }
+                        reconstructed_weight_ptrs[m] = static_cast<const std::byte*>(foreign_stage.Data) +
+                                                       static_cast<size_t>(slot) * expert_bytes;
                     } else {
                         reconstructed_weight_ptrs[m] = zero_weight.Data;
                     }
@@ -783,8 +842,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
             bool llep_lora_active = false;
             {
                 auto llep_lora_it = mLLEPStates.find(ep_key);
-                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.active &&
-                    llep_lora_it->second.has_merged_lora && llep_lora_it->second.merged_lora.down.has_value()) {
+                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.has_merged_lora && llep_lora_it->second.merged_lora.down.has_value()) {
                     down_ptr = &(*llep_lora_it->second.merged_lora.down);
                     llep_lora_active = true;
                 }
@@ -1065,12 +1123,96 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
 
                 modules::LoRABlockWeights<Tensor>* lora_grads = nullptr;
                 bool lora_accum = false;
-                if (mLoRAGrads && mComm && !llep_lora_active) {
-                    // Skip LoRA weight grads when LLEP is active — grad storage is
-                    // [num_local, ...] which doesn't match num_merged.
+                // LLEP: stage wgrads in MERGED [num_merged] temps, then scatter-add
+                // native rows locally and exchange foreign rows to their owners
+                // (mirrors moe_grouped_gemm_gate_up.cpp).
+                const ep::EPLayerMeta* wg_meta = nullptr;
+                if (llep_lora_active) {
+                    auto wg_it = mEPLayerMeta.find(ep_key);
+                    if (wg_it != mEPLayerMeta.end() && !wg_it->second.expert_to_gpu.empty()) {
+                        wg_meta = &wg_it->second;
+                    }
+                }
+                const bool llep_wgrad = llep_lora_active && wg_meta != nullptr && mComm != nullptr;
+                if (mLoRAGrads && mComm && (!llep_lora_active || llep_wgrad)) {
                     lora_grads = &mLoRAGrads->get_block_full(layer_idx, mRunState.MainStream, *mComm, lora_accum);
                 }
                 const float grad_beta = lora_accum ? 1.0f : 0.0f;
+
+                auto merged_temp = [&](long rows, long cols) -> Tensor {
+                    Tensor t = mRunState.temp_alloc(
+                        d_input.DType, {static_cast<long>(num_experts), rows, cols}, "llep_merged_wgrad_down");
+                    fill_zero(t, mRunState.MainStream);
+                    mTemps.push_back(t);
+                    return t;
+                };
+                Tensor mg_down_A, mg_down_B;
+                auto row_view = [&](const Tensor& t, int row) -> Tensor {
+                    const long r1 = t.Sizes[1], r2 = t.Sizes[2];
+                    const std::size_t off = static_cast<std::size_t>(row) * r1 * r2 * get_dtype_size(t.DType);
+                    return Tensor::from_pointer(static_cast<std::byte*>(t.Data) + off, t.Device, t.DType,
+                                                std::vector<long>{r1, r2});
+                };
+                auto row_add = [&](Tensor& dst3, int dst_row, const Tensor& src3, int src_row) {
+                    Tensor d = row_view(dst3, dst_row);
+                    Tensor sv = row_view(src3, src_row);
+                    vector_add_sr(d, d, sv, 1.0f, d.nelem(), 0, mRunState.MainStream);
+                };
+                auto scatter_exchange = [&](Tensor& mgA, Tensor& mgB,
+                                            modules::LoRAGroupedLayerWeights<Tensor>& local) {
+                    const auto& meta = *wg_meta;
+                    const int nl = std::max(meta.num_local, 1);
+                    const int my_ep = meta.native_start / nl;
+                    if (!lora_accum) {
+                        fill_zero(local.A, mRunState.MainStream);
+                        fill_zero(local.B, mRunState.MainStream);
+                    }
+                    std::vector<int> g2m(meta.expert_to_gpu.size(), -1);
+                    for (int m = 0; m < meta.num_merged; ++m) g2m[meta.merged_to_global[m]] = m;
+                    for (int m = 0; m < meta.num_merged; ++m) {
+                        const int ln = meta.merged_to_global[m] - meta.native_start;
+                        if (ln >= 0 && ln < meta.num_local) {
+                            row_add(local.A, ln, mgA, m);
+                            row_add(local.B, ln, mgB, m);
+                        }
+                    }
+                    const std::size_t a_bytes =
+                        static_cast<std::size_t>(mgA.Sizes[1]) * mgA.Sizes[2] * get_dtype_size(mgA.DType);
+                    const std::size_t b_bytes =
+                        static_cast<std::size_t>(mgB.Sizes[1]) * mgB.Sizes[2] * get_dtype_size(mgB.DType);
+                    std::vector<std::tuple<int, Tensor, Tensor>> recvs;
+                    mComm->weight_transfer_group_start();
+                    const int E_total = static_cast<int>(meta.expert_to_gpu.size());
+                    for (int e = 0; e < E_total; ++e) {
+                        const int owner = e / nl;
+                        const int helper = meta.expert_to_gpu[e];
+                        if (helper == owner) continue;
+                        if (helper == my_ep && g2m[e] >= 0) {
+                            Tensor sa = row_view(mgA, g2m[e]);
+                            Tensor sb = row_view(mgB, g2m[e]);
+                            mComm->send_wt(sa.Data, a_bytes, owner, mRunState.MainStream);
+                            mComm->send_wt(sb.Data, b_bytes, owner, mRunState.MainStream);
+                        } else if (owner == my_ep) {
+                            Tensor ta =
+                                mRunState.temp_alloc(mgA.DType, {mgA.Sizes[1], mgA.Sizes[2]}, "llep_wgrad_recv");
+                            Tensor tb =
+                                mRunState.temp_alloc(mgB.DType, {mgB.Sizes[1], mgB.Sizes[2]}, "llep_wgrad_recv");
+                            mTemps.push_back(ta);
+                            mTemps.push_back(tb);
+                            mComm->recv_wt(ta.Data, a_bytes, helper, mRunState.MainStream);
+                            mComm->recv_wt(tb.Data, b_bytes, helper, mRunState.MainStream);
+                            recvs.emplace_back(e, ta, tb);
+                        }
+                    }
+                    mComm->weight_transfer_group_end();
+                    for (auto& [e, ta, tb] : recvs) {
+                        const int ln = e - meta.native_start;
+                        Tensor da = row_view(local.A, ln);
+                        Tensor db = row_view(local.B, ln);
+                        vector_add_sr(da, da, ta, 1.0f, da.nelem(), 0, mRunState.MainStream);
+                        vector_add_sr(db, db, tb, 1.0f, db.nelem(), 0, mRunState.MainStream);
+                    }
+                };
 
                 if (total_tokens_i > 0 && rank > 0) {
                     Tensor lora_intermediate =
@@ -1088,7 +1230,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                                           EMMTranspose::TN);
                     scale_and_dropout(lora_intermediate, seed_down);
                     if (lora_grads && lora_grads->moe.grouped.down.has_value()) {
-                        dispatch_weight_grad(lora_grads->moe.grouped.down->B,
+                        dispatch_weight_grad(llep_wgrad ? (mg_down_B.Data ? mg_down_B : (mg_down_B = merged_temp(hidden_size, rank))) : lora_grads->moe.grouped.down->B,
                                              d_output,
                                              lora_intermediate,
                                              hidden_size,
@@ -1107,7 +1249,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                                           EMMTranspose::NN);
                     scale_and_dropout(lora_intermediate, seed_down);
                     if (lora_grads && lora_grads->moe.grouped.down.has_value()) {
-                        dispatch_weight_grad(lora_grads->moe.grouped.down->A,
+                        dispatch_weight_grad(llep_wgrad ? (mg_down_A.Data ? mg_down_A : (mg_down_A = merged_temp(rank, intermediate_size))) : lora_grads->moe.grouped.down->A,
                                              lora_intermediate,
                                              inp,
                                              rank,
@@ -1124,6 +1266,11 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                                           1.0f,
                                           1.0f,
                                           EMMTranspose::NN);
+
+                    if (llep_wgrad && lora_grads && mg_down_A.Data && mg_down_B.Data &&
+                        lora_grads->moe.grouped.down.has_value()) {
+                        scatter_exchange(mg_down_A, mg_down_B, *lora_grads->moe.grouped.down);
+                    }
                 }
             }  // if (down_ptr && down_ptr->has_value())
         }  // if (use_grouped)

--- a/csrc/src/runtime/ops/moe_grouped_gemm_down.cpp
+++ b/csrc/src/runtime/ops/moe_grouped_gemm_down.cpp
@@ -133,7 +133,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down(const CompiledOp& op) {
             num_experts = llep.num_merged_experts;
             expert_offsets_view.Sizes[0] = static_cast<long>(num_experts + 1);
             const auto meta_it = mEPLayerMeta.find(ep_key_any);
-            const bool refresh_native_only_ptrs = llep.owned_foreign_ptrs.empty() && meta_it != mEPLayerMeta.end() &&
+            const bool refresh_native_only_ptrs = !llep.has_foreign_experts && meta_it != mEPLayerMeta.end() &&
                                                   meta_it->second.num_merged == meta_it->second.num_local &&
                                                   llep.num_merged_experts == meta_it->second.num_local &&
                                                   weights.Rank >= 3;
@@ -589,7 +589,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
             num_experts = llep.num_merged_experts;
             expert_offsets_view.Sizes[0] = static_cast<long>(num_experts + 1);
             const auto meta_it = mEPLayerMeta.find(ep_key);
-            const bool refresh_native_only_ptrs = llep.owned_foreign_ptrs.empty() && meta_it != mEPLayerMeta.end() &&
+            const bool refresh_native_only_ptrs = !llep.has_foreign_experts && meta_it != mEPLayerMeta.end() &&
                                                   meta_it->second.num_merged == meta_it->second.num_local &&
                                                   llep.num_merged_experts == meta_it->second.num_local &&
                                                   weights.Rank >= 3;
@@ -645,9 +645,21 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                         foreign_slot.emplace_back(e, static_cast<int>(foreign_slot.size()));
                     }
                 }
+                // cpu_training: the replay dispatch for this ep_key fetched this
+                // layer's foreign experts into the ring arena moments ago, and
+                // the arena keeps them alive until the next dispatch. Reuse
+                // those pointers for dgrad instead of re-staging the same rows
+                // from the pinned host master on MainStream (native pointers
+                // are rebuilt from the op's fresh `weights` tensor either way).
+                const std::vector<const void*>* llep_foreign_ptrs = nullptr;
+                if (llep_it != mLLEPStates.end() && llep_it->second.active &&
+                    static_cast<int>(llep_it->second.down_weight_ptrs.size()) == meta.num_merged &&
+                    llep_it->second.merged_to_global == meta.merged_to_global) {
+                    llep_foreign_ptrs = &llep_it->second.down_weight_ptrs;
+                }
                 Tensor foreign_stage;
                 bool have_foreign_stage = false;
-                if (!foreign_slot.empty() && mOptions.CpuTraining) {
+                if (!foreign_slot.empty() && !llep_foreign_ptrs && mOptions.CpuTraining) {
                     Tensor* master = mWeights.master_tensor("blocks[" + std::to_string(layer_idx) + "].experts_down");
                     if (master && master->Rank >= 3 && master->DType == weights.DType) {
                         foreign_stage = mRunState.temp_alloc(weights.DType,
@@ -685,6 +697,8 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_down_backward(const CompiledOp&
                     if (local_idx >= 0 && local_idx < meta.num_local) {
                         reconstructed_weight_ptrs[m] =
                             static_cast<const std::byte*>(weights.Data) + static_cast<size_t>(local_idx) * expert_bytes;
+                    } else if (llep_foreign_ptrs) {
+                        reconstructed_weight_ptrs[m] = (*llep_foreign_ptrs)[m];
                     } else if (have_foreign_stage) {
                         int slot = 0;
                         for (const auto& [e, s2] : foreign_slot) {

--- a/csrc/src/runtime/ops/moe_grouped_gemm_gate_up.cpp
+++ b/csrc/src/runtime/ops/moe_grouped_gemm_gate_up.cpp
@@ -357,8 +357,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up(const CompiledOp& op) {
             const auto* lora_grouped_ptr = &lora_block.moe.grouped;
             {
                 auto llep_lora_it = mLLEPStates.find(ep_key_any);
-                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.active &&
-                    llep_lora_it->second.has_merged_lora) {
+                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.has_merged_lora) {
                     lora_grouped_ptr = &llep_lora_it->second.merged_lora;
                 }
             }
@@ -746,7 +745,9 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
     std::vector<const void*> reconstructed_weight_ptrs;
     {
         auto llep_it = mLLEPStates.find(ep_key);
-        if (llep_it != mLLEPStates.end() && llep_it->second.active) {
+        // cpu_training: stored native pointers reference a forward-time prefetch
+        // buffer that has been recycled — always reconstruct with fresh pointers.
+        if (llep_it != mLLEPStates.end() && llep_it->second.active && !mOptions.CpuTraining) {
             auto& llep = llep_it->second;
             is_llep_active = true;
             num_experts = llep.num_merged_experts;
@@ -754,7 +755,15 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
             llep_weight_ptrs = llep.gate_up_weight_ptrs.data();
         } else if (mOptions.EPSize > 1 && layer_idx >= 0) {
             auto meta_it = mEPLayerMeta.find(ep_key);
-            if (meta_it != mEPLayerMeta.end() && meta_it->second.num_merged != meta_it->second.num_local) {
+            auto merged_set_differs = [](const auto& meta) {
+                if (meta.num_merged != meta.num_local) return true;
+                for (int m = 0; m < meta.num_merged; ++m) {
+                    const int li = meta.merged_to_global[m] - meta.native_start;
+                    if (li < 0 || li >= meta.num_local) return true;
+                }
+                return false;
+            };
+            if (meta_it != mEPLayerMeta.end() && merged_set_differs(meta_it->second)) {
                 const auto& meta = meta_it->second;
                 is_llep_active = true;
                 num_experts = meta.num_merged;
@@ -765,11 +774,48 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                 const long gu_rows = (weights.Rank >= 2) ? weights.Sizes[1] : 0;
                 const long gu_cols = (weights.Rank >= 3) ? weights.Sizes[2] : 0;
                 const size_t expert_bytes = static_cast<size_t>(gu_rows * gu_cols) * elem_sz;
-                std::vector<long> zw_shape = {1L, gu_rows, gu_cols};
-                Tensor zero_weight =
-                    mRunState.temp_alloc(weights.DType, zw_shape, "moe_grouped_gemm_gate_up_zero_weight");
-                fill_zero(zero_weight, mRunState.MainStream);
-                mTemps.push_back(zero_weight);
+                // Foreign experts: under cpu_training re-fetch their rows from the
+                // GLOBAL pinned host master so spilled tokens get an exact dgrad.
+                // Without a host master (resident mode, LLEP state evicted) fall
+                // back to zeros — the legacy approximation.
+                std::vector<std::pair<int, int>> foreign_slot;  // (global_e, stage slot)
+                for (int m = 0; m < meta.num_merged; ++m) {
+                    const int e = meta.merged_to_global[m];
+                    const int li = e - meta.native_start;
+                    if (li < 0 || li >= meta.num_local) {
+                        foreign_slot.emplace_back(e, static_cast<int>(foreign_slot.size()));
+                    }
+                }
+                Tensor foreign_stage;
+                bool have_foreign_stage = false;
+                if (!foreign_slot.empty() && mOptions.CpuTraining) {
+                    Tensor* master =
+                        mWeights.master_tensor("blocks[" + std::to_string(layer_idx) + "].experts_gate_up");
+                    if (master && master->Rank >= 3 && master->DType == weights.DType) {
+                        foreign_stage = mRunState.temp_alloc(weights.DType,
+                                                             {static_cast<long>(foreign_slot.size()), gu_rows, gu_cols},
+                                                             "moe_grouped_gemm_gate_up_foreign_stage");
+                        mTemps.push_back(foreign_stage);
+                        for (const auto& [e, slot] : foreign_slot) {
+                            CUDA_CHECK(cudaMemcpyAsync(static_cast<std::byte*>(foreign_stage.Data) +
+                                                           static_cast<size_t>(slot) * expert_bytes,
+                                                       static_cast<const std::byte*>(master->Data) +
+                                                           static_cast<size_t>(e) * expert_bytes,
+                                                       expert_bytes,
+                                                       cudaMemcpyHostToDevice,
+                                                       mRunState.MainStream));
+                        }
+                        have_foreign_stage = true;
+                    }
+                }
+                Tensor zero_weight;
+                if (!foreign_slot.empty() && !have_foreign_stage) {
+                    std::vector<long> zw_shape = {1L, gu_rows, gu_cols};
+                    zero_weight =
+                        mRunState.temp_alloc(weights.DType, zw_shape, "moe_grouped_gemm_gate_up_zero_weight");
+                    fill_zero(zero_weight, mRunState.MainStream);
+                    mTemps.push_back(zero_weight);
+                }
 
                 reconstructed_weight_ptrs.resize(meta.num_merged);
                 for (int m = 0; m < meta.num_merged; ++m) {
@@ -778,6 +824,16 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                     if (local_idx >= 0 && local_idx < meta.num_local) {
                         reconstructed_weight_ptrs[m] =
                             static_cast<const std::byte*>(weights.Data) + static_cast<size_t>(local_idx) * expert_bytes;
+                    } else if (have_foreign_stage) {
+                        int slot = 0;
+                        for (const auto& [e, s] : foreign_slot) {
+                            if (e == global_e) {
+                                slot = s;
+                                break;
+                            }
+                        }
+                        reconstructed_weight_ptrs[m] = static_cast<const std::byte*>(foreign_stage.Data) +
+                                                       static_cast<size_t>(slot) * expert_bytes;
                     } else {
                         reconstructed_weight_ptrs[m] = zero_weight.Data;
                     }
@@ -926,8 +982,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
             bool llep_lora_active = false;
             {
                 auto llep_lora_it = mLLEPStates.find(ep_key);
-                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.active &&
-                    llep_lora_it->second.has_merged_lora) {
+                if (llep_lora_it != mLLEPStates.end() && llep_lora_it->second.has_merged_lora) {
                     lora_grouped_ptr = &llep_lora_it->second.merged_lora;
                     llep_lora_active = true;
                 }
@@ -1137,13 +1192,100 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
 
             modules::LoRABlockWeights<Tensor>* lora_grads = nullptr;
             bool lora_accum = false;
-            if (mLoRAGrads && mComm && !llep_lora_active) {
-                // Skip LoRA weight grads when LLEP is active — grad storage is
-                // [num_local, ...] which doesn't match num_merged.  Input gradient
-                // (dx) is still correct via merged LoRA weights.
+            // LLEP: wgrads are computed in MERGED expert space (the offsets are
+            // merged) — stage them in [num_merged] temps, then scatter-add native
+            // rows into the local grad storage and send foreign rows to their
+            // owner ranks (see scatter_exchange below).
+            const ep::EPLayerMeta* wg_meta = nullptr;
+            if (llep_lora_active) {
+                auto wg_it = mEPLayerMeta.find(ep_key);
+                if (wg_it != mEPLayerMeta.end() && !wg_it->second.expert_to_gpu.empty()) {
+                    wg_meta = &wg_it->second;
+                }
+            }
+            const bool llep_wgrad = llep_lora_active && wg_meta != nullptr && mComm != nullptr;
+            if (mLoRAGrads && mComm && (!llep_lora_active || llep_wgrad)) {
                 lora_grads = &mLoRAGrads->get_block_full(layer_idx, mRunState.MainStream, *mComm, lora_accum);
             }
             const float grad_beta = lora_accum ? 1.0f : 0.0f;
+
+            auto merged_temp = [&](long rows, long cols) -> Tensor {
+                Tensor t = mRunState.temp_alloc(
+                    d_gate_up.DType, {static_cast<long>(num_experts), rows, cols}, "llep_merged_wgrad");
+                fill_zero(t, mRunState.MainStream);
+                mTemps.push_back(t);
+                return t;
+            };
+            Tensor mg_gate_up_A, mg_gate_up_B, mg_gate_A, mg_gate_B, mg_up_A, mg_up_B;
+
+            auto row_view = [&](const Tensor& t, int row) -> Tensor {
+                const long r1 = t.Sizes[1], r2 = t.Sizes[2];
+                const std::size_t off =
+                    static_cast<std::size_t>(row) * r1 * r2 * get_dtype_size(t.DType);
+                return Tensor::from_pointer(static_cast<std::byte*>(t.Data) + off, t.Device, t.DType,
+                                            std::vector<long>{r1, r2});
+            };
+            auto row_add = [&](Tensor& dst3, int dst_row, const Tensor& src3, int src_row) {
+                Tensor d = row_view(dst3, dst_row);
+                Tensor sv = row_view(src3, src_row);
+                vector_add_sr(d, d, sv, 1.0f, d.nelem(), 0, mRunState.MainStream);
+            };
+            // Scatter merged wgrads into local rows; exchange foreign rows to owners.
+            // Send/recv order: ascending global expert id, A before B — identical on
+            // every rank, so the pairwise WT-comm schedule matches.
+            auto scatter_exchange = [&](Tensor& mgA, Tensor& mgB,
+                                        modules::LoRAGroupedLayerWeights<Tensor>& local) {
+                const auto& meta = *wg_meta;
+                const int nl = std::max(meta.num_local, 1);
+                const int my_ep = meta.native_start / nl;
+                if (!lora_accum) {
+                    fill_zero(local.A, mRunState.MainStream);
+                    fill_zero(local.B, mRunState.MainStream);
+                }
+                std::vector<int> g2m(meta.expert_to_gpu.size(), -1);
+                for (int m = 0; m < meta.num_merged; ++m) g2m[meta.merged_to_global[m]] = m;
+                for (int m = 0; m < meta.num_merged; ++m) {
+                    const int ln = meta.merged_to_global[m] - meta.native_start;
+                    if (ln >= 0 && ln < meta.num_local) {
+                        row_add(local.A, ln, mgA, m);
+                        row_add(local.B, ln, mgB, m);
+                    }
+                }
+                const std::size_t a_bytes = static_cast<std::size_t>(mgA.Sizes[1]) * mgA.Sizes[2] *
+                                            get_dtype_size(mgA.DType);
+                const std::size_t b_bytes = static_cast<std::size_t>(mgB.Sizes[1]) * mgB.Sizes[2] *
+                                            get_dtype_size(mgB.DType);
+                std::vector<std::tuple<int, Tensor, Tensor>> recvs;  // (expert, tmpA, tmpB)
+                mComm->weight_transfer_group_start();
+                const int E_total = static_cast<int>(meta.expert_to_gpu.size());
+                for (int e = 0; e < E_total; ++e) {
+                    const int owner = e / nl;
+                    const int helper = meta.expert_to_gpu[e];
+                    if (helper == owner) continue;
+                    if (helper == my_ep && g2m[e] >= 0) {
+                        Tensor sa = row_view(mgA, g2m[e]);
+                        Tensor sb = row_view(mgB, g2m[e]);
+                        mComm->send_wt(sa.Data, a_bytes, owner, mRunState.MainStream);
+                        mComm->send_wt(sb.Data, b_bytes, owner, mRunState.MainStream);
+                    } else if (owner == my_ep) {
+                        Tensor ta = mRunState.temp_alloc(mgA.DType, {mgA.Sizes[1], mgA.Sizes[2]}, "llep_wgrad_recv");
+                        Tensor tb = mRunState.temp_alloc(mgB.DType, {mgB.Sizes[1], mgB.Sizes[2]}, "llep_wgrad_recv");
+                        mTemps.push_back(ta);
+                        mTemps.push_back(tb);
+                        mComm->recv_wt(ta.Data, a_bytes, helper, mRunState.MainStream);
+                        mComm->recv_wt(tb.Data, b_bytes, helper, mRunState.MainStream);
+                        recvs.emplace_back(e, ta, tb);
+                    }
+                }
+                mComm->weight_transfer_group_end();
+                for (auto& [e, ta, tb] : recvs) {
+                    const int ln = e - meta.native_start;
+                    Tensor da = row_view(local.A, ln);
+                    Tensor db = row_view(local.B, ln);
+                    vector_add_sr(da, da, ta, 1.0f, da.nelem(), 0, mRunState.MainStream);
+                    vector_add_sr(db, db, tb, 1.0f, db.nelem(), 0, mRunState.MainStream);
+                }
+            };
 
             if (total_tokens_i > 0 && rank > 0) {
                 Tensor lora_intermediate = view_or_temp(mLoRARunState->moe_lora_intermediate1, total_tokens_l, rank);
@@ -1162,7 +1304,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                           EMMTranspose::TN);
                     scale_and_dropout(lora_intermediate, seed_gate_up);
                     if (lora_grads && lora_grads->moe.grouped.gate_up.has_value()) {
-                        dispatch_weight_grad(lora_grads->moe.grouped.gate_up->B,
+                        dispatch_weight_grad(llep_wgrad ? (mg_gate_up_B.Data ? mg_gate_up_B : (mg_gate_up_B = merged_temp(gate_up_dim, rank))) : lora_grads->moe.grouped.gate_up->B,
                                              d_gate_up,
                                              lora_intermediate,
                                              gate_up_dim,
@@ -1179,7 +1321,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                           EMMTranspose::NN);
                     scale_and_dropout(lora_intermediate, seed_gate_up);
                     if (lora_grads && lora_grads->moe.grouped.gate_up.has_value()) {
-                        dispatch_weight_grad(lora_grads->moe.grouped.gate_up->A,
+                        dispatch_weight_grad(llep_wgrad ? (mg_gate_up_A.Data ? mg_gate_up_A : (mg_gate_up_A = merged_temp(rank, hidden_size))) : lora_grads->moe.grouped.gate_up->A,
                                              lora_intermediate,
                                              inp,
                                              rank,
@@ -1223,7 +1365,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                               EMMTranspose::TN);
                         scale_and_dropout(lora_intermediate, seed_gate);
                         if (lora_grads && lora_grads->moe.grouped.gate.has_value()) {
-                            dispatch_weight_grad(lora_grads->moe.grouped.gate->B,
+                            dispatch_weight_grad(llep_wgrad ? (mg_gate_B.Data ? mg_gate_B : (mg_gate_B = merged_temp(intermediate_size, rank))) : lora_grads->moe.grouped.gate->B,
                                                  d_gate,
                                                  lora_intermediate,
                                                  intermediate_size,
@@ -1241,7 +1383,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                               EMMTranspose::NN);
                         scale_and_dropout(lora_intermediate, seed_gate);
                         if (lora_grads && lora_grads->moe.grouped.gate.has_value()) {
-                            dispatch_weight_grad(lora_grads->moe.grouped.gate->A,
+                            dispatch_weight_grad(llep_wgrad ? (mg_gate_A.Data ? mg_gate_A : (mg_gate_A = merged_temp(rank, hidden_size))) : lora_grads->moe.grouped.gate->A,
                                                  lora_intermediate,
                                                  inp,
                                                  rank,
@@ -1272,7 +1414,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                               EMMTranspose::TN);
                         scale_and_dropout(lora_intermediate, seed_up);
                         if (lora_grads && lora_grads->moe.grouped.up.has_value()) {
-                            dispatch_weight_grad(lora_grads->moe.grouped.up->B,
+                            dispatch_weight_grad(llep_wgrad ? (mg_up_B.Data ? mg_up_B : (mg_up_B = merged_temp(intermediate_size, rank))) : lora_grads->moe.grouped.up->B,
                                                  d_up,
                                                  lora_intermediate,
                                                  intermediate_size,
@@ -1289,7 +1431,7 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                               EMMTranspose::NN);
                         scale_and_dropout(lora_intermediate, seed_up);
                         if (lora_grads && lora_grads->moe.grouped.up.has_value()) {
-                            dispatch_weight_grad(lora_grads->moe.grouped.up->A,
+                            dispatch_weight_grad(llep_wgrad ? (mg_up_A.Data ? mg_up_A : (mg_up_A = merged_temp(rank, hidden_size))) : lora_grads->moe.grouped.up->A,
                                                  lora_intermediate,
                                                  inp,
                                                  rank,
@@ -1304,6 +1446,18 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                                               1.0f,
                                               1.0f,
                                               EMMTranspose::NN);
+                    }
+                }
+
+                if (llep_wgrad && lora_grads) {
+                    if (mg_gate_up_A.Data && mg_gate_up_B.Data && lora_grads->moe.grouped.gate_up.has_value()) {
+                        scatter_exchange(mg_gate_up_A, mg_gate_up_B, *lora_grads->moe.grouped.gate_up);
+                    }
+                    if (mg_gate_A.Data && mg_gate_B.Data && lora_grads->moe.grouped.gate.has_value()) {
+                        scatter_exchange(mg_gate_A, mg_gate_B, *lora_grads->moe.grouped.gate);
+                    }
+                    if (mg_up_A.Data && mg_up_B.Data && lora_grads->moe.grouped.up.has_value()) {
+                        scatter_exchange(mg_up_A, mg_up_B, *lora_grads->moe.grouped.up);
                     }
                 }
             }

--- a/csrc/src/runtime/ops/moe_grouped_gemm_gate_up.cpp
+++ b/csrc/src/runtime/ops/moe_grouped_gemm_gate_up.cpp
@@ -786,9 +786,21 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                         foreign_slot.emplace_back(e, static_cast<int>(foreign_slot.size()));
                     }
                 }
+                // cpu_training: the replay dispatch for this ep_key fetched this
+                // layer's foreign experts into the ring arena moments ago, and
+                // the arena keeps them alive until the next dispatch. Reuse
+                // those pointers for dgrad instead of re-staging the same rows
+                // from the pinned host master on MainStream (native pointers
+                // are rebuilt from the op's fresh `weights` tensor either way).
+                const std::vector<const void*>* llep_foreign_ptrs = nullptr;
+                if (llep_it != mLLEPStates.end() && llep_it->second.active &&
+                    static_cast<int>(llep_it->second.gate_up_weight_ptrs.size()) == meta.num_merged &&
+                    llep_it->second.merged_to_global == meta.merged_to_global) {
+                    llep_foreign_ptrs = &llep_it->second.gate_up_weight_ptrs;
+                }
                 Tensor foreign_stage;
                 bool have_foreign_stage = false;
-                if (!foreign_slot.empty() && mOptions.CpuTraining) {
+                if (!foreign_slot.empty() && !llep_foreign_ptrs && mOptions.CpuTraining) {
                     Tensor* master =
                         mWeights.master_tensor("blocks[" + std::to_string(layer_idx) + "].experts_gate_up");
                     if (master && master->Rank >= 3 && master->DType == weights.DType) {
@@ -824,6 +836,8 @@ void CompiledExecutor::dispatch_moe_grouped_gemm_gate_up_backward(const Compiled
                     if (local_idx >= 0 && local_idx < meta.num_local) {
                         reconstructed_weight_ptrs[m] =
                             static_cast<const std::byte*>(weights.Data) + static_cast<size_t>(local_idx) * expert_bytes;
+                    } else if (llep_foreign_ptrs) {
+                        reconstructed_weight_ptrs[m] = (*llep_foreign_ptrs)[m];
                     } else if (have_foreign_stage) {
                         int slot = 0;
                         for (const auto& [e, s] : foreign_slot) {

--- a/csrc/src/runtime/ops/moe_permute.cpp
+++ b/csrc/src/runtime/ops/moe_permute.cpp
@@ -1,8 +1,10 @@
 #include "runtime/executor/compiled_ops.h"
 
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include "runtime/executor/compiled_ops_helpers.h"
@@ -84,15 +86,35 @@ void CompiledExecutor::dispatch_moe_permute(const CompiledOp& op) {
                       num_experts,
                       mRunState.MainStream);
 
-    // Cache expert offsets on host for grouped GEMM fast path.
+    // Cache expert offsets on host for grouped GEMM fast path. Stage through
+    // PINNED memory + a poll wait: a pageable async D2H can block inside the
+    // driver's staging pool when all worker threads copy at once, convoying
+    // with in-stream NCCL kernels into a cross-rank deadlock.
     if (num_experts > 0) {
+        const std::size_t off_bytes = static_cast<std::size_t>(num_experts + 1) * sizeof(int);
+        if (mMoEOffsetsPinnedBytes < off_bytes) {
+            if (mMoEOffsetsPinned) {
+                CUDA_CHECK(cudaFreeHost(mMoEOffsetsPinned));
+            }
+            CUDA_CHECK(cudaHostAlloc(&mMoEOffsetsPinned, off_bytes, cudaHostAllocDefault));
+            mMoEOffsetsPinnedBytes = off_bytes;
+        }
         mMoEExpertOffsetsData.resize(static_cast<std::size_t>(num_experts + 1));
-        CUDA_CHECK(cudaMemcpyAsync(mMoEExpertOffsetsData.data(),
+        CUDA_CHECK(cudaMemcpyAsync(mMoEOffsetsPinned,
                                    expert_offsets.get<int>(),
-                                   static_cast<std::size_t>(num_experts + 1) * sizeof(int),
+                                   off_bytes,
                                    cudaMemcpyDeviceToHost,
                                    mRunState.MainStream));
-        CUDA_CHECK(cudaStreamSynchronize(mRunState.MainStream));
+        while (true) {
+            const cudaError_t st = cudaStreamQuery(mRunState.MainStream);
+            if (st == cudaSuccess) break;
+            if (st != cudaErrorNotReady) {
+                CUDA_CHECK(st);
+            }
+            (void)cudaGetLastError();
+            std::this_thread::yield();
+        }
+        std::memcpy(mMoEExpertOffsetsData.data(), mMoEOffsetsPinned, off_bytes);
 
         // Populate per-layer cache so downstream gate_up/down ops skip redundant D2H syncs.
         if (layer_idx_any >= 0) {

--- a/csrc/src/runtime/training/runtime_options.h
+++ b/csrc/src/runtime/training/runtime_options.h
@@ -46,6 +46,9 @@ struct RuntimeOptions {
     // See RecomputeLevel enum above for level descriptions.
     RecomputeLevel Recompute = RecomputeLevel::None;
     bool OffloadResidual = false;
+    // Offload per-layer saved-for-backward tensors to pinned host at forward
+    // layer end; restored at backward layer start. Requires recompute.
+    bool OffloadSavedTensors = false;
     int LMHeadChunks = 1;
     bool SkipIgnoredLMHeadRows = false;
     int AttBwdChunks = 1;

--- a/csrc/src/tokenizer/tokenizer.cpp
+++ b/csrc/src/tokenizer/tokenizer.cpp
@@ -546,8 +546,12 @@ Tokenizer Tokenizer::from_pretrained(const std::string& model_dir) {
         impl.add_bos = config.value("add_bos_token", false);
         impl.add_eos = config.value("add_eos_token", false);
 
-        // Load chat template (Jinja2 string) — parse directly, skip capability probing
-        if (config.contains("chat_template") && config["chat_template"].is_string()) {
+        // Load chat template (Jinja2 string) — parse directly, skip capability probing.
+        // A standalone chat_template.jinja takes precedence (HF convention): some
+        // checkpoints set the config field to "{% include 'chat_template.jinja' %}",
+        // which minja cannot resolve.
+        if (!fs::exists(dir / "chat_template.jinja") && config.contains("chat_template") &&
+            config["chat_template"].is_string()) {
             std::string tmpl_str = config["chat_template"].get<std::string>();
             impl.chat_tmpl_root = minja::Parser::parse(tmpl_str,
                                                        {

--- a/csrc/src/utilities/comm.cpp
+++ b/csrc/src/utilities/comm.cpp
@@ -7,7 +7,10 @@
 
 #include <algorithm>
 #include <cstring>
+#include <chrono>
+#include <csignal>
 #include <cstdlib>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 #include <variant>
@@ -112,12 +115,71 @@ NCCLCommunicator::NCCLCommunicator(int rank, int world, const void* nccl_id, int
  *
  * Always destroys the internal CUDA event/stream (best-effort; never throws).
  */
+namespace {
+/// Teardown body for ~NCCLCommunicator's helper thread. Takes raw handles BY
+/// VALUE — the helper may outlive the object (detached on timeout), so it must
+/// never dereference the communicator.
+void terminate_nccl_comms(ncclComm_t main_comm,
+                          ncclComm_t ep_comm,
+                          ncclComm_t dp_comm,
+                          ncclComm_t wt_comm,
+                          cudaStream_t comms_stream,
+                          bool already_torn_down) {
+    if (already_torn_down || !main_comm) {
+        return;
+    }
+    ncclResult_t result;
+    ncclCheck(ncclCommGetAsyncError(main_comm, &result));
+    if (result == ncclSuccess) {
+        CUDA_CHECK(cudaStreamSynchronize(comms_stream));
+        CUDA_CHECK(cudaDeviceSynchronize());
+        if (wt_comm) {
+            ncclCheck(ncclCommFinalize(wt_comm));
+            ncclCheck(ncclCommDestroy(wt_comm));
+        }
+        if (dp_comm) {
+            ncclCheck(ncclCommFinalize(dp_comm));
+            ncclCheck(ncclCommDestroy(dp_comm));
+        }
+        if (ep_comm) {
+            ncclCheck(ncclCommFinalize(ep_comm));
+            ncclCheck(ncclCommDestroy(ep_comm));
+        }
+        ncclCheck(ncclCommFinalize(main_comm));
+        ncclCheck(ncclCommDestroy(main_comm));
+    } else {
+        if (wt_comm) ncclCommAbort(wt_comm);
+        if (dp_comm) ncclCommAbort(dp_comm);
+        if (ep_comm) ncclCommAbort(ep_comm);
+        ncclCommAbort(main_comm);
+    }
+}
+}  // namespace
+
 NCCLCommunicator::~NCCLCommunicator() {
     // When used with the python bindings, ncclCommFinalize() can hang forever;
     // I haven't found a fix, so here we just make sure that the hang gets localized
     // to a helper thread (which we leak, but generally ~NCCLCommunicator is expected
-    // to run at program shutdown anyway)
-    auto terminate_future = std::async(std::launch::async, [this]() { this->terminate_nccl(); });
+    // to run at program shutdown anyway).
+    //
+    // The helper must NOT capture `this`: on timeout the future is detached while
+    // this object is destroyed underneath it (observed SIGSEGV at exit). Claim the
+    // teardown flag here and hand the helper raw handles by value.
+    const bool already_torn_down = mNcclTornDown.exchange(true);
+    auto terminate_future = std::async(std::launch::async,
+                                       [main_comm = mNcclComm,
+                                        ep_comm = mEPComm,
+                                        dp_comm = mDPComm,
+                                        wt_comm = mWeightTransferComm,
+                                        comms_stream = mCommsStream,
+                                        already_torn_down]() {
+                                           terminate_nccl_comms(main_comm,
+                                                                ep_comm,
+                                                                dp_comm,
+                                                                wt_comm,
+                                                                comms_stream,
+                                                                already_torn_down);
+                                       });
 
     if (terminate_future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
         fprintf(stderr, "NCCL termination timed out, detaching\n");
@@ -155,49 +217,34 @@ NCCLCommunicator::~NCCLCommunicator() {
  *
  * @note Intended to be called from a helper thread in the destructor to avoid process-wide hangs.
  */
-void NCCLCommunicator::terminate_nccl() {
-    ncclResult_t result;
-    ncclCheck(ncclCommGetAsyncError(mNcclComm, &result));
-    // do "nice" shutdown if we're in a good state,
-    // just abort if there is something weird going on.
-    if (std::uncaught_exceptions() == 0 && result == ncclSuccess) {
-        CUDA_CHECK(cudaStreamSynchronize(mCommsStream));
-        CUDA_CHECK(cudaDeviceSynchronize());
-
-        // Destroy EP sub-communicators before the global comm
-        if (mWeightTransferComm) {
-            ncclCheck(ncclCommFinalize(mWeightTransferComm));
-            ncclCheck(ncclCommDestroy(mWeightTransferComm));
-            mWeightTransferComm = nullptr;
-        }
-        if (mDPComm) {
-            ncclCheck(ncclCommFinalize(mDPComm));
-            ncclCheck(ncclCommDestroy(mDPComm));
-            mDPComm = nullptr;
-        }
-        if (mEPComm) {
-            ncclCheck(ncclCommFinalize(mEPComm));
-            ncclCheck(ncclCommDestroy(mEPComm));
-            mEPComm = nullptr;
-        }
-
-        ncclCheck(ncclCommFinalize(mNcclComm));
-        ncclCheck(ncclCommDestroy(mNcclComm));
-    } else {
-        if (mWeightTransferComm) {
-            ncclCommAbort(mWeightTransferComm);
-            mWeightTransferComm = nullptr;
-        }
-        if (mDPComm) {
-            ncclCommAbort(mDPComm);
-            mDPComm = nullptr;
-        }
-        if (mEPComm) {
-            ncclCommAbort(mEPComm);
-            mEPComm = nullptr;
-        }
-        ncclCheck(ncclCommAbort(mNcclComm));
+void NCCLCommunicator::abort_comms() {
+    if (mNcclTornDown.exchange(true)) {
+        return;
     }
+    // ncclCommAbort is documented as callable from a different thread to break
+    // ranks out of collectives that will never complete (peer crashed). Pending
+    // operations on these comms return an error instead of spinning forever.
+    // Deliberately do not null the handles: the owning thread may be concurrently
+    // inside a collective reading them; it observes the abort via the NCCL error.
+    if (mWeightTransferComm) {
+        ncclCommAbort(mWeightTransferComm);
+    }
+    if (mDPComm) {
+        ncclCommAbort(mDPComm);
+    }
+    if (mEPComm) {
+        ncclCommAbort(mEPComm);
+    }
+    if (mNcclComm) {
+        ncclCommAbort(mNcclComm);
+    }
+}
+
+void NCCLCommunicator::terminate_nccl() {
+    if (mNcclTornDown.exchange(true)) {
+        return;  // already aborted/claimed elsewhere
+    }
+    terminate_nccl_comms(mNcclComm, mEPComm, mDPComm, mWeightTransferComm, mCommsStream, false);
 }
 
 /**
@@ -884,12 +931,71 @@ void NCCLCommunicator::schedule_destructive_all_to_all(const Tensor& tensor) {
  * Can optionally replace some NCCL ops (all-gather and/or send/recv) with device-to-device
  * memcpy coordinated via barriers.
  */
+/// Yield-spin barrier with std::barrier's arrive_and_wait / arrive_and_drop
+/// surface. Waiters spin on an atomic generation instead of parking on a futex:
+/// under heavy multi-threaded CUDA load we observed rare lost-wakeup stalls
+/// (minutes, resolved by any signal) with the futex-parked std::barrier — a
+/// spinner cannot miss a wakeup. Barrier phases here are short (launch-queue
+/// throttling, memcpy handoffs), so spinning is the right trade.
+class SpinBarrier {
+public:
+    explicit SpinBarrier(int participants) : mParticipants(participants) {}
+
+    void arrive_and_wait() {
+        long gen;
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            gen = mGeneration.load(std::memory_order_relaxed);
+            if (++mArrivals >= mParticipants) {
+                mArrivals = 0;
+                mGeneration.store(gen + 1, std::memory_order_release);
+                return;
+            }
+        }
+        while (mGeneration.load(std::memory_order_acquire) == gen) {
+            std::this_thread::yield();
+        }
+    }
+
+    void arrive_and_drop() {
+        std::lock_guard<std::mutex> lock(mMutex);
+        const long gen = mGeneration.load(std::memory_order_relaxed);
+        --mParticipants;
+        if (mParticipants > 0 && mArrivals >= mParticipants) {
+            mArrivals = 0;
+            mGeneration.store(gen + 1, std::memory_order_release);
+        }
+    }
+
+private:
+    std::atomic<long> mGeneration{0};
+    std::mutex mMutex;  ///< guards mArrivals/mParticipants transitions
+    int mParticipants;
+    int mArrivals = 0;
+};
+
 class NCCLCommunicatorImpl : public NCCLCommunicator {
 public:
     struct SharedState {
-        std::unique_ptr<std::barrier<>> Barrier;
+        std::unique_ptr<SpinBarrier> Barrier;
         std::vector<std::byte*> Buffer;  // one pointer per thread
         std::vector<std::exception_ptr> Exceptions;
+        // Live communicators, one slot per local rank (registered in the
+        // NCCLCommunicatorImpl ctor, cleared in its dtor). Guarded by
+        // AbortMutex — NOT Mutex: the abort thread can wedge inside
+        // ncclCommAbort (CUDA driver locks), and it must never starve
+        // has_exception()/check_exceptions() which lock Mutex.
+        std::vector<NCCLCommunicator*> Comms;
+        std::mutex AbortMutex;
+        // Local rank of the first thread that stored an exception (-1 = none).
+        // join() rethrows this one so the root cause (e.g. an OOM) surfaces
+        // instead of a follow-on NCCL-abort error from a surviving rank.
+        int FirstExceptionRank = -1;
+        // Number of worker threads that have not finished their lambda yet.
+        // Set to the launch count up front; each thread decrements on exit
+        // (normal or exceptional). Lets wait_exit_for() poll for teardown
+        // completion without a blocking join.
+        std::atomic<int> ThreadsAlive{0};
         std::mutex Mutex;
         int NumNodes = 1;   // number of nodes (1 = single node)
         int NodeRank = 0;   // this node's rank
@@ -1042,9 +1148,18 @@ NCCLCommunicatorImpl::NCCLCommunicatorImpl(int local_rank,
       mLocalRank(local_rank),
       mAllGatherUseMemcpy(memcpy_allgather),
       mSendRecvUseMemcpy(memcpy_send_recv) {
+    std::lock_guard<std::mutex> lock(mShare->AbortMutex);
+    if (mShare->Comms.size() <= static_cast<std::size_t>(local_rank)) {
+        mShare->Comms.resize(static_cast<std::size_t>(local_rank) + 1, nullptr);
+    }
+    mShare->Comms[static_cast<std::size_t>(local_rank)] = this;
 }
 
 NCCLCommunicatorImpl::~NCCLCommunicatorImpl() {
+    if (mShare) {
+        std::lock_guard<std::mutex> lock(mShare->AbortMutex);
+        mShare->Comms[static_cast<std::size_t>(mLocalRank)] = nullptr;
+    }
     if (mShare && mShare->Barrier) {
         mShare->Barrier->arrive_and_drop();
     }
@@ -1358,6 +1473,61 @@ public:
         return false;
     }
 
+    void abort_async() override {
+        // Run on a detached thread: ncclCommAbort can itself block on CUDA
+        // driver locks held by a wedged thread, and the caller must stay
+        // responsive to escalate (bounded wait -> forced exit). Captures the
+        // shared state (not `this`) so pack lifetime doesn't matter.
+        auto state = mState;
+        std::thread([state]() {
+            // Holding AbortMutex keeps each comm alive for the duration of its
+            // abort: ~NCCLCommunicatorImpl deregisters under the same mutex.
+            // If ncclCommAbort wedges (driver locks), this blocks only comm
+            // destructors — never the exception-query path (Mutex) — so the
+            // caller's bounded wait still times out and escalates.
+            std::lock_guard<std::mutex> lock(state->AbortMutex);
+            for (auto* comm : state->Comms) {
+                if (comm) {
+                    comm->abort_comms();
+                }
+            }
+        }).detach();
+    }
+
+    bool wait_exit_for(int timeout_ms) override {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (mState->ThreadsAlive.load(std::memory_order_acquire) > 0) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return true;
+    }
+
+    void rethrow_exception() override {
+        check_exceptions();
+    }
+
+    void poke_workers() override {
+        // One-time: install a no-op SIGUSR2 handler WITHOUT SA_RESTART so a
+        // poked thread's blocking syscall returns EINTR and re-checks its
+        // condition (lost-wakeup recovery).
+        static std::once_flag once;
+        std::call_once(once, [] {
+            struct sigaction sa{};
+            sa.sa_handler = [](int) {};
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags = 0;  // deliberately no SA_RESTART
+            sigaction(SIGUSR2, &sa, nullptr);
+        });
+        for (auto& t : mThreads) {
+            if (t.joinable()) {
+                pthread_kill(t.native_handle(), SIGUSR2);
+            }
+        }
+    }
+
 private:
     void join_impl() {
         check_exceptions();
@@ -1371,6 +1541,18 @@ private:
 
     void check_exceptions() {
         std::lock_guard<std::mutex> lock(mState->Mutex);
+        // Rethrow the chronologically first exception: after an abort, surviving
+        // ranks store follow-on NCCL errors that would otherwise mask the root
+        // cause (and break OOM detection in the Python recovery path).
+        if (mState->FirstExceptionRank >= 0) {
+            const auto first = static_cast<size_t>(mState->FirstExceptionRank);
+            if (auto error = mState->Exceptions[first]; error) {
+                fprintf(stderr, "Thread %zu exited with uncaught exception\n", first);
+                fflush(stderr);
+                mState->Exceptions[first] = nullptr;
+                std::rethrow_exception(error);
+            }
+        }
         for (size_t t = 0; t < mThreads.size(); ++t) {
             if (auto error = mState->Exceptions[t]; error) {
                 fprintf(stderr, "Thread %zu exited with uncaught exception\n", t);
@@ -1421,9 +1603,10 @@ launch_communicators_impl(int ngpus,
 
     // Create shared state for local threads
     auto shared_state = std::make_shared<NCCLCommunicatorImpl::SharedState>();
-    shared_state->Barrier = std::make_unique<std::barrier<>>(ngpus);
+    shared_state->Barrier = std::make_unique<SpinBarrier>(ngpus);
     shared_state->Buffer.resize(ngpus);
     shared_state->Exceptions.resize(ngpus);
+    shared_state->ThreadsAlive.store(ngpus, std::memory_order_release);
     shared_state->NumNodes = 1;
     shared_state->NodeRank = 0;
     shared_state->LocalGPUs = ngpus;
@@ -1434,6 +1617,12 @@ launch_communicators_impl(int ngpus,
 
     for (int local_rank = 0; local_rank < ngpus; ++local_rank) {
         threads.emplace_back([=]() {
+            struct ExitGuard {
+                std::shared_ptr<NCCLCommunicatorImpl::SharedState> state;
+                ~ExitGuard() {
+                    state->ThreadsAlive.fetch_sub(1, std::memory_order_release);
+                }
+            } exit_guard{shared_state};
             try {
                 if (!set_cpu_affinity()) {
                     fprintf(stderr, "WARNING: Failed to set CPU affinity for local rank %d\n", local_rank);
@@ -1446,6 +1635,9 @@ launch_communicators_impl(int ngpus,
             } catch (...) {
                 std::lock_guard<std::mutex> lock(shared_state->Mutex);
                 shared_state->Exceptions[local_rank] = std::current_exception();
+                if (shared_state->FirstExceptionRank < 0) {
+                    shared_state->FirstExceptionRank = local_rank;
+                }
             }
         });
     }
@@ -1542,9 +1734,10 @@ NCCLCommunicator::launch_communicators_multinode(int ngpus,
 
     // Create shared state for local threads
     auto shared_state = std::make_shared<NCCLCommunicatorImpl::SharedState>();
-    shared_state->Barrier = std::make_unique<std::barrier<>>(ngpus);
+    shared_state->Barrier = std::make_unique<SpinBarrier>(ngpus);
     shared_state->Buffer.resize(ngpus);
     shared_state->Exceptions.resize(ngpus);
+    shared_state->ThreadsAlive.store(ngpus, std::memory_order_release);
     shared_state->NumNodes = num_nodes;
     shared_state->NodeRank = node_rank;
     shared_state->LocalGPUs = ngpus;
@@ -1577,6 +1770,12 @@ NCCLCommunicator::launch_communicators_multinode(int ngpus,
         int global_rank = node_rank * ngpus + local_rank;
 
         threads.emplace_back([=]() {
+            struct ExitGuard {
+                std::shared_ptr<NCCLCommunicatorImpl::SharedState> state;
+                ~ExitGuard() {
+                    state->ThreadsAlive.fetch_sub(1, std::memory_order_release);
+                }
+            } exit_guard{shared_state};
             try {
                 if (!set_cpu_affinity()) {
                     fprintf(stderr, "WARNING: Failed to set CPU affinity for local rank %d\n", local_rank);
@@ -1614,6 +1813,9 @@ NCCLCommunicator::launch_communicators_multinode(int ngpus,
             } catch (...) {
                 std::lock_guard<std::mutex> lock(shared_state->Mutex);
                 shared_state->Exceptions[local_rank] = std::current_exception();
+                if (shared_state->FirstExceptionRank < 0) {
+                    shared_state->FirstExceptionRank = local_rank;
+                }
             }
         });
     }

--- a/csrc/src/utilities/comm.h
+++ b/csrc/src/utilities/comm.h
@@ -7,6 +7,7 @@
 #define SUROGATE_SRC_UTILITIES_COMM_H
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -34,6 +35,24 @@ public:
     virtual ~CommunicatorThreadsPack() = default;
     virtual void join() = 0;
     virtual bool has_exception() const = 0;
+    // Abort all ranks' NCCL communicators on a detached helper thread so ranks
+    // stuck in collectives (waiting for a crashed peer) return with an error
+    // instead of spinning forever. Detached because ncclCommAbort itself can
+    // wedge on CUDA driver locks held by a stuck thread — the caller must not
+    // block on it. Idempotent per communicator.
+    virtual void abort_async() = 0;
+    // Wait up to timeout_ms for all worker threads to exit. Returns true if
+    // they all exited (join() is then guaranteed not to block).
+    virtual bool wait_exit_for(int timeout_ms) = 0;
+    // Rethrow the stored root-cause exception (if any) WITHOUT joining the
+    // threads. Used when workers are wedged and join() would hang.
+    virtual void rethrow_exception() = 0;
+    // Deliver a no-op signal (SIGUSR2, SA_RESTART off) to every worker thread.
+    // Interrupts driver/futex waits that missed their wakeup (observed rarely
+    // under heavy multi-threaded CUDA load); the wait retries and sees the
+    // completed condition. Safe: the handler does nothing, EINTR-aware code
+    // (CUDA driver, NCCL, libstdc++ atomic waits) simply re-checks.
+    virtual void poke_workers() = 0;
 };
 
 class NCCLCommunicator {
@@ -262,6 +281,12 @@ public:
      */
     static std::array<std::byte, 128> generate_nccl_id();
 
+    /// Abort all NCCL communicators owned by this rank (global + EP/DP/WT).
+    /// Callable from any thread; used to break ranks out of collectives that
+    /// will never complete because a peer crashed. Idempotent with respect to
+    /// terminate_nccl(): whichever runs first claims the teardown.
+    void abort_comms();
+
 protected:
     void terminate_nccl();
 
@@ -295,6 +320,10 @@ private:
     ncclComm_t mEPComm = nullptr;
     ncclComm_t mDPComm = nullptr;
     ncclComm_t mWeightTransferComm = nullptr;
+
+    // Set once teardown (abort_comms or terminate_nccl) has claimed the comms;
+    // the loser of the race must not touch them again.
+    std::atomic<bool> mNcclTornDown{false};
 
     cudaEvent_t mCommsSync;
     cudaStream_t mCommsStream;

--- a/examples/sft/laguna/laguna-s-lora-fp8.yaml
+++ b/examples/sft/laguna/laguna-s-lora-fp8.yaml
@@ -1,0 +1,58 @@
+# Laguna-S-2.1 (~117B total, ~6B active MoE) LoRA SFT on 8 GPUs.
+# Native CPU offloading (cpu_training): BF16 base weights stream per-layer from
+# pinned CPU RAM; experts are sharded 8-way (ep_size). Compute runs fp8-hybrid.
+model: poolside/Laguna-S-2.1
+output_dir: ./output_laguna_s
+
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 1
+
+gpus: 8
+ep_size: 8
+
+sample_packing: true
+sequence_len: 256
+
+max_steps: 20
+eval_steps: 100
+learning_rate: 2e-4
+warmup_ratio: 0.1
+
+recipe: fp8-hybrid
+lmhead_chunks: 8
+
+lora: true
+lora_rank: 16
+lora_alpha: 32
+lora_dtype: bf16
+
+qlora_offload_experts: false
+cpu_training: true
+# recompute (on by default) bounds per-layer activations; offload_residual moves the
+# per-layer residual checkpoints to pinned CPU so total activation memory is independent
+# of depth — needed here, the OOM was a late-layer (op ~1738) backward saved-tensor.
+offload_residual: true
+# Experimental: stream per-layer saved-for-backward tensors to pinned CPU.
+# Correct (XS-validated) but at Laguna scale the v1 restore pattern still adds
+# transient pressure — leave off until the overlap/refinement pass lands.
+offload_saved_tensors: false
+
+# Full targets: grouped expert-LoRA is EP-sharded (each rank adapts its 32
+# experts, ~1.7 GB/GPU); adapter export all-gathers the shards into one file.
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# Temporary: print per-phase GPU memory so we can see what fills the device
+# during the step-1 backward (current OOM point).
+# debug_memory_breakdown: true
+
+dataloader_num_workers: 4
+datasets:
+  - path: "OpenLLM-Ro/ro_gsm8k"
+    type: auto

--- a/examples/sft/laguna/laguna-s-lora-fp8.yaml
+++ b/examples/sft/laguna/laguna-s-lora-fp8.yaml
@@ -9,6 +9,10 @@ gradient_accumulation_steps: 1
 
 gpus: 8
 ep_size: 8
+# LLEP load balancing (threshold 1.3 to enable): balances the routing-hot rank's
+# VRAM (uniform ~22.5 GB vs 30.5/15.8 skew) but currently costs ~2.4x step time
+# until the LLEP perf pass lands. 999 = static EP (fastest, validated).
+ep_load_balance_threshold: 999
 
 sample_packing: true
 sequence_len: 256

--- a/examples/sft/laguna/laguna-s-lora-fp8.yaml
+++ b/examples/sft/laguna/laguna-s-lora-fp8.yaml
@@ -10,8 +10,9 @@ gradient_accumulation_steps: 1
 gpus: 8
 ep_size: 8
 # LLEP load balancing (threshold 1.3 to enable): balances the routing-hot rank's
-# VRAM (uniform ~22.5 GB vs 30.5/15.8 skew) but currently costs ~2.4x step time
-# until the LLEP perf pass lands. 999 = static EP (fastest, validated).
+# VRAM (uniform ~22.5 GB vs 30.5/15.8 skew) at ~1.6x step time after the perf
+# pass (ring arena + backward prefetch + replay LoRA reuse). Use it when static
+# EP's hot rank would OOM (longer sequences); 999 = static EP (fastest at 256).
 ep_load_balance_threshold: 999
 
 sample_packing: true

--- a/examples/sft/qwen35/qwen35-4b-text-lora-fp8-8gpu.yaml
+++ b/examples/sft/qwen35/qwen35-4b-text-lora-fp8-8gpu.yaml
@@ -1,0 +1,37 @@
+# Qwen3.5-4B LoRA SFT, fp8-hybrid, all 8 GPUs — sustained-load thermal test.
+# max_steps sized for a ~10-15 min soak (dataset cycles epochs); stop early once
+# temperatures plateau.
+model: Qwen/Qwen3.5-4B
+output_dir: ./output_q35_4b_heat
+
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 4
+
+sample_packing: true
+sequence_len: 2048
+gpus: 8
+
+max_steps: 500
+eval_steps: 0
+
+learning_rate: 2e-4
+warmup_ratio: 0.15
+
+recipe: fp8-hybrid
+
+lora: true
+lora_rank: 16
+lora_alpha: 32
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+dataloader_num_workers: 4
+datasets:
+  - path: "OpenLLM-Ro/ro_gsm8k"
+    type: auto

--- a/surogate/core/config/sft_config.py
+++ b/surogate/core/config/sft_config.py
@@ -345,6 +345,11 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
 
     offload_residual: bool | None = False
 
+    # Offload per-layer saved-for-backward tensors to pinned CPU at forward layer
+    # end; restored at backward layer start. Cuts step VRAM by the saved-tensor
+    # footprint (linear in tokens) at ~5-15% step-time cost. Requires recompute.
+    offload_saved_tensors: bool | None = False
+
     # CPU-RAM centric training: stream weights & gradients per-layer, run optimizer on CPU.
     # Replaces offload_master/offload_optimizer/offload_grads/use_zero_copy/use_write_combined.
     cpu_training: bool | None = False
@@ -487,6 +492,7 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
             self.recompute = bool(recompute_raw)
 
         self.offload_residual = cfg.get("offload_residual", self.offload_residual)
+        self.offload_saved_tensors = cfg.get("offload_saved_tensors", self.offload_saved_tensors)
         self.cpu_training = cfg.get("cpu_training", self.cpu_training)
         self.offload_master = cfg.get("offload_master", self.offload_master)
         self.offload_quants = cfg.get("offload_quants", self.offload_quants)
@@ -1059,6 +1065,7 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
         self.runtime_config = _surogate.RuntimeOptions(
             recompute="true" if self.recompute else "false",
             offload_residual=self.offload_residual,
+            
             cpu_training=self.cpu_training,
             offload_master=self.offload_master,
             offload_quants=self.offload_quants,
@@ -1091,6 +1098,7 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
         self.runtime_config.use_write_combined = self.use_write_combined
         self.runtime_config.selective_expert_dequant = self.qlora_selective_expert_dequant
         self.runtime_config.offload_experts = self.qlora_offload_experts
+        self.runtime_config.offload_saved_tensors = bool(self.offload_saved_tensors) and bool(self.recompute)
         # Expert Parallelism
         self.runtime_config.ep_size = self.ep_size
         self.runtime_config.ep_load_balance_threshold = self.ep_load_balance_threshold


### PR DESCRIPTION
## Summary
- **LLEP under cpu_training**: foreign expert weights fetched H2D from the shared global pinned host masters in forward AND backward (replacing the zero-weight dgrad approximation); expert-LoRA wgrad computed in merged space and exchanged to owner ranks (plan-driven, symmetric); replay restores the forward dispatch plan instead of re-running collectives (fixes an intermittent cross-rank issue-order deadlock).
- **Result**: Laguna-S (117B-A6B, 256 experts) trains on 8x RTX 5090 with uniform ~22.5 GB/rank instead of a 30.5/15.8 GB routing-hot skew. XS loss parity LLEP vs static: 6.50/2.07 vs 6.82/2.20; expert coverage 8906/10023 vs 8859/10023.
- **Perf pass** (was ~2.4x static step time, now ~1.6x — 8.5-10s → ~6.1s/step at seq 256): ring-slab arena for foreign receive buffers (kills a ~300k/step cudaMalloc driver-lock storm), backward dgrad reuse of replay-fetched foreign pointers (removes inline H2D re-staging on MainStream), replay reuse of forward's merged LoRA (removes per-replay-layer NCCL LoRA exchange), backward prefetch of the next replay layer's weights (overlaps H2D with compute), EP control stream for count exchanges.
- **Stability**: SpinBarrier + pinned staging + stream polling for the EP dispatch path; no-progress watchdog + fail-fast defunct-trainer handling; teardown SIGSEGV fixed (NCCL teardown helper captures comm handles by value).
- **Experimental**: saved-tensor offload to pinned host (`offload_saved_tensors`, default off — correct on XS, insufficient VRAM margins at Laguna scale).
- Example config `examples/sft/laguna/laguna-s-lora-fp8.yaml` defaults to static EP (fastest at seq 256); LLEP opt-in via `ep_load_balance_threshold: 1.3` for workloads where the hot rank would OOM.

## Test plan
- [x] XS LLEP vs static loss parity + expert coverage
- [x] Laguna-S 20-step run: loss 8.1→3.0, adapter export verified (72,770 tensors), clean exit
- [x] Laguna-S LLEP perf runs: loss trajectory identical across all perf builds (step-19 loss 3.02-3.04)
- [x] Laguna-S static path re-validated after control-stream change (4.1s/step, loss 2.98)
- [x] 12/12 stall-free runs after the replay plan cache fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)