### PR TITLE
fix(docker): align images with install.sh (torch 2.11, vllm 0.25.1) and refresh the ld cache

### DIFF
--- a/Dockerfile.cu128
+++ b/Dockerfile.cu128
@@ -26,6 +26,9 @@ ARG DSTACK_RUNNER_VERSION=0.20.18
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_LIB_ROOT="/root/.venv/lib/python3.12/site-packages/nvidia"
 ENV UV_NO_CACHE=1
+# torch 2.11 pulls the full CUDA wheel set (cudnn/cublas are 350-400MB each);
+# uv's 30s default request timeout loses that race on a slow link.
+ENV UV_HTTP_TIMEOUT=600
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --allow-change-held-packages ca-certificates curl libdw-dev python3-dev build-essential rsync wget netcat-openbsd gcc patch pciutils fuse3 openssh-server sudo openssh-server git \
@@ -48,11 +51,14 @@ RUN ~/.local/bin/uv venv /root/.venv --python=3.12
 ENV PATH="/root/.venv/bin:$PATH" \
     VIRTUAL_ENV="/root/.venv"
 
-# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers)
-RUN ~/.local/bin/uv pip install "torch==2.10.0+${CUDA_TAG}" "torchvision==0.25.0+${CUDA_TAG}" "torchaudio==2.10.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
- && ~/.local/bin/uv pip install "vllm==0.19.1" \
+# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers).
+# ldconfig runs last: the cache built above was made before these libs existed, so without
+# refreshing it the loader cannot find libcudart and the entrypoint fails to import _surogate.
+RUN ~/.local/bin/uv pip install "torch==2.11.0+${CUDA_TAG}" "torchvision==0.26.0+${CUDA_TAG}" "torchaudio==2.11.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+ && ~/.local/bin/uv pip install "vllm==0.25.1" \
  && ~/.local/bin/uv pip install ${WHEEL_URL} \
- && ~/.local/bin/uv pip install "nvidia-cuda-runtime-cu12==12.8.90" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.8.93" "nvidia-cudnn-cu12==9.19.0.56"
+ && ~/.local/bin/uv pip install "nvidia-cuda-runtime-cu12==12.8.90" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.8.93" "nvidia-cudnn-cu12==9.19.0.56" \
+ && ldconfig
 
 # Add dstack launcher
 RUN curl --connect-timeout 60 --max-time 240 --retry 1 --output /usr/local/bin/dstack-runner https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/${DSTACK_RUNNER_VERSION}/binaries/dstack-runner-linux-amd64 \

--- a/Dockerfile.cu129
+++ b/Dockerfile.cu129
@@ -26,6 +26,9 @@ ARG DSTACK_RUNNER_VERSION=0.20.18
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_LIB_ROOT="/root/.venv/lib/python3.12/site-packages/nvidia"
 ENV UV_NO_CACHE=1
+# torch 2.11 pulls the full CUDA wheel set (cudnn/cublas are 350-400MB each);
+# uv's 30s default request timeout loses that race on a slow link.
+ENV UV_HTTP_TIMEOUT=600
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --allow-change-held-packages ca-certificates curl libdw-dev python3-dev build-essential rsync wget netcat-openbsd gcc patch pciutils fuse3 openssh-server sudo openssh-server git \
@@ -48,11 +51,14 @@ RUN ~/.local/bin/uv venv /root/.venv --python=3.12
 ENV PATH="/root/.venv/bin:$PATH" \
     VIRTUAL_ENV="/root/.venv"
 
-# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers)
-RUN ~/.local/bin/uv pip install "torch==2.10.0+${CUDA_TAG}" "torchvision==0.25.0+${CUDA_TAG}" "torchaudio==2.10.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
- && ~/.local/bin/uv pip install "vllm==0.19.1" \
+# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers).
+# ldconfig runs last: the cache built above was made before these libs existed, so without
+# refreshing it the loader cannot find libcudart and the entrypoint fails to import _surogate.
+RUN ~/.local/bin/uv pip install "torch==2.11.0+${CUDA_TAG}" "torchvision==0.26.0+${CUDA_TAG}" "torchaudio==2.11.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+ && ~/.local/bin/uv pip install "vllm==0.25.1" \
  && ~/.local/bin/uv pip install ${WHEEL_URL} \
- && ~/.local/bin/uv pip install "nvidia-cuda-runtime-cu12==12.9.79" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.9.86" "nvidia-cudnn-cu12==9.19.0.56"
+ && ~/.local/bin/uv pip install "nvidia-cuda-runtime-cu12==12.9.79" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.9.86" "nvidia-cudnn-cu12==9.19.0.56" \
+ && ldconfig
 
 # Add dstack launcher
 RUN curl --connect-timeout 60 --max-time 240 --retry 1 --output /usr/local/bin/dstack-runner https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/${DSTACK_RUNNER_VERSION}/binaries/dstack-runner-linux-amd64 \

--- a/Dockerfile.cu130
+++ b/Dockerfile.cu130
@@ -26,6 +26,9 @@ ARG DSTACK_RUNNER_VERSION=0.20.18
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_LIB_ROOT="/root/.venv/lib/python3.12/site-packages/nvidia"
 ENV UV_NO_CACHE=1
+# torch 2.11 pulls the full CUDA wheel set (cudnn/cublas are 350-400MB each);
+# uv's 30s default request timeout loses that race on a slow link.
+ENV UV_HTTP_TIMEOUT=600
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --allow-change-held-packages ca-certificates curl libdw-dev python3-dev build-essential rsync wget netcat-openbsd gcc patch pciutils fuse3 openssh-server sudo openssh-server git \
@@ -48,11 +51,14 @@ RUN ~/.local/bin/uv venv /root/.venv --python=3.12
 ENV PATH="/root/.venv/bin:$PATH" \
     VIRTUAL_ENV="/root/.venv"
 
-# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers)
-RUN ~/.local/bin/uv pip install "torch==2.10.0+${CUDA_TAG}" "torchvision==0.25.0+${CUDA_TAG}" "torchaudio==2.10.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
- && ~/.local/bin/uv pip install "vllm==0.19.1" \
+# Install wheel from URL (single RUN so nvidia version overrides don't leave duplicates in lower layers).
+# ldconfig runs last: the cache built above was made before these libs existed, so without
+# refreshing it the loader cannot find libcudart and the entrypoint fails to import _surogate.
+RUN ~/.local/bin/uv pip install "torch==2.11.0+${CUDA_TAG}" "torchvision==0.26.0+${CUDA_TAG}" "torchaudio==2.11.0+${CUDA_TAG}" --index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+ && ~/.local/bin/uv pip install "vllm==0.25.1" \
  && ~/.local/bin/uv pip install ${WHEEL_URL} \
- && ~/.local/bin/uv pip install "nvidia-cuda-runtime==13.1.80" "nvidia-cudnn-cu13>=9.10.2.21" "nvidia-nccl-cu13==2.29.3" "nvidia-cufile==1.16.1.26" "nvidia-cuda-nvrtc==13.1.115"
+ && ~/.local/bin/uv pip install "nvidia-cuda-runtime==13.1.80" "nvidia-cudnn-cu13>=9.10.2.21" "nvidia-nccl-cu13==2.29.3" "nvidia-cufile==1.16.1.26" "nvidia-cuda-nvrtc==13.1.115" \
+ && ldconfig
 
 # Add dstack launcher
 RUN curl --connect-timeout 60 --max-time 240 --retry 1 --output /usr/local/bin/dstack-runner https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/${DSTACK_RUNNER_VERSION}/binaries/dstack-runner-linux-amd64 \


### PR DESCRIPTION
## Why

The Docker stage has failed on every release since v1.4.0, so no container images have been published for either v1.4.0 or v1.4.1:

```
Because there is no version of torch==2.11.0+cu130 and
surogate==1.4.1+cu130 depends on torch==2.11.0+cu130, we can conclude
that surogate==1.4.1+cu130 cannot be used.
```

The wheels declare `torch==2.11.0+cuXXX` — [set_cuda_version_tag.py](.github/scripts/set_cuda_version_tag.py) bakes that into `Requires-Dist` at build time — while the images installed torch `2.10.0`. That left `uv pip install ${WHEEL_URL}` needing to resolve torch 2.11.0 from an index, and that step runs without `--index-url`, so it searched PyPI, which carries no `+cuXXX` local versions.

`install.sh` is the source of truth and already installs torch 2.11.0 / torchvision 0.26.0 / torchaudio 2.11.0 and vllm 0.25.1; the images' `nvidia-*` pins already matched it. Bumping torch makes the wheel's requirement satisfied by what is already installed — the same reason install.sh gets away with no index on its wheel step.

## Changes

- torch `2.10.0` → `2.11.0`, torchvision `0.25.0` → `0.26.0`, torchaudio `2.10.0` → `2.11.0`
- vllm `0.19.1` → `0.25.1`
- **`ldconfig` at the end of the install layer.** It previously ran at line 38, before the venv and nvidia wheels existed, so the loader cache had no `libcudart` entry. Every image built from these files would have died at `from surogate import _surogate` with `libcudart.so.13: cannot open shared object file`. Pre-existing, and invisible until now only because the stage never got far enough to produce an image.
- **`UV_HTTP_TIMEOUT=600`.** torch 2.11 pulls a much larger CUDA wheel set than 2.10 (cudnn 349 MB, cublas 403 MB, plus a new `cuda-toolkit[nvtx]` path); uv's 30 s default request timeout aborted the build twice on large files.

## Verification

Built locally and run **with a GPU attached** — CI builds these on GPU-less `ubuntu-latest` and structurally cannot catch a loader fault:

| | cu130 | cu128 |
|---|---|---|
| image builds | ✅ | ✅ |
| `surogate --help` (`--gpus`) | ✅ | ✅ |

Resolved inside the cu130 image: torch `2.11.0+cu130`, torchvision `0.26.0+cu130`, torchaudio `2.11.0+cu130`, vllm `0.25.1`, surogate `1.4.1+cu130`, transformers `5.14.1`. NVML paths return the device correctly (`NVIDIA GeForce RTX 5090 sm120 31.4GB`) — relevant since v1.4.1 is the container NVML fix.

cu129 is structurally identical to cu128 (same lib layout, same cu12 pins) and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)