### PR TITLE
fix(grpo): stop forcing fp32 master weights

### DIFF
--- a/examples/turnopd/train_2b.yaml
+++ b/examples/turnopd/train_2b.yaml
@@ -18,11 +18,11 @@ optimizer: adamw
 
 recipe: bf16
 
-# master_dtype/gradient_dtype are deliberately left at the GRPO fp32 default.
-# bf16 master has been tried for GRPO before and fails: it does not preserve
-# enough gradient signal. A 4B student + fp32 master exceeds a single 32GB card
-# (29.3GB arena), so the student is sized to the constraint rather than the
-# precision being lowered. 2B is also the paper's own Multi-Hop Search student.
+# gradient_dtype is left at the GRPO fp32 default; master_dtype follows the model
+# dtype (bf16), which measured runs show is enough — the fp32 master this config
+# used to assume was what made a 4B student overflow a single 32GB card (29.3GB
+# arena). Precision on the trainable side comes from lora_dtype (fp32 by default).
+# 2B is also the paper's own Multi-Hop Search student.
 
 lora: true
 lora_rank: 16

--- a/examples/turnopd/train_2b_capped.yaml
+++ b/examples/turnopd/train_2b_capped.yaml
@@ -18,11 +18,11 @@ optimizer: adamw
 
 recipe: bf16
 
-# master_dtype/gradient_dtype are deliberately left at the GRPO fp32 default.
-# bf16 master has been tried for GRPO before and fails: it does not preserve
-# enough gradient signal. A 4B student + fp32 master exceeds a single 32GB card
-# (29.3GB arena), so the student is sized to the constraint rather than the
-# precision being lowered. 2B is also the paper's own Multi-Hop Search student.
+# gradient_dtype is left at the GRPO fp32 default; master_dtype follows the model
+# dtype (bf16), which measured runs show is enough — the fp32 master this config
+# used to assume was what made a 4B student overflow a single 32GB card (29.3GB
+# arena). Precision on the trainable side comes from lora_dtype (fp32 by default).
+# 2B is also the paper's own Multi-Hop Search student.
 
 lora: true
 lora_rank: 16

--- a/surogate/grpo/config.py
+++ b/surogate/grpo/config.py
@@ -77,10 +77,19 @@ class GRPOTrainConfig(SFTConfig):
     def __init__(self, cfg: DictDefault):
         # Each token's gradient is advantage * importance_ratio_clip * (softmax - 1{target}) / N_valid.
         # The advantage is often < 0.1, the clipped ratio is near 1.0 ± epsilon, and the loss mask removes prompt tokens.
-        # The effective gradient per parameter ends up 10-100x smaller than SFT.
-        # At that scale, BF16 rounding kills the signal.
-        if "master_dtype" not in cfg:
-            cfg["master_dtype"] = "fp32"
+        # The effective gradient per parameter ends up 10-100x smaller than SFT, so the *gradients* stay fp32.
+        #
+        # The master weights do not: measured GRPO runs show a BF16 master is enough.
+        # Masters are allocated for every param, frozen ones included, and a master
+        # dtype that differs from the param dtype also forces a separate work copy
+        # (dsl_weight_manager.cpp) — so fp32 cost 6 bytes/param (fp32 master + bf16
+        # work) against 2 when they alias, e.g. 12 GB vs 4 GB of arena on a 2B, most
+        # of it for a frozen base a LoRA run never trains. Precision where it matters
+        # comes from the adapter instead: lora_dtype defaults to "fp32", so the
+        # trainable LoRA weights and their optimizer state stay full precision.
+        #
+        # Leaving master_dtype unset falls back to the model dtype (BF16). A full
+        # fine-tune that wants the old behaviour can set master_dtype: fp32 in its yaml.
         if "gradient_dtype" not in cfg:
             cfg["gradient_dtype"] = "fp32"
 

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -178,7 +178,7 @@ class GRPOTrainer:
         self._turn_rows_path = Path(config.output_dir) / "turn_stats.jsonl"
 
         # dispatch-PP: stage the forward/backward across the GPU pool so a model
-        # whose fp32 master does not fit resident can still train. GRPO drives the
+        # whose weights do not fit resident can still train. GRPO drives the
         # two halves itself (staged forward -> Python per-token grads -> staged
         # backward seeded with them), because its gradients do not come from
         # cross-entropy.

--- a/tests/grpo/test_dispatch_pp_routing.py
+++ b/tests/grpo/test_dispatch_pp_routing.py
@@ -1,7 +1,6 @@
 """GRPO routes through dispatch-PP when parallelism=dispatch_pp.
 
-dispatch-PP exists so a model whose fp32 master does not fit resident can still
-train (bf16 master is not an option for GRPO — it starves the gradient signal).
+dispatch-PP exists so a model whose weights do not fit resident can still train.
 GRPO cannot use the fused dispatch step directly because its gradients do not
 come from cross-entropy, so it drives the two halves itself:
 


### PR DESCRIPTION
`GRPOTrainConfig.__init__` injected `master_dtype=fp32` into every GRPO run. The
stated reason was gradient scale — a GRPO per-token gradient is
`advantage * ratio_clip * (softmax - 1{target}) / N_valid`, 10-100x smaller than
SFT, so bf16 rounding was assumed to swamp the signal. Measured runs say
otherwise for the *master* copy: bf16 masters are enough. The gradients keep
`gradient_dtype=fp32`, which is where that range argument actually applies.

Dropping the override lets `master_dtype` fall back to the model dtype — the
framework's own documented default.

## The saving is larger than 4 → 2 bytes/param

`dsl_weight_manager` allocates a master for **every** param, frozen ones
included, and `master_dtype != param_dtype` additionally sets `separate_work`,
forcing a distinct bf16 work copy:

| master_dtype | master | work | total |
|---|---|---|---|
| fp32 | 4 | 2 | **6 bytes/param** |
| bf16 | — (work aliases master) | 2 | **2 bytes/param** |

Measured on a single RTX 5090, LoRA r16, seq 512, `recipe: bf16` — persistent
arena at trainer construction:

| model | fp32 master | bf16 master | |
|---|---|---|---|
| Qwen3.5-2B | 13778 MiB | 4660 MiB | **2.96x** |
| Qwen3.5-4B | 27865 MiB (**OOM**) | 9395 MiB | **2.97x** |

Most of what is freed was a frozen base that a LoRA run never trains.
**Qwen3.5-4B GRPO now fits on one 32GB card** — it previously died at trainer
construction with `cudaMalloc(29217146368) for persistent failed: out of memory`,
confirming the 29.3 GB arena the turnopd configs cited to justify a 2B student.

Precision on the trainable side is unaffected: `lora_dtype` already defaults to
`fp32`, so adapter weights and their optimizer state stay full precision. A full
fine-tune that wants the old behaviour sets `master_dtype: fp32` in its yaml.

## Swept along

Three comments asserted the opposite and are now corrected:

- `examples/turnopd/train_2b{,_capped}.yaml` claimed *"bf16 master has been tried
  for GRPO before and fails"* and sized the student to 2B because a 4B + fp32
  master needed a 29.3 GB arena — that constraint is what this removes.
- `test_dispatch_pp_routing.py` and `trainer.py` justified dispatch-PP by *"a
  model whose fp32 master does not fit resident"*; reworded to weights — still
  true, no longer tied to the dtype.

## Verification

- `master_dtype` resolves to `None` → C++ takes `config.DType` (bf16)
- explicit `master_dtype: fp32` still overrides cleanly (`'F32'`)
- 105 GRPO tests pass

Arena figures measured post-merge on a free GPU; the 6:2 bytes/param model
predicted them to within 1.5%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
