### PR TITLE
fix(grpo): honor checkpoint resume, surface stalled progress, plumb vLLM memory knobs

### DIFF
--- a/docs/examples/grpo/grpo.md
+++ b/docs/examples/grpo/grpo.md
@@ -23,7 +23,7 @@ Also, we will use the [Co-locate mode](../../guides/rl-training.md#co-locate-mod
 Run the following command:
 
 ```shell
-surogate grpo --train examples/grpo/train.yaml --infer examples/grpo/infer.yaml --orch examples/grpo/orch.yaml
+surogate grpo-colocate --train examples/grpo/train.yaml --infer examples/grpo/infer.yaml --orch examples/grpo/orch.yaml
 ```
 
 After training is complete, the LoRA adapter will be saved in the `./outputs/final_adapter` folder. 

--- a/docs/getting-started/quickstart-grpo.md
+++ b/docs/getting-started/quickstart-grpo.md
@@ -41,6 +41,25 @@ If you use `uv`, prefix any of the above with `uv run`.
 
 Outputs (checkpoints, LoRA adapters, logs) are written under the trainer's `output_dir`.
 
+### Resuming an interrupted run
+
+The trainer resumes from its latest checkpoint automatically —
+`resume_from_checkpoint` defaults to `true`, and `checkpoint_dir` is where it
+looks. Re-run the same command and it picks up where it stopped:
+
+```
+Resuming from checkpoint step 5 (next batch: 6)
+```
+
+A checkpoint at step `S` means "trained through batch `S`", so the resumed run
+starts at `S + 1`. That one number drives everything downstream — which batch
+is packed, which batch is read from the transport, the LR schedule position,
+the save cadence, and the step number the broadcast weights are published
+under — so the orchestrator, which may already be waiting on the broadcast for
+step `S`, is unblocked rather than desynchronized.
+
+Set `resume_from_checkpoint: false` in `train.yaml` to force a fresh run.
+
 ## 4) Example Configuration
 
 A minimal setup using the **reverse-text** environment. With co-locate (`grpo-colocate`) this runs on a single GPU; with split (`grpo`) it runs on two GPUs (one for vLLM, one for the trainer):
@@ -82,6 +101,10 @@ noise_scheduler:
 model: Qwen/Qwen3-0.6B
 enable_lora: true
 max_lora_rank: 32
+
+# Optional; omit to use vLLM's own defaults.
+# max_num_seqs: 16      # concurrency cap — see "Serving memory" below
+# kv_cache_dtype: fp8   # halves KV bytes/token
 ```
 
 **`orch.yaml`**:
@@ -150,6 +173,20 @@ All precision options from SFT are available:
 - **BF16** (`recipe: bf16`): Maximum accuracy
 - **QLoRA**: Add `qlora_fp8: true`, `qlora_bnb: true`, or `qlora_fp4: true` for quantized base weights
 
+### Serving Memory
+
+Two `infer.yaml` keys decide whether a large policy plus LoRA fits:
+
+- **`max_num_seqs`** caps concurrent sequences and so sizes the CUDA-graph and
+  activation buffers. A 27B model served TP2 with `enable_lora: true` OOMs at
+  the vLLM default and fits at `16`. Lowering `gpu_memory_utilization` does
+  **not** help — it shrinks the budget those buffers draw from.
+- **`kv_cache_dtype: fp8`** halves KV bytes per token, raising sustainable
+  concurrency on a KV-bound server. It also perturbs sampled logprobs, which
+  feed GRPO's importance ratio, so check `mismatch_kl` after enabling it.
+
+Both default to unset, in which case vLLM's own defaults apply.
+
 ## 6) Advanced: Three-Process Mode
 
 For multi-node setups (or any case where you want each component in its own process), run three commands separately:
@@ -170,6 +207,25 @@ For single-host runs, prefer `surogate grpo` (split GPUs) or `surogate grpo-colo
 ## Notes
 
 - GRPO requires `vllm` to be installed for the inference server.
+- **Reading progress from a log file.** The orchestrator's rollout progress bar
+  is rendered by `tqdm`, which needs a TTY — under `nohup` or any redirect it
+  writes nothing useful. Alongside it, the orchestrator emits plain `[progress]`
+  lines carrying the same information, so a redirected log stays readable:
+
+  ```
+  [progress] step 11 Generating rollouts (train): 128/256 (50%) | 42.7/min | elapsed 3m00s | eta 3m00s
+  ```
+
+  A step that stops completing rollouts is reported explicitly instead of
+  falling silent:
+
+  ```
+  [progress] step 11 Generating rollouts (train): 128/256 — NO completions in the last 60s (inflight 64, scoring 3, elapsed 14m22s)
+  ```
+
+  That line is the signal to check the inference server: a deep queue, an
+  unresponsive engine, or rollouts erroring out all look identical from a
+  frozen progress bar.
 - The `model` field must match across all three config files.
 - `max_steps` in `train.yaml` and `orch.yaml` should match.
 

--- a/docs/getting-started/training-modes.md
+++ b/docs/getting-started/training-modes.md
@@ -126,10 +126,18 @@ Surogate supports:
 - **Typical data:** Prompts + reward environments (math, code, custom verifiers)
 - **Typical run shape:** Iterative rollout → reward → gradient loop
 
-GRPO coordinates three components in a single command:
+GRPO coordinates three components — inference server, orchestrator, and trainer —
+in a single command. On two or more GPUs, assign each side its own:
 
 ```bash
-surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml
+surogate grpo --train train.yaml --infer infer.yaml --orch orch.yaml \
+    --vllm-gpus 0 --trainer-gpus 1
+```
+
+On a single GPU, co-locate them instead (they share base weights via CUDA IPC):
+
+```bash
+surogate grpo-colocate --train train.yaml --infer infer.yaml --orch orch.yaml
 ```
 
 ### When to use it

--- a/docs/guides/rl-training.md
+++ b/docs/guides/rl-training.md
@@ -267,6 +267,23 @@ Surogate uses a global step counter $n = 1, 2, 3, \ldots$ to tag all artifacts:
 
 The off-policy gap is at most $k$ steps. Rollouts whose gap exceeds `max_off_policy_steps` are discarded by the orchestrator.
 
+### Resuming a run
+
+The trainer resumes from the latest checkpoint in `checkpoint_dir` automatically
+(`resume_from_checkpoint` defaults to `true`). A checkpoint at step $S$ means
+"trained through batch $S$", so the resumed run starts at $S + 1$ and logs:
+
+```
+Resuming from checkpoint step 5 (next batch: 6)
+```
+
+The resume point is trainer-owned, deliberately: the orchestrator's own progress
+counter is *ahead* by up to $k$ steps, so seeding from it would skip the
+unconsumed batches in between and publish broadcasts under step numbers the
+orchestrator has already read. Instead, the resumed trainer re-emits the
+checkpoint's weights under step $S$, which unblocks an orchestrator already
+waiting on that broadcast.
+
 ### Loss Objective
 
 The loss is a token-level variant of the [AIPO objective](https://arxiv.org/abs/2505.24034) (introduced in Llama-RL), without the entropy and KL terms. For $N$ prompts, each with a group of $G$ rollouts:
@@ -300,6 +317,27 @@ The CLI applies `CUDA_VISIBLE_DEVICES=<trainer ids>` to the parent process **bef
 ### Weight broadcast
 
 In split mode, weight broadcasts use the filesystem backend regardless of what is configured in the YAML. Each broadcast writes the LoRA adapter (~10 MB) to `{output_dir}/broadcasts/step_N/`; vLLM polls for the `STABLE` marker file and hot-reloads the adapter.
+
+### Reading progress from a log file
+
+The orchestrator's rollout progress bar is `tqdm`, which needs a TTY. Under
+`nohup` or any redirect it writes nothing readable, so the orchestrator also
+emits plain `[progress]` INFO lines carrying rate and ETA:
+
+```
+[progress] step 11 Generating rollouts (train): 128/256 (50%) | 42.7/min | elapsed 3m00s | eta 3m00s
+```
+
+A step that stops completing rollouts says so rather than falling silent:
+
+```
+[progress] step 11 Generating rollouts (train): 128/256 — NO completions in the last 60s (inflight 64, scoring 3, elapsed 14m22s)
+```
+
+Treat that line as the cue to inspect the inference server. A deep queue, an
+unresponsive engine, and rollouts erroring out are indistinguishable from a
+frozen progress bar, and errored rollouts in particular are logged per-rollout —
+easy to scroll past in volume.
 
 ### Lifecycle
 
@@ -385,6 +423,27 @@ zero_level: 1  # Default: shard optimizer states
 ```
 
 Each micro-batch is replicated across all GPUs. The per-token gradient computation happens on the first GPU's logprobs, and the resulting gradients are replicated for the backward pass.
+
+### Fitting a large policy on the inference side
+
+Two `infer.yaml` keys decide whether a large model plus LoRA fits, and they are
+often reached for in the wrong order:
+
+- **`max_num_seqs`** caps concurrent sequences and therefore sizes the
+  CUDA-graph and activation buffers. On a 27B model served TP2 with
+  `enable_lora: true`, the vLLM default OOMs at startup and a small value
+  (e.g. `16`) fits. Lowering `gpu_memory_utilization` does **not** help here —
+  it shrinks the very budget those buffers are allocated from.
+- **`kv_cache_dtype: fp8`** halves KV bytes per token, which raises the
+  concurrency a KV-bound server can sustain. It also perturbs sampled
+  logprobs, and those feed GRPO's importance ratio — watch `mismatch_kl` for a
+  step or two after enabling it.
+
+```yaml
+# infer.yaml
+max_num_seqs: 16
+kv_cache_dtype: fp8
+```
 
 ## Tuning Tips
 
@@ -748,6 +807,8 @@ Key inference options:
 | `port`                    | `8000`         | Bind port                                              |
 | `dtype`                   | `"auto"`       | Data type (`float16`, `bfloat16`, `auto`)              |
 | `max_model_len`           | `null`         | Maximum context length                                 |
+| `max_num_seqs`            | `null`         | Max concurrent sequences (null = vLLM default)         |
+| `kv_cache_dtype`          | `null`         | KV cache dtype, e.g. `fp8` (null = vLLM default)       |
 | `enforce_eager`           | `false`        | Disable CUDA graphs (useful for debugging)             |
 | `trust_remote_code`       | `false`        | Allow custom HF model code                             |
 | `tp`                      | `1`            | Tensor parallelism degree                              |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,6 +36,69 @@ Options:
 
 - `--hub_token <token>`: optional, Hugging Face token for private model access
 
+### `grpo`
+
+GRPO RL training with vLLM and the trainer on **disjoint** GPU sets, communicating
+over the filesystem.
+
+```bash
+surogate grpo --train examples/grpo/train.yaml --infer examples/grpo/infer.yaml --orch examples/grpo/orch.yaml \
+    --vllm-gpus 0,1 --trainer-gpus 2,3
+```
+
+Options:
+
+- `--train <path>`: required, trainer config YAML
+- `--infer <path>`: required, vLLM inference config YAML
+- `--orch <path>`: required, orchestrator config YAML
+- `--vllm-gpus <ids>`: required, comma-separated GPU ids for vLLM. Count must equal `infer.dp * infer.tp`
+- `--trainer-gpus <ids>`: required, comma-separated GPU ids for the trainer. Count must equal `train.gpus`, which
+  therefore becomes optional in the YAML
+- `--judge-infer <path>`: optional, inference config for a RULER judge server. With `--judge-gpus` and
+  `ruler.enabled: true` in `orch.yaml`, a second vLLM subprocess is spawned for the judge
+- `--judge-gpus <ids>`: optional, GPU ids for the judge. Must be disjoint from `--vllm-gpus` and `--trainer-gpus`
+
+### `grpo-colocate`
+
+Same three configs, but vLLM and the trainer **share** GPUs and exchange base weights
+via zero-copy CUDA IPC. `gpu_memory_utilization` is computed automatically.
+
+```bash
+surogate grpo-colocate --train examples/grpo/train.yaml --infer examples/grpo/infer.yaml --orch examples/grpo/orch.yaml
+```
+
+Options: `--train`, `--infer`, `--orch` (all required). No GPU-assignment flags — the
+components share every visible GPU.
+
+### `grpo-infer`
+
+Runs only the inference server. Use it for multi-node setups, or any case where each
+component should own its process. This is the server that exposes the weight-update and
+LoRA hot-load admin routes the trainer broadcasts into — a stock `vllm serve` does not.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 surogate grpo-infer infer.yaml
+```
+
+### `grpo-orch`
+
+Runs only the orchestrator: samples rollouts against the environments, scores them, and
+writes batches to the transport.
+
+```bash
+surogate grpo-orch orch.yaml
+```
+
+### `grpo-train`
+
+Runs only the trainer: consumes batches, applies GRPO updates, and broadcasts weights.
+Resumes from the latest checkpoint in `checkpoint_dir` automatically — see
+[GRPO (RL) Settings](config.md#grpo-rl-settings).
+
+```bash
+CUDA_VISIBLE_DEVICES=1 surogate grpo-train train.yaml
+```
+
 ### `pt`
 
 Pretraining.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -424,6 +424,77 @@ training-loop settings from the SFT config. `gradient_dtype` and the LoRA dtype
 default to FP32; the frozen base does not require an FP32 master copy. CUDA graphs
 are disabled because the native DPO step is not graph-captured.
 
+## GRPO (RL) Settings
+
+Online reinforcement learning (the `surogate grpo`, `grpo-colocate`, and
+`grpo-train` commands). `GRPOTrainConfig` extends the SFT config, so every
+model, LoRA, QLoRA, recipe, optimizer, checkpoint, and runtime option above
+applies unchanged. Data comes from the orchestrator over the transport rather
+than from `datasets`, which is forced empty. See the
+[RL Training guide](../guides/rl-training.md) and
+[Quickstart: GRPO](../getting-started/quickstart-grpo.md).
+
+### Trainer config (`train.yaml`)
+
+| Option                  | Type   | Default        | Description                                                                                     |
+| ----------------------- | ------ | -------------- | ----------------------------------------------------------------------------------------------- |
+| `transport_type`        | string | `"filesystem"` | How training batches arrive from the orchestrator: `filesystem` or `zmq`.                        |
+| `weight_broadcast_type` | string | `"filesystem"` | How updated weights reach the inference server: `filesystem` (disk), `nccl` (GPU broadcast), or `colocate` (zero-copy shared memory). |
+| `max_async_level`       | int    | `1`            | How many steps the orchestrator may run ahead of the trainer. `1` is one step of off-policy staleness. |
+| `pad_to_multiple_of`    | int    | `1`            | Padding multiple for packed micro-batches.                                                       |
+| `doc_masking`           | bool   | `true`         | Document-level attention masking so packed samples cannot attend across each other.              |
+| `turn_diagnostics`      | bool   | `false`        | Route the micro-step through the Python loss instead of the fused native step so per-token logprobs are visible. Same gradients, slower — measurement only. |
+
+`gradient_dtype` defaults to `fp32` for GRPO (the per-token gradient is 10-100x
+smaller than in SFT), while master weights follow the model dtype; precision
+where it matters comes from `lora_dtype`, which stays `fp32`.
+
+### GRPO loss (`loss:` block in `train.yaml`)
+
+| Option          | Type  | Default | Description                                                                     |
+| --------------- | ----- | ------- | --------------------------------------------------------------------------------- |
+| `ipo_mask_low`  | float | `0.2`   | Low threshold for masking tokens by probability difference.                       |
+| `ipo_mask_high` | float | `0.2`   | High threshold for masking tokens by probability difference.                      |
+| `adv_tau`       | float | `1.0`   | Advantage scaling.                                                                |
+| `teacher_tau`   | float | `0.0`   | Weight on the teacher term for on-policy distillation. `0.0` disables it.         |
+| `kl_tau`        | float | `1e-3`  | KL penalty coefficient. Raise if the policy diverges from the reference too fast. |
+
+### QeRL noise scheduler (`noise_scheduler:` block)
+
+| Option        | Type  | Default | Description                                                     |
+| ------------- | ----- | ------- | ----------------------------------------------------------------- |
+| `enabled`     | bool  | `false` | Add Gaussian noise to inference-model RMSNorm weights before rollouts. |
+| `sigma_start` | float | `5e-2`  | Initial noise standard deviation.                                 |
+| `sigma_end`   | float | `5e-4`  | Final noise standard deviation.                                   |
+| `num_stages`  | int   | `10`    | Number of geometric decay intervals between the two.              |
+
+### Inference server config (`infer.yaml`)
+
+Keys most often set; see the [RL Training guide](../guides/rl-training.md) for the full table.
+
+| Option                   | Type   | Default        | Description                                                                             |
+| ------------------------ | ------ | -------------- | ----------------------------------------------------------------------------------------- |
+| `model`                  | string | (required)     | HuggingFace model ID or local path. Must match `train.yaml` and `orch.yaml`.              |
+| `tp` / `dp`              | int    | `1` / `1`      | Tensor and data parallelism degrees.                                                      |
+| `max_model_len`          | int    | `null`         | Maximum context length.                                                                   |
+| `max_num_seqs`           | int    | `null`         | Cap on concurrent sequences. Sizes the CUDA-graph and activation buffers, so it — not `gpu_memory_utilization` — is the knob that decides whether a large model plus LoRA fits. `null` uses vLLM's default. |
+| `kv_cache_dtype`         | string | `null`         | KV cache dtype. `fp8` halves KV bytes per token and raises sustainable concurrency, at the cost of perturbing sampled logprobs — watch `mismatch_kl`. `null` uses vLLM's default. |
+| `enable_lora`            | bool   | `true`         | Enable LoRA hot-reload, which is how the trainer's adapter reaches the server.             |
+| `max_lora_rank`          | int    | `null`         | Maximum LoRA rank, auto-rounded up to a vLLM-valid value.                                 |
+| `gpu_memory_utilization` | float  | `0.9`          | Fraction of GPU memory for the KV cache. Computed automatically in co-locate mode.         |
+| `weight_broadcast_type`  | string | `"filesystem"` | Must match the trainer's setting.                                                          |
+
+### Checkpoint resume
+
+`resume_from_checkpoint` (default `true`) and `checkpoint_dir` behave as they do
+for SFT: re-running `grpo-train` picks up the latest checkpoint instead of
+starting over. A checkpoint at step `S` means "trained through batch `S`", so the
+resumed run starts at `S + 1`. That single resume point drives which batch is
+packed, which batch is read from the transport, the LR schedule position, the
+save cadence, and the step number weights are broadcast under — so an
+orchestrator already waiting on the step-`S` broadcast is unblocked rather than
+desynchronized. Set `resume_from_checkpoint: false` to force a fresh run.
+
 ## Memory Optimization Settings
 
 | Option                     | Type | Default | Description                                                                                               |

--- a/surogate/core/config/grpo_inference_config.py
+++ b/surogate/core/config/grpo_inference_config.py
@@ -38,6 +38,8 @@ class GRPOInferenceConfig:
         model: Name or path of the HF model to use.
         dtype: Data type for model weights and activations. Passed to vLLM as `--dtype`.
         max_model_len: Maximum model context length. Passed to vLLM as `--max-model-len`.
+        max_num_seqs: Maximum number of concurrent sequences. Passed to vLLM as `--max-num-seqs`.
+        kv_cache_dtype: KV cache data type, e.g. `fp8`. Passed to vLLM as `--kv-cache-dtype`.
         enforce_eager: Whether to enforce eager mode. Passed to vLLM as `--enforce-eager`.
         trust_remote_code: Whether to trust remote code. Passed to vLLM engine init.
         enable_auto_tool_choice: Whether to enable auto tool choice. Passed to vLLM as `--enable-auto-tool-choice`.
@@ -68,6 +70,16 @@ class GRPOInferenceConfig:
     model: str | None = None
     dtype: Literal["auto", "float16", "bfloat16", "float32"] | None = "auto"
     max_model_len: int | None = None
+    # Concurrency cap. Sizes the CUDA-graph/activation buffers, so it is the
+    # knob that decides whether a big model + LoRA fits: enabling LoRA on a
+    # 27B TP2 server OOMs at the vLLM default and fits at a small value
+    # (measured 2026-07-31). Lowering gpu_memory_utilization does NOT help --
+    # it shrinks the very budget the allocation draws from.
+    max_num_seqs: int | None = None
+    # fp8 KV halves cache bytes/token, raising concurrency on a KV-bound
+    # server. It also perturbs sampled logprobs, which feed GRPO's importance
+    # ratio -- watch mismatch_kl before adopting.
+    kv_cache_dtype: str | None = None
     enforce_eager: bool | None = False
     trust_remote_code: bool | None = False
     enable_auto_tool_choice: bool | None = False
@@ -101,6 +113,8 @@ class GRPOInferenceConfig:
         self.model = cfg.get("model", self.model)
         self.dtype = cfg.get("dtype", self.dtype)
         self.max_model_len = cfg.get("max_model_len", self.max_model_len)
+        self.max_num_seqs = cfg.get("max_num_seqs", self.max_num_seqs)
+        self.kv_cache_dtype = cfg.get("kv_cache_dtype", self.kv_cache_dtype)
         self.enforce_eager = cfg.get("enforce_eager", self.enforce_eager)
         self.trust_remote_code = cfg.get("trust_remote_code", self.trust_remote_code)
         self.enable_auto_tool_choice = cfg.get("enable_auto_tool_choice", self.enable_auto_tool_choice)
@@ -145,6 +159,8 @@ class GRPOInferenceConfig:
             "model": "model",
             "dtype": "dtype",
             "max_model_len": "max_model_len",
+            "max_num_seqs": "max_num_seqs",
+            "kv_cache_dtype": "kv_cache_dtype",
             "enforce_eager": "enforce_eager",
             "trust_remote_code": "trust_remote_code",
             "enable_auto_tool_choice": "enable_auto_tool_choice",
@@ -171,6 +187,12 @@ class GRPOInferenceConfig:
 
         # Set `logprobs_mode` to `processed_logprobs` by default
         rsetattr(namespace, "logprobs_mode", "processed_logprobs")
+
+        # Leave vLLM's own default in place when unset (None is not a valid
+        # value for these scalars).
+        for _scalar in ("max_num_seqs", "kv_cache_dtype"):
+            if hasattr(namespace, _scalar) and getattr(namespace, _scalar) is None:
+                delattr(namespace, _scalar)
 
         # Remove reasoning_parser if not set (vLLM doesn't accept None)
         if namespace.reasoning_parser is None:

--- a/surogate/grpo/orchestrator/scheduler.py
+++ b/surogate/grpo/orchestrator/scheduler.py
@@ -433,7 +433,19 @@ class Scheduler:
             finished_tasks, _ = await asyncio.wait(
                 pending,
                 return_when=asyncio.FIRST_COMPLETED,
+                # Heartbeat timeout (2026-07-29): with no completions the
+                # progress tracker never ticks and the log goes silent for
+                # the exact stalls it should surface (observed: 14+ quiet
+                # minutes while the conductor queue was 60 deep). A timed
+                # wakeup emits a stall line instead.
+                timeout=60.0,
             )
+            if not finished_tasks:
+                pbar.stall_tick(
+                    inflight=self.inflight_rollout_count,
+                    scoring=len(self.scoring_tasks),
+                )
+                continue
             await self.checkpoint_ready.wait()
 
             for finished_task in finished_tasks:

--- a/surogate/grpo/packer.py
+++ b/surogate/grpo/packer.py
@@ -52,7 +52,7 @@ class BasePacker(ABC):
         self.seq_len = seq_len
         self.pad_to_multiple_of = pad_to_multiple_of
         self.tokenizer = tokenizer
-        self.receiver = setup_training_batch_receiver(config)
+        self.receiver = setup_training_batch_receiver(config, start_step=start_step)
         shutil.rmtree(get_rollout_dir(self.multi_run_manager.output_dir), ignore_errors=True)
         self.sender: MicroBatchSender = setup_micro_batch_sender(
             self.multi_run_manager.output_dir, dp_world_size, start_step, config

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -22,14 +22,13 @@ from surogate import _surogate
 from surogate.grpo.config import GRPOTrainConfig
 from surogate.grpo.data import GRPODataLoader
 from surogate.grpo.loss import compute_grpo_per_token_grads
-from surogate.grpo.runs import get_multi_run_manager
 from surogate.grpo.turn_stats import TurnAccumulator
 from surogate.grpo.weight_broadcast import SurogateWeightBroadcast
 from surogate.train.lr_schedule import LRSchedule
 from surogate.train.metrics_writer import MetricsWriter
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
-from surogate.utils.lora_compat import ensure_vllm_lora_compat
+from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
 from surogate.utils.tensor import to_surogate_dtype
 
 logger = get_logger()
@@ -128,6 +127,28 @@ class GRPOTrainer:
         else:
             logger.info(f"Importing weights from {model_weights_path}")
             self.trainer.import_weights(model_weights_path)
+
+        # Checkpoint resume. `resume_from_checkpoint` is inherited from
+        # SFTConfig and defaults to True, but GRPOTrainer never acted on it:
+        # every restart began at step 0 with a fresh adapter, re-trained the
+        # batches already on disk, and re-emitted weight broadcasts under step
+        # numbers the orchestrator had already consumed.
+        #
+        # `self.start_step` is the NEXT batch to train: a checkpoint at step S
+        # means "trained through batch S", so a resumed run starts at S + 1.
+        self.start_step = 0
+        resume_step = -1
+        if config.resume_from_checkpoint and config.checkpoint_dir:
+            resume_step = _surogate.find_latest_checkpoint(str(config.checkpoint_dir))
+        if resume_step >= 0:
+            if config.lora:
+                ensure_surogate_lora_compat(
+                    Path(config.checkpoint_dir) / f"step_{resume_step:08d}",
+                    config.model_dir,
+                )
+            logger.info(f"Resuming from checkpoint step {resume_step} (next batch: {resume_step + 1})")
+            self.trainer.load_checkpoint(str(config.checkpoint_dir), resume_step)
+            self.start_step = resume_step + 1
 
         # loss_scale is computed dynamically per pack — see train() loop
 
@@ -576,11 +597,11 @@ class GRPOTrainer:
         config = self.config
         max_steps = config.max_steps
 
-        self._setup_data(start_step=0)
-
-        # Get MultiRunManager — packer auto-increments progress[0].step after
-        # each pack() call.
-        mrm = get_multi_run_manager()
+        # start_step comes from checkpoint resume (the next batch to train).
+        # It drives the packer (which batch to pack next), the data loader
+        # (which batch to read), and the internal step counter (save cadence
+        # and LR). All three must agree or a restart re-trains from batch 0.
+        self._setup_data(start_step=self.start_step)
 
         logger.info("Starting GRPO training loop")
         logger.info(f"  Model: {config.model}")
@@ -606,9 +627,21 @@ class GRPOTrainer:
         else:
             logger.info("  Running indefinitely (waiting for orchestrator)")
 
-        step = 0  # Internal trainer step (one per grad_accum chunk, for LR schedule + logging)
+        # Internal trainer step (one per grad_accum chunk, for LR schedule and
+        # logging). Starts at the resume point so save cadence and metrics
+        # continue the same sequence instead of restarting at 0.
+        step = self.start_step
+        # Trainer-owned batch counter. mrm.progress[0].step is initialized from
+        # the ORCHESTRATOR's checkpoints on run discovery, and the orchestrator
+        # runs ahead of a resumed trainer by up to max_async_level — reading it
+        # here misnames weight broadcasts after a restart (e.g. checkpoint-5
+        # weights emitted as step_9). `start_step + packs_done` is identical to
+        # the old value on a fresh run (0 + N) and correct on resume: the first
+        # iteration re-emits the checkpoint weights under the resume step,
+        # unblocking an orchestrator already waiting on that broadcast.
+        packs_done = 0
         while True:
-            orch_step = mrm.progress[0].step if 0 in mrm.progress else 0
+            orch_step = self.start_step + packs_done
 
             # 1. Broadcast weights (after first orchestrator step)
             if orch_step > 0:
@@ -622,6 +655,7 @@ class GRPOTrainer:
 
             # 2. Pack and wait for batch — packer increments progress[0].step
             self.packer.pack()
+            packs_done += 1
             self.data_loader.wait_for_batch()
 
             # 3. Get micro-batches
@@ -837,8 +871,9 @@ class GRPOTrainer:
 
             step += 1
 
-        # Final weight broadcast
-        self.broadcast.broadcast(self.trainer, mrm.progress[0].step)
+        # Final weight broadcast — same trainer-owned counter as the loop, so a
+        # resumed run does not publish under an orchestrator step number.
+        self.broadcast.broadcast(self.trainer, self.start_step + packs_done)
 
         # Save final adapter/model
         output_path = Path(config.output_dir)

--- a/surogate/grpo/transport/__init__.py
+++ b/surogate/grpo/transport/__init__.py
@@ -31,9 +31,11 @@ def setup_training_batch_sender(output_dir: Path, transport: TransportConfigType
         raise ValueError(f"Invalid transport type: {transport.type}")
 
 
-def setup_training_batch_receiver(transport: TransportConfigType) -> TrainingBatchReceiver:
+def setup_training_batch_receiver(
+    transport: TransportConfigType, start_step: int | None = None
+) -> TrainingBatchReceiver:
     if transport.type == "filesystem":
-        return FileSystemTrainingBatchReceiver()
+        return FileSystemTrainingBatchReceiver(start_step=start_step)
     elif transport.type == "zmq":
         return ZMQTrainingBatchReceiver(transport)
     else:

--- a/surogate/grpo/transport/filesystem.py
+++ b/surogate/grpo/transport/filesystem.py
@@ -38,7 +38,7 @@ class FileSystemTrainingBatchSender(TrainingBatchSender):
 class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
     """Filesystem-based training batch receiver that reads batches from multiple run directories."""
 
-    def __init__(self) -> None:
+    def __init__(self, start_step: int | None = None) -> None:
         super().__init__()
         self.multi_run_manager = get_multi_run_manager()
         self._last_logged_paths: list[Path] | None = None
@@ -47,12 +47,22 @@ class FileSystemTrainingBatchReceiver(TrainingBatchReceiver):
         # Track received steps per run independently of multi_run_manager.progress[idx].step
         # This prevents duplicate reads when trainer step != orchestrator step
         self._received_steps: dict[int, int] = {}
+        # Trainer resume point (2026-07-29): when set, the TRAINER governs
+        # which raw batch is consumed next. progress[idx].step comes from
+        # the ORCHESTRATOR's checkpoints (its next batch to COLLECT), which
+        # runs ahead of the trainer by max_async_level — initializing from
+        # it after a trainer restart SKIPS the unconsumed batches between
+        # the trainer checkpoint and the orch checkpoint.
+        self._start_step = start_step
 
     def _get_received_step(self, idx: int) -> int:
         """Get the next step to receive for a run, initializing from progress if needed."""
         if idx not in self._received_steps:
-            # Initialize from multi_run_manager.progress on first access (for checkpoint resume)
-            self._received_steps[idx] = self.multi_run_manager.progress[idx].step
+            if self._start_step is not None:
+                self._received_steps[idx] = self._start_step
+            else:
+                # Initialize from multi_run_manager.progress on first access (for checkpoint resume)
+                self._received_steps[idx] = self.multi_run_manager.progress[idx].step
         return self._received_steps[idx]
 
     def _get_batch_path(self, idx: int) -> Path:

--- a/surogate/grpo/utils/logger.py
+++ b/surogate/grpo/utils/logger.py
@@ -217,6 +217,17 @@ class ProgressTracker:
         self.current = 0
         self._last_logged_percent = -log_every_percent
         self._postfix: dict[str, Any] = {}
+        # Plain-log progress cadence (2026-07-29): tqdm renders \r to a TTY,
+        # so under nohup/file logging batch progress was INVISIBLE — the log
+        # showed per-env stats but never how far the current step was. Emit
+        # an INFO line with rate + ETA every log_every_percent OR every
+        # `heartbeat_s`, whichever comes first.
+        import time as _time
+
+        self._time = _time
+        self._start_time = _time.time()
+        self._last_line_time = 0.0
+        self._heartbeat_s = 60.0
 
         if self.json_logging:
             self._pbar = None
@@ -230,8 +241,58 @@ class ProgressTracker:
         self.current += n
         if self._pbar is not None:
             self._pbar.update(n)
+            self._maybe_log_line()
         else:
             self._log_progress()
+
+    def _maybe_log_line(self):
+        """Plain INFO progress line for file/nohup logs (non-JSON mode)."""
+        percent = int(100 * self.current / self.total) if self.total > 0 else 0
+        now = self._time.time()
+        due_percent = percent >= self._last_logged_percent + self.log_every_percent
+        due_time = now - self._last_line_time >= self._heartbeat_s
+        if not (due_percent or due_time or self.current >= self.total):
+            return
+        elapsed = max(now - self._start_time, 1e-6)
+        rate = self.current / elapsed  # units/s
+        remaining = max(self.total - self.current, 0)
+        eta_s = remaining / rate if rate > 0 else float("inf")
+
+        def _fmt(seconds: float) -> str:
+            if seconds == float("inf"):
+                return "?"
+            seconds = int(seconds)
+            return (f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+                    if seconds >= 3600 else f"{seconds // 60}m{seconds % 60:02d}s")
+
+        step_txt = f" step {self.step}" if self.step is not None else ""
+        get_logger().info(
+            f"[progress]{step_txt} {self.desc}: {self.current}/{self.total} "
+            f"({percent}%) | {rate * 60:.1f}/min | elapsed {_fmt(elapsed)} | "
+            f"eta {_fmt(eta_s)}")
+        self._last_logged_percent = percent
+        self._last_line_time = now
+
+    def stall_tick(self, inflight: int = 0, scoring: int = 0):
+        """Heartbeat when NO work completed in the wait window (2026-07-29).
+
+        update() only logs on completions, so a stalled tail was silent
+        exactly when visibility mattered most. Rate-limited to one line per
+        heartbeat window.
+        """
+        now = self._time.time() if hasattr(self, "_time") else None
+        if now is None:
+            return
+        if now - self._last_line_time < self._heartbeat_s:
+            return
+        elapsed = max(now - self._start_time, 1e-6)
+        step_txt = f" step {self.step}" if self.step is not None else ""
+        get_logger().info(
+            f"[progress]{step_txt} {self.desc}: {self.current}/{self.total} "
+            f"— NO completions in the last {int(self._heartbeat_s)}s "
+            f"(inflight {inflight}, scoring {scoring}, "
+            f"elapsed {int(elapsed) // 60}m{int(elapsed) % 60:02d}s)")
+        self._last_line_time = now
 
     def set_postfix(self, postfix: dict[str, Any]):
         self._postfix = postfix

--- a/tests/grpo/test_inference_config.py
+++ b/tests/grpo/test_inference_config.py
@@ -1,0 +1,22 @@
+"""GRPOInferenceConfig -> vLLM namespace mapping for the newly plumbed scalars."""
+
+from surogate.core.config.grpo_inference_config import GRPOInferenceConfig
+from surogate.utils.dict import DictDefault
+
+
+def test_max_num_seqs_and_kv_cache_dtype_reach_vllm():
+    cfg = GRPOInferenceConfig(DictDefault({"model": "m", "max_num_seqs": 16, "kv_cache_dtype": "fp8"}))
+    assert cfg.max_num_seqs == 16
+    assert cfg.kv_cache_dtype == "fp8"
+
+    ns = cfg.to_vllm()
+    assert ns.max_num_seqs == 16
+    assert ns.kv_cache_dtype == "fp8"
+
+
+def test_unset_scalars_are_dropped_so_vllm_defaults_apply():
+    """None is not a valid value for either flag — the attribute must be absent."""
+    cfg = GRPOInferenceConfig(DictDefault({"model": "m"}))
+    ns = cfg.to_vllm()
+    assert not hasattr(ns, "max_num_seqs")
+    assert not hasattr(ns, "kv_cache_dtype")

--- a/tests/grpo/test_progress_tracker_lines.py
+++ b/tests/grpo/test_progress_tracker_lines.py
@@ -1,0 +1,59 @@
+"""Plain-log progress lines from ProgressTracker (nohup visibility, 2026-07-29)."""
+
+from surogate.grpo.utils import logger as logger_mod
+from surogate.grpo.utils.logger import ProgressTracker
+
+
+class _Capture:
+    def __init__(self):
+        self.lines = []
+
+    def info(self, msg):
+        self.lines.append(msg)
+
+    def bind(self, **kw):
+        return self
+
+
+def test_plain_mode_emits_rate_and_eta(monkeypatch):
+    cap = _Capture()
+    monkeypatch.setattr(logger_mod, "get_logger", lambda: cap)
+    t = ProgressTracker(total=100, desc="Generating rollouts (train)",
+                        json_logging=False, step=10)
+    t._pbar = None  # force the plain path without a TTY bar
+    t.update = ProgressTracker.update.__get__(t)  # rebind after pbar strip
+
+    # emulate the tqdm branch calling _maybe_log_line
+    for _ in range(25):
+        t.current += 1
+        t._maybe_log_line()
+    assert any("[progress] step 10" in ln and "eta" in ln for ln in cap.lines)
+    first = cap.lines[0]
+    assert "25/100" in cap.lines[-1] or "(2" in cap.lines[-1]
+    assert "/min" in first
+
+
+def test_percent_cadence_not_every_update(monkeypatch):
+    cap = _Capture()
+    monkeypatch.setattr(logger_mod, "get_logger", lambda: cap)
+    t = ProgressTracker(total=1000, desc="d", json_logging=False)
+    t._pbar = None
+    for _ in range(99):   # 9.9% — below the 10% cadence
+        t.current += 1
+        t._maybe_log_line()
+    assert len(cap.lines) <= 1  # at most the first crossing at 0%+
+
+
+def test_stall_tick_emits_and_rate_limits(monkeypatch):
+    cap = _Capture()
+    monkeypatch.setattr(logger_mod, "get_logger", lambda: cap)
+    t = ProgressTracker(total=256, desc="Generating rollouts (train)",
+                        json_logging=False, step=11)
+    t._pbar = None
+    t.current = 128
+    t._last_line_time = 0.0
+    t.stall_tick(inflight=64, scoring=3)
+    assert len(cap.lines) == 1
+    assert "NO completions" in cap.lines[0] and "128/256" in cap.lines[0]
+    t.stall_tick(inflight=64, scoring=3)   # within the same window
+    assert len(cap.lines) == 1             # rate-limited

--- a/tests/grpo/test_receiver_start_step.py
+++ b/tests/grpo/test_receiver_start_step.py
@@ -1,0 +1,44 @@
+"""The batch receiver must resume from the TRAINER's step, not the orchestrator's.
+
+`multi_run_manager.progress[idx].step` is loaded from the ORCHESTRATOR's
+checkpoints and means "the next batch to collect". The orchestrator runs ahead
+of the trainer by up to `max_async_level`, so a restarted trainer that seeded
+its receiver from that value skipped every batch in between — permanently
+dropped, never trained on.
+"""
+
+from unittest.mock import patch
+
+from surogate.grpo.transport import setup_training_batch_receiver
+from surogate.grpo.transport.filesystem import FileSystemTrainingBatchReceiver
+
+
+class _Progress:
+    def __init__(self, step):
+        self.step = step
+
+
+class _MRM:
+    def __init__(self, step):
+        self.progress = {0: _Progress(step)}
+
+
+def test_start_step_overrides_orchestrator_progress():
+    with patch("surogate.grpo.transport.filesystem.get_multi_run_manager", return_value=_MRM(9)):
+        r = FileSystemTrainingBatchReceiver(start_step=6)
+    assert r._get_received_step(0) == 6, "trainer resume point must win over orch progress"
+
+
+def test_without_start_step_falls_back_to_progress():
+    with patch("surogate.grpo.transport.filesystem.get_multi_run_manager", return_value=_MRM(9)):
+        r = FileSystemTrainingBatchReceiver()
+    assert r._get_received_step(0) == 9
+
+
+def test_factory_forwards_start_step():
+    class _Cfg:
+        type = "filesystem"
+
+    with patch("surogate.grpo.transport.filesystem.get_multi_run_manager", return_value=_MRM(9)):
+        r = setup_training_batch_receiver(_Cfg(), start_step=4)
+    assert r._get_received_step(0) == 4


### PR DESCRIPTION
Three defects found running a long unattended GRPO campaign, plus the docs that would have prevented two of them.

## Checkpoint resume was silently ignored

`GRPOTrainConfig` inherits `resume_from_checkpoint` (default `true`) from `SFTConfig`, but `GRPOTrainer` never read it: every restart began at step 0 with a fresh adapter and re-trained every batch still on disk.

The resume point is now trainer-owned and drives the packer, the transport receiver, the LR schedule, the save cadence, and the step number weights are broadcast under.

It has to be trainer-owned. `multi_run_manager.progress[].step` comes from the **orchestrator's** checkpoints and means "next batch to collect", which runs ahead by up to `max_async_level` — seeding from it skipped the unconsumed batches in between (permanently dropped, never trained on) and published broadcasts under step numbers the orchestrator had already read. On a fresh run `start_step + packs_done` is identical to the old value (`0 + N`).

## Progress went silent exactly when it mattered

The rollout progress bar is `tqdm`, which needs a TTY — under `nohup` it wrote nothing readable. And `update()` only fires on completions, so a *stalled* step logged nothing at all (observed: 14+ quiet minutes with the inference queue 60 deep).

- `ProgressTracker` now emits plain `[progress]` INFO lines with rate and ETA.
- The scheduler's `FIRST_COMPLETED` wait takes a 60s timeout, so a window with zero completions reports inflight/scoring counts instead of nothing.

```
[progress] step 11 Generating rollouts (train): 128/256 (50%) | 42.7/min | elapsed 3m00s | eta 3m00s
[progress] step 11 Generating rollouts (train): 128/256 — NO completions in the last 60s (inflight 64, scoring 3, elapsed 14m22s)
```

## `max_num_seqs` and `kv_cache_dtype` were not plumbed to vLLM

`max_num_seqs` sizes the CUDA-graph and activation buffers, so it — not `gpu_memory_utilization`, which shrinks the budget those buffers draw from — is what decides whether a large model plus LoRA fits. A 27B model served TP2 with `enable_lora: true` OOMs at the vLLM default and fits at `16`. Both keys are dropped from the namespace when unset so vLLM's own defaults apply.

## Docs

- GRPO commands were **entirely absent** from the CLI reference; `grpo`, `grpo-colocate`, `grpo-infer`, `grpo-orch`, `grpo-train` are now documented with their flags.
- GRPO had **no section** in the config reference; trainer, loss, noise-scheduler, inference, and resume settings are now covered.
- Two documented commands could not run as written: `surogate grpo` without the now-required `--vllm-gpus`/`--trainer-gpus`, and the co-locate example invoking split mode.
- Resume semantics, the `[progress]` lines, and the two serving-memory knobs are documented in the quickstart and the RL guide.

## Tests

- `tests/grpo/test_receiver_start_step.py` — trainer resume point wins over orchestrator progress
- `tests/grpo/test_inference_config.py` — both scalars reach vLLM; absent when unset
- `tests/grpo/test_progress_tracker_lines.py` — rate/ETA cadence, stall rate-limiting

All 113 tests in `tests/grpo` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)