### PR TITLE
feat(grpo): chunked GRPO engine, ratio_clip, adapter init, buffer recycling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,15 @@ BUILD_TYPE ?= Release
 PARALLEL_JOBS ?= $(shell nproc)
 
 CCACHE := $(shell which ccache 2>/dev/null)
+CUDA_HOME ?= $(or $(CUDA_PATH),$(shell dirname $$(dirname $$(which nvcc 2>/dev/null)) 2>/dev/null),/usr/local/cuda)
+# Resolve version-switching symlinks such as /usr/local/cuda before handing the
+# compiler and toolkit root to CMake.  Otherwise an existing CMake cache can
+# retain one toolkit's libraries while the symlink starts compiling objects
+# with another toolkit's cudaDeviceProp ABI.
+CUDA_HOME := $(realpath $(CUDA_HOME))
+CUDA_CMAKE_FLAGS := -DCMAKE_CUDA_COMPILER=$(CUDA_HOME)/bin/nvcc -DCUDAToolkit_ROOT=$(CUDA_HOME)
 ifdef CCACHE
 CCACHE_FLAGS := -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
-CUDA_HOME ?= $(or $(CUDA_PATH),$(shell dirname $$(dirname $$(which nvcc 2>/dev/null)) 2>/dev/null),/usr/local/cuda)
 export CCACHE_CUDA_PATHS := $(CUDA_HOME)
 endif
 
@@ -19,7 +25,7 @@ all: build
 
 # Configure the build
 configure:
-	cmake -S csrc -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) $(CCACHE_FLAGS)
+	cmake -S csrc -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) $(CUDA_CMAKE_FLAGS) $(CCACHE_FLAGS)
 
 # Build all targets
 build: configure
@@ -35,7 +41,7 @@ define build_wheel
 	cp pyproject.toml pyproject.toml.bak && \
 	trap 'mv -f pyproject.toml.bak pyproject.toml' EXIT INT TERM; \
 	uv run --no-project --with tomlkit python3 .github/scripts/set_cuda_version_tag.py $(1) && \
-	CMAKE_ARGS="$(CCACHE_FLAGS)" CMAKE_BUILD_PARALLEL_LEVEL=$(PARALLEL_JOBS) uv build --wheel --out-dir dist && \
+	CMAKE_ARGS="$(CUDA_CMAKE_FLAGS) $(CCACHE_FLAGS)" CMAKE_BUILD_PARALLEL_LEVEL=$(PARALLEL_JOBS) uv build --wheel --out-dir dist && \
 	uv run --no-project --with auditwheel --with patchelf auditwheel repair dist/*.whl \
 		-w dist/repaired/ \
 		--exclude libcuda.so.1 \
@@ -123,7 +129,7 @@ format-check:
 
 # Build test executables without running them
 build-tests:
-	cmake -S csrc -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_TESTS=ON $(CCACHE_FLAGS)
+	cmake -S csrc -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_TESTS=ON $(CUDA_CMAKE_FLAGS) $(CCACHE_FLAGS)
 	cmake --build $(BUILD_DIR) --parallel $(PARALLEL_JOBS) --target unit-tests integration-tests
 
 # Build and run unit tests (kernels, modules, components)

--- a/csrc/src/binding/binding.cpp
+++ b/csrc/src/binding/binding.cpp
@@ -2033,7 +2033,8 @@ NB_MODULE(_surogate, m) {
                float ipo_mask_high,
                float adv_tau,
                float teacher_tau,
-               float kl_tau) {
+               float kl_tau,
+               float ratio_clip) {
                 if (sample_starts.shape(0) != sample_ends.shape(0)) {
                     throw std::invalid_argument("sample_starts and sample_ends must have the same length");
                 }
@@ -2069,7 +2070,8 @@ NB_MODULE(_surogate, m) {
                                           ipo_mask_high,
                                           adv_tau,
                                           teacher_tau,
-                                          kl_tau);
+                                          kl_tau,
+                                          ratio_clip);
             },
             nb::arg("input_ids"),
             nb::arg("targets"),
@@ -2087,6 +2089,7 @@ NB_MODULE(_surogate, m) {
             nb::arg("adv_tau") = 1.0f,
             nb::arg("teacher_tau") = 0.0f,
             nb::arg("kl_tau") = 1.0e-3f,
+            nb::arg("ratio_clip") = 7.389056f,
             "Run one GRPO training micro-step with native CUDA per-token gradient generation.")
         .def(
             "backward_grpo",

--- a/csrc/src/binding/py_train.cpp
+++ b/csrc/src/binding/py_train.cpp
@@ -638,6 +638,12 @@ void copy_chunk_inputs_for_ctx(IModel& model,
     }
 }
 
+/// Defined further down beside the GRPO chunked step; declared here — inside
+/// the SAME anonymous namespace as that definition, so this is a declaration
+/// of it rather than a second overload — because the SFT chunked path needs
+/// the same packed-doc window metadata.
+IModel::ChunkPackMeta chunk_pack_meta_from_positions(const std::int32_t* pr, int T, long base_pos);
+
 }  // namespace
 
 void MultiGPUPyTrainer::step_chunked(const std::int32_t* inputs,
@@ -667,13 +673,19 @@ void MultiGPUPyTrainer::step_chunked(const std::int32_t* inputs,
     // Phase A — KV sweep: forward chunks left-to-right filling the per-layer
     // attention KV caches. Saved-tensor persistence is skipped; the loss op
     // lives in backward, so this pass pays layers only.
+    // Every chunk is swept: unlike the GRPO path there are no per-sample end
+    // offsets here to prove a tail chunk is all padding, and Phase B below
+    // walks the full range — the two passes must cover the same chunks.
     for (int c = 0; c < seq_chunks; ++c) {
         copy_chunk(c);
         const int micro_eff = mTrainMicroStep * seq_chunks + c;
-        run_work([c, seq_chunks, micro_eff](sThreadContext& ctx) {
-            ctx.Model->set_sequence_chunk(c, seq_chunks);
+        const long base_pos_a = static_cast<long>(c) * T;
+        run_work([c, seq_chunks, micro_eff, base_pos_a, this](sThreadContext& ctx) {
             Tensor in = ctx.Model->get_input_buffer();
             Tensor pos = ctx.Model->get_position_ids_buffer();
+            const auto meta = chunk_pack_meta_from_positions(pos.get<std::int32_t>(),
+                                                            static_cast<int>(this->T), base_pos_a);
+            ctx.Model->set_sequence_chunk(c, seq_chunks, &meta);
             ctx.Model->forward_no_save(in, pos, *ctx.Communicator, micro_eff);
         });
     }
@@ -3387,7 +3399,16 @@ void MultiGPUPyTrainer::step_grpo_native(const std::int32_t* inputs,
                                          float ipo_mask_high,
                                          float adv_tau,
                                          float teacher_tau,
-                                         float kl_tau) {
+                                         float kl_tau,
+                                         float ratio_clip) {
+    if (mOptions.SequenceChunks > 1) {
+        step_grpo_native_chunked(inputs, targets, inference_logprobs, advantages, loss_mask,
+                                 sample_starts, sample_ends, sample_count, position_ids,
+                                 temperatures, teacher_logprobs, loss_scale, ipo_mask_low,
+                                 ipo_mask_high, adv_tau, teacher_tau, kl_tau, ratio_clip,
+                                 mOptions.SequenceChunks);
+        return;
+    }
     const int ep_size = std::max(1, mOptions.EPSize);
     for (int i = 0; i < (int)mContexts.size(); ++i) {
         auto& ctx = mContexts.at(i);
@@ -3426,6 +3447,7 @@ void MultiGPUPyTrainer::step_grpo_native(const std::int32_t* inputs,
         .adv_tau = adv_tau,
         .teacher_tau = teacher_tau,
         .kl_tau = kl_tau,
+        .ratio_clip = ratio_clip,
     };
 
     run_work([micro_idx = mTrainMicroStep,
@@ -3475,6 +3497,197 @@ void MultiGPUPyTrainer::step_grpo_native(const std::int32_t* inputs,
                                     teacher_logprobs);
     });
 
+    ++mTrainMicroStep;
+}
+
+
+namespace {
+/// Chunk-local document geometry from sliced positions (identical logic to
+/// validate_chunked): position resets mark packed-sample starts; win_start
+/// clamps a row-initial document continued from a previous row.
+IModel::ChunkPackMeta chunk_pack_meta_from_positions(const std::int32_t* pr, int T, long base_pos) {
+    IModel::ChunkPackMeta m;
+    const int t0 = static_cast<int>(base_pos);
+    m.win_start = std::max(0, t0 - pr[0]);
+    m.cu_q = {0};
+    m.cu_k = {0};
+    int seg_start = 0;
+    int doc_start_rel = m.win_start - t0;
+    auto close_seg = [&](int seg_end) {
+        const int q_len = seg_end - seg_start;
+        const int k_len = seg_end - doc_start_rel;
+        m.cu_q.push_back(m.cu_q.back() + q_len);
+        m.cu_k.push_back(m.cu_k.back() + k_len);
+        m.max_q = std::max(m.max_q, q_len);
+        m.max_k = std::max(m.max_k, k_len);
+    };
+    for (int t = 1; t < T; ++t) {
+        if (pr[t] != pr[t - 1] + 1) {
+            close_seg(t);
+            seg_start = t;
+            doc_start_rel = t;
+        }
+    }
+    close_seg(T);
+    m.num_segs = static_cast<int>(m.cu_q.size()) - 1;
+    m.kv_len = t0 + static_cast<int>(T) - m.win_start;
+    return m;
+}
+}  // namespace
+
+void MultiGPUPyTrainer::step_grpo_native_chunked(const std::int32_t* inputs,
+                                                 const std::int32_t* targets,
+                                                 const float* inference_logprobs,
+                                                 const float* advantages,
+                                                 const std::uint8_t* loss_mask,
+                                                 const std::int32_t* sample_starts,
+                                                 const std::int32_t* sample_ends,
+                                                 int sample_count,
+                                                 const std::int32_t* position_ids,
+                                                 const float* temperatures,
+                                                 const float* teacher_logprobs,
+                                                 float loss_scale,
+                                                 float ipo_mask_low,
+                                                 float ipo_mask_high,
+                                                 float adv_tau,
+                                                 float teacher_tau,
+                                                 float kl_tau,
+                                                 float ratio_clip,
+                                                 int seq_chunks) {
+    if (mTrainMicroStep >= mGradAccumulation) {
+        throw std::runtime_error(fmt::format(
+            "step_grpo_native_chunked: micro_step {} >= grad_accumulation {}", mTrainMicroStep, mGradAccumulation));
+    }
+    const int ep_size = std::max(1, mOptions.EPSize);
+    const long T_full = static_cast<long>(T) * seq_chunks;
+    const int accum_eff = mGradAccumulation * seq_chunks;
+
+    // Skip all-padding tail chunks: with single-sample bins the real tokens
+    // end at max(sample_ends); chunks past that contribute nothing (their
+    // dloss is all zero) and cost a full re-forward+backward each.
+    long max_end = 0;
+    for (int s = 0; s < sample_count; ++s) {
+        max_end = std::max(max_end, static_cast<long>(sample_ends[s]));
+    }
+    const int chunks_occupied =
+        std::max(1, std::min(seq_chunks, static_cast<int>((max_end + T - 1) / T)));
+
+    const dsl::GrpoNativeLossConfig loss_config{
+        .loss_scale = loss_scale,
+        .ipo_mask_low = ipo_mask_low,
+        .ipo_mask_high = ipo_mask_high,
+        .adv_tau = adv_tau,
+        .teacher_tau = teacher_tau,
+        .kl_tau = kl_tau,
+        .ratio_clip = ratio_clip,
+    };
+
+    auto copy_chunk = [&](int c) {
+        const long base_pos = static_cast<long>(c) * T;
+        for (int i = 0; i < static_cast<int>(mContexts.size()); ++i) {
+            auto& ctx = mContexts.at(i);
+            if (!ctx.Model) {
+                throw std::runtime_error(fmt::format("step_grpo_native_chunked: ctx[{}].Model is null", i));
+            }
+            const int src_row = host_batch_row_for_local_rank(i, ep_size);
+            copy_chunk_inputs_for_ctx(*ctx.Model, inputs, targets, position_ids, src_row, B, T, T_full, base_pos);
+        }
+    };
+
+    // Upload the FULL sequence's GRPO arrays once per micro-batch. Sample
+    // ranges are global; the per-chunk kernel windows into them.
+    run_work([inference_logprobs,
+              advantages,
+              loss_mask,
+              sample_starts,
+              sample_ends,
+              sample_count,
+              temperatures,
+              teacher_logprobs,
+              T_full,
+              zero_metrics = (mTrainMicroStep == 0),
+              B = this->B](sThreadContext& ctx) {
+        auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+        if (!dsl_model) {
+            throw std::runtime_error("step_grpo_native_chunked: model is not a DslModel");
+        }
+        const int gpu_rank = ctx.Communicator->local_rank();
+        const int gpu_ep_size = ctx.Communicator->ep_size();
+        const int src_row = host_batch_row_for_local_rank(gpu_rank, gpu_ep_size);
+        const float* temps_for_this_gpu = nullptr;
+        if (temperatures) {
+            temps_for_this_gpu = temperatures + static_cast<std::ptrdiff_t>(src_row) * B * T_full;
+        }
+        dsl_model->grpo_native_upload_full(inference_logprobs,
+                                           advantages,
+                                           loss_mask,
+                                           sample_starts,
+                                           sample_ends,
+                                           sample_count,
+                                           static_cast<long>(B) * T_full,
+                                           zero_metrics,
+                                           temps_for_this_gpu,
+                                           teacher_logprobs);
+    });
+
+    // Phase A — KV sweep: forward chunks left-to-right filling the per-layer
+    // attention KV caches (saved-tensor persistence skipped).
+    for (int c = 0; c < chunks_occupied; ++c) {
+        copy_chunk(c);
+        const int micro_eff = mTrainMicroStep * seq_chunks + c;
+        const long base_pos_a = static_cast<long>(c) * T;
+        run_work([c, seq_chunks, micro_eff, base_pos_a, this](sThreadContext& ctx) {
+            Tensor in = ctx.Model->get_input_buffer();
+            Tensor pos = ctx.Model->get_position_ids_buffer();
+            const auto meta = chunk_pack_meta_from_positions(pos.get<std::int32_t>(),
+                                                            static_cast<int>(this->T), base_pos_a);
+            ctx.Model->set_sequence_chunk(c, seq_chunks, &meta);
+            ctx.Model->forward_no_save(in, pos, *ctx.Communicator, micro_eff);
+        });
+    }
+
+    // Phase B — reverse re-forward + windowed GRPO dloss + backward. dK/dV
+    // accumulate across chunks exactly as in step_chunked.
+    run_work([](sThreadContext& ctx) { ctx.Model->zero_sequence_chunk_dkv(); });
+    const bool has_temps = temperatures != nullptr;
+    const bool has_teacher = teacher_logprobs != nullptr;
+    for (int c = chunks_occupied - 1; c >= 0; --c) {
+        copy_chunk(c);
+        const int micro_eff = mTrainMicroStep * seq_chunks + (seq_chunks - 1 - c);
+        const long window_start = static_cast<long>(c) * T;
+        run_work([c,
+                  seq_chunks,
+                  micro_eff,
+                  accum_eff,
+                  window_start,
+                  sample_count,
+                  loss_config,
+                  has_temps,
+                  has_teacher](sThreadContext& ctx) {
+            auto* dsl_model = dynamic_cast<dsl::DslModel*>(ctx.Model.get());
+            if (!dsl_model) {
+                throw std::runtime_error("step_grpo_native_chunked: model is not a DslModel");
+            }
+            Tensor in = ctx.Model->get_input_buffer();
+            Tensor pos = ctx.Model->get_position_ids_buffer();
+            Tensor tgt = ctx.Model->get_target_buffer();
+            const auto meta = chunk_pack_meta_from_positions(pos.get<std::int32_t>(),
+                                                            static_cast<int>(in.Sizes[1]), window_start);
+            ctx.Model->set_sequence_chunk(c, seq_chunks, &meta);
+            dsl_model->step_grpo_native_window(in,
+                                               pos,
+                                               tgt,
+                                               window_start,
+                                               sample_count,
+                                               accum_eff,
+                                               micro_eff,
+                                               *ctx.Communicator,
+                                               loss_config,
+                                               has_temps,
+                                               has_teacher);
+        });
+    }
+    run_work([](sThreadContext& ctx) { ctx.Model->set_sequence_chunk(-1, 0); });
     ++mTrainMicroStep;
 }
 

--- a/csrc/src/binding/py_train.h
+++ b/csrc/src/binding/py_train.h
@@ -325,7 +325,31 @@ public:
                           float ipo_mask_high,
                           float adv_tau,
                           float teacher_tau,
-                          float kl_tau);
+                          float kl_tau,
+                          float ratio_clip);
+    /// Chunked-sequence GRPO micro-step (mirrors step_chunked): KV sweep over
+    /// chunks, then reverse re-forward + windowed GRPO dloss + backward.
+    /// Taken automatically by step_grpo_native when SequenceChunks > 1;
+    /// per-token arrays and sample ranges are GLOBAL over [rows, B, N*T].
+    void step_grpo_native_chunked(const std::int32_t* inputs,
+                                  const std::int32_t* targets,
+                                  const float* inference_logprobs,
+                                  const float* advantages,
+                                  const std::uint8_t* loss_mask,
+                                  const std::int32_t* sample_starts,
+                                  const std::int32_t* sample_ends,
+                                  int sample_count,
+                                  const std::int32_t* position_ids,
+                                  const float* temperatures,
+                                  const float* teacher_logprobs,
+                                  float loss_scale,
+                                  float ipo_mask_low,
+                                  float ipo_mask_high,
+                                  float adv_tau,
+                                  float teacher_tau,
+                                  float kl_tau,
+                                  float ratio_clip,
+                                  int seq_chunks);
     std::unordered_map<std::string, float> get_grpo_native_metrics();
 
     // Knowledge-distillation training micro-step: standard SFT forward/backward

--- a/csrc/src/kernels/fused_classifier.cu
+++ b/csrc/src/kernels/fused_classifier.cu
@@ -1532,7 +1532,14 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
                                          float ipo_mask_high,
                                          float adv_tau,
                                          float teacher_tau,
-                                         float kl_tau) {
+                                         float kl_tau,
+                                         float ratio_clip,
+                                         long window_start) {
+    // Chunked-sequence GRPO: `losses`/`custom_dloss` are CHUNK-local buffers
+    // covering global slots [window_start, window_start + BT); the per-token
+    // arrays (inference_logprobs/advantages/loss_mask) and sample ranges are
+    // GLOBAL over the full packed sequence. window_start == 0 with BT = full
+    // sequence reproduces the unchunked behavior exactly.
     __shared__ float reductions[GRPO_METRIC_COUNT][256];
 
     const int sample_idx = static_cast<int>(blockIdx.x);
@@ -1542,7 +1549,14 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
 
     const int start = sample_starts[sample_idx];
     const int end = sample_ends[sample_idx];
-    if (start < 0 || end > BT || start >= end) {
+    const long window_end = window_start + static_cast<long>(BT);
+    if (start < 0 || start >= end) {
+        return;
+    }
+    // Intersect this sample with the chunk window; empty slices exit early.
+    const long lo = start > window_start ? start : window_start;
+    const long hi = static_cast<long>(end) < window_end ? static_cast<long>(end) : window_end;
+    if (lo >= hi) {
         return;
     }
 
@@ -1559,19 +1573,20 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
     float masked_count = 0.0f;
     float unmasked_count = 0.0f;
 
-    for (int out_idx = start + static_cast<int>(threadIdx.x); out_idx < end; out_idx += static_cast<int>(blockDim.x)) {
+    for (long out_idx = lo + static_cast<long>(threadIdx.x); out_idx < hi; out_idx += static_cast<long>(blockDim.x)) {
+        const long local_idx = out_idx - window_start;  // chunk-local slot
         if (out_idx + 1 >= end) {
-            custom_dloss[out_idx] = 0.0f;
+            custom_dloss[local_idx] = 0.0f;
             continue;
         }
 
-        const int logical_idx = out_idx + 1;
+        const long logical_idx = out_idx + 1;
         if (loss_mask[logical_idx] == 0) {
-            custom_dloss[out_idx] = 0.0f;
+            custom_dloss[local_idx] = 0.0f;
             continue;
         }
 
-        const float trainer_logprob = -losses[out_idx];
+        const float trainer_logprob = -losses[local_idx];
         const float inference_logprob = inference_logprobs[logical_idx];
         const float log_importance_ratio = trainer_logprob - inference_logprob;
         const float importance_ratio = expf(log_importance_ratio);
@@ -1589,8 +1604,12 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
             teacher_kl_sum += teacher_kl;
         }
         if (keep) {
-            dloss += scaled_advantage * importance_ratio;
-            policy_sum -= scaled_advantage * importance_ratio;
+            // Gradient uses the CAPPED ratio (GRPOLossConfig.ratio_clip);
+            // mismatch metrics below keep the uncapped value so staleness
+            // monitoring sees real drift.
+            const float capped_ratio = fminf(importance_ratio, ratio_clip);
+            dloss += scaled_advantage * capped_ratio;
+            policy_sum -= scaled_advantage * capped_ratio;
             keep_count += 1.0f;
             unmasked_mismatch_sum += importance_ratio - log_importance_ratio - 1.0f;
             unmasked_count += 1.0f;
@@ -1605,7 +1624,7 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
         is_masked_low_sum += is_masked_low ? 1.0f : 0.0f;
         is_masked_high_sum += is_masked_high ? 1.0f : 0.0f;
         total_count += 1.0f;
-        custom_dloss[out_idx] = dloss * inv_loss_scale;
+        custom_dloss[local_idx] = dloss * inv_loss_scale;
     }
 
     reductions[GRPO_METRIC_POLICY_LOSS][threadIdx.x] = policy_sum;
@@ -1616,7 +1635,8 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
     reductions[GRPO_METRIC_IS_MASKED_LOW][threadIdx.x] = is_masked_low_sum;
     reductions[GRPO_METRIC_IS_MASKED_HIGH][threadIdx.x] = is_masked_high_sum;
     reductions[GRPO_METRIC_TEACHER_KL][threadIdx.x] = teacher_kl_sum;
-    reductions[GRPO_METRIC_SAMPLE_COUNT][threadIdx.x] = total_count > 0.0f ? 1.0f : 0.0f;
+    reductions[GRPO_METRIC_SAMPLE_COUNT][threadIdx.x] =
+        (total_count > 0.0f && static_cast<long>(start) >= window_start) ? 1.0f : 0.0f;
     reductions[GRPO_METRIC_KEEP_TOKENS][threadIdx.x] = keep_count;
     reductions[GRPO_METRIC_TOTAL_TOKENS][threadIdx.x] = total_count;
     __syncthreads();
@@ -1646,7 +1666,9 @@ __global__ void grpo_custom_dloss_kernel(float* custom_dloss,
         if (teacher_logprobs) {
             atomicAdd(metrics + GRPO_METRIC_TEACHER_KL, reductions[GRPO_METRIC_TEACHER_KL][0] / sample_total);
         }
-        atomicAdd(metrics + GRPO_METRIC_SAMPLE_COUNT, 1.0f);
+        if (static_cast<long>(start) >= window_start) {
+            atomicAdd(metrics + GRPO_METRIC_SAMPLE_COUNT, 1.0f);
+        }
         atomicAdd(metrics + GRPO_METRIC_KEEP_TOKENS, reductions[GRPO_METRIC_KEEP_TOKENS][0]);
         atomicAdd(metrics + GRPO_METRIC_TOTAL_TOKENS, sample_total);
     }
@@ -1669,6 +1691,8 @@ void compute_grpo_custom_dloss(float* custom_dloss,
                                float adv_tau,
                                float teacher_tau,
                                float kl_tau,
+                               float ratio_clip,
+                               long window_start,
                                cudaStream_t stream) {
     if (sample_count <= 0 || BT <= 0) {
         return;
@@ -1691,7 +1715,9 @@ void compute_grpo_custom_dloss(float* custom_dloss,
                                                                ipo_mask_high,
                                                                adv_tau,
                                                                teacher_tau,
-                                                               kl_tau);
+                                                               kl_tau,
+                                                               ratio_clip,
+                                                               window_start);
     CUDA_CHECK(cudaGetLastError());
 }
 

--- a/csrc/src/kernels/kernels.h
+++ b/csrc/src/kernels/kernels.h
@@ -1787,6 +1787,8 @@ void compute_grpo_custom_dloss(float* custom_dloss,
                                float adv_tau,
                                float teacher_tau,
                                float kl_tau,
+                               float ratio_clip,
+                               long window_start,
                                cudaStream_t stream);
 
 // DPO (Direct Preference Optimization) preference loss. One logical pair is

--- a/csrc/src/runtime/dsl/dsl_model.h
+++ b/csrc/src/runtime/dsl/dsl_model.h
@@ -60,6 +60,7 @@ struct GrpoNativeLossConfig {
     float adv_tau = 1.0f;
     float teacher_tau = 0.0f;
     float kl_tau = 1.0e-3f;
+    float ratio_clip = 7.389056f;  // e^2 cap on the PG importance ratio
 };
 
 struct GrpoNativeMetrics {
@@ -441,6 +442,35 @@ public:
                           const GrpoNativeLossConfig& loss_config,
                           const float* temperatures_cpu = nullptr,
                           const float* teacher_logprobs_cpu = nullptr);
+
+    /// Chunked-sequence GRPO (mirrors MultiGPUPyTrainer::step_chunked).
+    /// Upload the FULL packed sequence's per-token arrays and sample ranges
+    /// once per micro-batch, then execute per-chunk windows: re-forward the
+    /// chunk, seed its backward with the GRPO custom dloss computed over the
+    /// window (kernel reads the full arrays at global coordinates), backward.
+    /// Caller manages set_sequence_chunk()/forward_no_save() phases exactly
+    /// like the SFT chunked step.
+    void grpo_native_upload_full(const float* inference_logprobs_cpu,
+                                 const float* advantages_cpu,
+                                 const std::uint8_t* loss_mask_cpu,
+                                 const std::int32_t* sample_starts_cpu,
+                                 const std::int32_t* sample_ends_cpu,
+                                 int sample_count,
+                                 long total_tokens,
+                                 bool zero_metrics,
+                                 const float* temperatures_cpu = nullptr,
+                                 const float* teacher_logprobs_cpu = nullptr);
+    void step_grpo_native_window(Tensor inputs,
+                                 Tensor position_ids,
+                                 Tensor targets,
+                                 long window_start,
+                                 int sample_count,
+                                 int grad_accum_steps,
+                                 int micro_step,
+                                 NCCLCommunicator& comm,
+                                 const GrpoNativeLossConfig& loss_config,
+                                 bool has_temperatures,
+                                 bool has_teacher_logprobs);
     GrpoNativeMetrics consume_grpo_native_metrics();
 
     /// Knowledge-distillation training step: standard SFT forward + backward

--- a/csrc/src/runtime/dsl/dsl_model_execution.cpp
+++ b/csrc/src/runtime/dsl/dsl_model_execution.cpp
@@ -887,46 +887,36 @@ void DslModel::backward_grpo(Tensor inputs,
     mGrpoInvTemperatureGpu = nullptr;
 }
 
-void DslModel::step_grpo_native(Tensor inputs,
-                                Tensor position_ids,
-                                Tensor targets,
-                                const float* inference_logprobs_cpu,
-                                const float* advantages_cpu,
-                                const std::uint8_t* loss_mask_cpu,
-                                const std::int32_t* sample_starts_cpu,
-                                const std::int32_t* sample_ends_cpu,
-                                int sample_count,
-                                int grad_accum_steps,
-                                int micro_step,
-                                NCCLCommunicator& comm,
-                                const GrpoNativeLossConfig& loss_config,
-                                const float* temperatures_cpu,
-                                const float* teacher_logprobs_cpu) {
+void DslModel::grpo_native_upload_full(const float* inference_logprobs_cpu,
+                                       const float* advantages_cpu,
+                                       const std::uint8_t* loss_mask_cpu,
+                                       const std::int32_t* sample_starts_cpu,
+                                       const std::int32_t* sample_ends_cpu,
+                                       int sample_count,
+                                       long total_tokens,
+                                       bool zero_metrics,
+                                       const float* temperatures_cpu,
+                                       const float* teacher_logprobs_cpu) {
     if (!mExecutor) {
-        throw std::logic_error("DslModel::step_grpo_native called before allocate_run_state()");
+        throw std::logic_error("DslModel::grpo_native_upload_full called before allocate_run_state()");
     }
     if (!inference_logprobs_cpu || !advantages_cpu || !loss_mask_cpu || !sample_starts_cpu || !sample_ends_cpu) {
         throw std::invalid_argument(
-            "step_grpo_native requires inference_logprobs, advantages, loss_mask, sample ranges");
+            "grpo_native_upload_full requires inference_logprobs, advantages, loss_mask, sample ranges");
     }
     if (sample_count <= 0) {
-        throw std::invalid_argument("step_grpo_native requires at least one sample range");
-    }
-    if (!(loss_config.loss_scale > 0.0f) || !std::isfinite(loss_config.loss_scale)) {
-        throw std::invalid_argument("step_grpo_native loss_scale must be finite and positive");
+        throw std::invalid_argument("grpo_native_upload_full requires at least one sample range");
     }
 
     auto& rs = *mRunState;
     auto& scratch = rs.grpo_native_scratch();
     cudaStream_t main_stream = rs.MainStream;
-    const int B_val = static_cast<int>(inputs.Sizes[0]);
-    const int T_val = static_cast<int>(inputs.Sizes[1]);
-    const std::size_t bt = static_cast<std::size_t>(B_val) * static_cast<std::size_t>(T_val);
+    const std::size_t bt = static_cast<std::size_t>(total_tokens);
     if (bt > static_cast<std::size_t>(scratch.max_tokens) ||
         static_cast<std::size_t>(sample_count) > static_cast<std::size_t>(scratch.max_samples)) {
-        throw std::runtime_error("step_grpo_native inputs exceed allocated GRPO scratch capacity");
+        throw std::runtime_error("grpo_native_upload_full inputs exceed allocated GRPO scratch capacity");
     }
-    if (micro_step == 0) {
+    if (zero_metrics) {
         CUDA_CHECK(cudaMemsetAsync(scratch.metrics.Data,
                                    0,
                                    static_cast<std::size_t>(GRPO_METRIC_COUNT) * sizeof(float),
@@ -969,13 +959,10 @@ void DslModel::step_grpo_native(Tensor inputs,
                                cudaMemcpyHostToDevice,
                                main_stream));
 
-    const float* teacher_logprobs_gpu = nullptr;
     if (teacher_logprobs_cpu) {
         copy_float_input(scratch.host_teacher_logprobs[staging_slot], scratch.teacher_logprobs, teacher_logprobs_cpu);
-        teacher_logprobs_gpu = scratch.teacher_logprobs.get<float>();
     }
 
-    const float* inv_temperature_gpu = nullptr;
     if (temperatures_cpu) {
         auto* inv_temp = scratch.host_temperatures[staging_slot].get<float>();
         for (std::size_t i = 0; i < bt; ++i) {
@@ -986,13 +973,51 @@ void DslModel::step_grpo_native(Tensor inputs,
                                    bt * sizeof(float),
                                    cudaMemcpyHostToDevice,
                                    main_stream));
-        inv_temperature_gpu = scratch.inv_temperature.get<float>();
     }
     CUDA_CHECK(cudaEventRecord(scratch.host_copy_done[staging_slot], main_stream));
     scratch.host_copy_recorded[staging_slot] = true;
+}
 
+void DslModel::step_grpo_native_window(Tensor inputs,
+                                       Tensor position_ids,
+                                       Tensor targets,
+                                       long window_start,
+                                       int sample_count,
+                                       int grad_accum_steps,
+                                       int micro_step,
+                                       NCCLCommunicator& comm,
+                                       const GrpoNativeLossConfig& loss_config,
+                                       bool has_temperatures,
+                                       bool has_teacher_logprobs) {
+    if (!mExecutor) {
+        throw std::logic_error("DslModel::step_grpo_native_window called before allocate_run_state()");
+    }
+    if (!(loss_config.loss_scale > 0.0f) || !std::isfinite(loss_config.loss_scale)) {
+        throw std::invalid_argument("step_grpo_native_window loss_scale must be finite and positive");
+    }
+
+    auto& rs = *mRunState;
+    auto& scratch = rs.grpo_native_scratch();
+    cudaStream_t main_stream = rs.MainStream;
+    const int B_val = static_cast<int>(inputs.Sizes[0]);
+    const int T_val = static_cast<int>(inputs.Sizes[1]);
+    const std::size_t bt = static_cast<std::size_t>(B_val) * static_cast<std::size_t>(T_val);
+    if (static_cast<long>(window_start + static_cast<long>(bt)) > scratch.max_tokens) {
+        throw std::runtime_error("step_grpo_native_window window exceeds uploaded GRPO scratch");
+    }
+
+    const float* teacher_logprobs_gpu =
+        has_teacher_logprobs ? scratch.teacher_logprobs.get<float>() : nullptr;
+    const float* inv_temperature_gpu =
+        has_temperatures ? scratch.inv_temperature.get<float>() + window_start : nullptr;
+
+    // Chunked-sequence mode carries per-document geometry in the chunk
+    // metadata (ChunkPackMeta on the kvprefix path) — the dense doc-masking
+    // context must stay clear, exactly as in DslModel::forward().
     const bool doc_masking_active =
-        causal_lm_profile().apply_doc_masking(*mExecutor, mOptions, mModelConfig, inputs, position_ids, micro_step);
+        mSequenceChunkActive
+            ? false
+            : causal_lm_profile().apply_doc_masking(*mExecutor, mOptions, mModelConfig, inputs, position_ids, micro_step);
 
     if (lora_enabled()) {
         ensure_lora_run_state(comm, B_val, T_val);
@@ -1027,6 +1052,8 @@ void DslModel::step_grpo_native(Tensor inputs,
                               loss_config.adv_tau,
                               loss_config.teacher_tau,
                               loss_config.kl_tau,
+                              loss_config.ratio_clip,
+                              window_start,
                               main_stream);
 
     if (!lora_enabled()) {
@@ -1050,6 +1077,45 @@ void DslModel::step_grpo_native(Tensor inputs,
     if (doc_masking_active) mExecutor->clear_doc_masking();
     mLoRAGrads->end_micro_step(main_stream, comm);
     internal::record_event_if_not_capturing(rs.BackwardDone, main_stream);
+}
+
+void DslModel::step_grpo_native(Tensor inputs,
+                                Tensor position_ids,
+                                Tensor targets,
+                                const float* inference_logprobs_cpu,
+                                const float* advantages_cpu,
+                                const std::uint8_t* loss_mask_cpu,
+                                const std::int32_t* sample_starts_cpu,
+                                const std::int32_t* sample_ends_cpu,
+                                int sample_count,
+                                int grad_accum_steps,
+                                int micro_step,
+                                NCCLCommunicator& comm,
+                                const GrpoNativeLossConfig& loss_config,
+                                const float* temperatures_cpu,
+                                const float* teacher_logprobs_cpu) {
+    const long bt = static_cast<long>(inputs.Sizes[0]) * static_cast<long>(inputs.Sizes[1]);
+    grpo_native_upload_full(inference_logprobs_cpu,
+                            advantages_cpu,
+                            loss_mask_cpu,
+                            sample_starts_cpu,
+                            sample_ends_cpu,
+                            sample_count,
+                            bt,
+                            /*zero_metrics=*/micro_step == 0,
+                            temperatures_cpu,
+                            teacher_logprobs_cpu);
+    step_grpo_native_window(inputs,
+                            position_ids,
+                            targets,
+                            /*window_start=*/0,
+                            sample_count,
+                            grad_accum_steps,
+                            micro_step,
+                            comm,
+                            loss_config,
+                            temperatures_cpu != nullptr,
+                            teacher_logprobs_cpu != nullptr);
 }
 
 GrpoNativeMetrics DslModel::consume_grpo_native_metrics() {

--- a/csrc/src/runtime/dsl/dsl_run_state.cpp
+++ b/csrc/src/runtime/dsl/dsl_run_state.cpp
@@ -323,6 +323,8 @@ DslRunState::DslRunState(const PretrainedConfig& config,
       mCpuTraining(options.CpuTraining),
       mNumLayers(config.NumLayers),
       mPerLayerGraphsEnabled(options.UseCudaGraphs) {
+    mGrpoTokenCapacity =
+        static_cast<long>(B) * static_cast<long>(T) * std::max(1, options.SequenceChunks);
     if (!mAllocator) {
         throw std::runtime_error("DslRunState: allocator is null");
     }
@@ -1063,28 +1065,31 @@ void DslRunState::allocate_scratch_buffers(const PretrainedConfig& cfg) {
         }
     }
 
-    mGrpoNativeScratch.max_tokens = BT;
-    mGrpoNativeScratch.max_samples = BT;
+    // Chunked GRPO holds the FULL packed sequence's arrays on device while
+    // the graph executes chunk windows (B*T is the CHUNK size then).
+    const long BT_grpo = mGrpoTokenCapacity > 0 ? mGrpoTokenCapacity : BT;
+    mGrpoNativeScratch.max_tokens = BT_grpo;
+    mGrpoNativeScratch.max_samples = BT_grpo;
     mGrpoNativeScratch.inference_logprobs =
-        mAllocator->allocate(ETensorDType::FP32, "grpo_inference_logprobs", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::FP32, "grpo_inference_logprobs", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.advantages =
-        mAllocator->allocate(ETensorDType::FP32, "grpo_advantages", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::FP32, "grpo_advantages", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.teacher_logprobs =
-        mAllocator->allocate(ETensorDType::FP32, "grpo_teacher_logprobs", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::FP32, "grpo_teacher_logprobs", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.loss_mask =
-        mAllocator->allocate(ETensorDType::BYTE, "grpo_loss_mask", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::BYTE, "grpo_loss_mask", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.sample_starts =
-        mAllocator->allocate(ETensorDType::INT32, "grpo_sample_starts", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::INT32, "grpo_sample_starts", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.sample_ends =
-        mAllocator->allocate(ETensorDType::INT32, "grpo_sample_ends", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::INT32, "grpo_sample_ends", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.pair_chosen =
-        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_chosen", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_chosen", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.pair_rejected =
-        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_rejected", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::INT32, "grpo_pair_rejected", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.custom_dloss =
         mAllocator->allocate(ETensorDType::FP32, "grpo_custom_dloss", EAllocationType::ON_DEVICE, {BT});
     mGrpoNativeScratch.inv_temperature =
-        mAllocator->allocate(ETensorDType::FP32, "grpo_inv_temperature", EAllocationType::ON_DEVICE, {BT});
+        mAllocator->allocate(ETensorDType::FP32, "grpo_inv_temperature", EAllocationType::ON_DEVICE, {BT_grpo});
     mGrpoNativeScratch.metrics =
         mAllocator->allocate(ETensorDType::FP32, "grpo_metrics", EAllocationType::ON_DEVICE, {11});
     mGrpoNativeScratch.host_metrics =
@@ -1095,42 +1100,42 @@ void DslRunState::allocate_scratch_buffers(const PretrainedConfig& cfg) {
             mAllocator->allocate(ETensorDType::FP32,
                                  ("grpo_host_inference_logprobs_" + suffix).c_str(),
                                  EAllocationType::PINNED,
-                                 {BT});
+                                 {BT_grpo});
         mGrpoNativeScratch.host_advantages[slot] = mAllocator->allocate(ETensorDType::FP32,
                                                                         ("grpo_host_advantages_" + suffix).c_str(),
                                                                         EAllocationType::PINNED,
-                                                                        {BT});
+                                                                        {BT_grpo});
         mGrpoNativeScratch.host_teacher_logprobs[slot] =
             mAllocator->allocate(ETensorDType::FP32,
                                  ("grpo_host_teacher_logprobs_" + suffix).c_str(),
                                  EAllocationType::PINNED,
-                                 {BT});
+                                 {BT_grpo});
         mGrpoNativeScratch.host_temperatures[slot] = mAllocator->allocate(ETensorDType::FP32,
                                                                           ("grpo_host_temperatures_" + suffix).c_str(),
                                                                           EAllocationType::PINNED,
-                                                                          {BT});
+                                                                          {BT_grpo});
         mGrpoNativeScratch.host_loss_mask[slot] = mAllocator->allocate(ETensorDType::BYTE,
                                                                        ("grpo_host_loss_mask_" + suffix).c_str(),
                                                                        EAllocationType::PINNED,
-                                                                       {BT});
+                                                                       {BT_grpo});
         mGrpoNativeScratch.host_sample_starts[slot] =
             mAllocator->allocate(ETensorDType::INT32,
                                  ("grpo_host_sample_starts_" + suffix).c_str(),
                                  EAllocationType::PINNED,
-                                 {BT});
+                                 {BT_grpo});
         mGrpoNativeScratch.host_sample_ends[slot] = mAllocator->allocate(ETensorDType::INT32,
                                                                          ("grpo_host_sample_ends_" + suffix).c_str(),
                                                                          EAllocationType::PINNED,
-                                                                         {BT});
+                                                                         {BT_grpo});
         mGrpoNativeScratch.host_pair_chosen[slot] = mAllocator->allocate(ETensorDType::INT32,
                                                                          ("grpo_host_pair_chosen_" + suffix).c_str(),
                                                                          EAllocationType::PINNED,
-                                                                         {BT});
+                                                                         {BT_grpo});
         mGrpoNativeScratch.host_pair_rejected[slot] =
             mAllocator->allocate(ETensorDType::INT32,
                                  ("grpo_host_pair_rejected_" + suffix).c_str(),
                                  EAllocationType::PINNED,
-                                 {BT});
+                                 {BT_grpo});
     }
 
     // Encoder backward scratch buffers - skip in LoRA-only mode since embedding backward is skipped entirely

--- a/csrc/src/runtime/dsl/dsl_run_state.h
+++ b/csrc/src/runtime/dsl/dsl_run_state.h
@@ -411,6 +411,9 @@ private:
     std::byte* mOwnedExternalStack = nullptr;
     std::size_t mOwnedExternalStackBytes = 0;
     RecomputeLevel mRecomputeLevel = RecomputeLevel::Enabled;
+    /// Token capacity for GRPO native scratch: B*T*SequenceChunks — chunked
+    /// GRPO uploads FULL-sequence arrays once and executes per chunk window.
+    long mGrpoTokenCapacity = 0;
     bool mLoraOnlyMode = false;
     bool mPrequantized = false;
     bool mCpuTraining = false;

--- a/csrc/src/testing/kernels/test-fp8-quant.cpp
+++ b/csrc/src/testing/kernels/test-fp8-quant.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+#include "kernels/kernels.h"
+
+namespace {
+
+constexpr long kElementCount = 4096;
+
+template <class Input>
+std::vector<Input> make_input() {
+    std::vector<Input> input(kElementCount, Input(0.25F));
+    input[173] = Input(-7.5F);
+    return input;
+}
+
+template <class Output, class Input>
+void require_abs_quant_launch(const cudaDeviceProp& device_properties, float expected_inverse_scale) {
+    const std::vector<Input> host_input = make_input<Input>();
+    const float host_abs_max = 7.5F;
+
+    Input* device_input = nullptr;
+    Output* device_output = nullptr;
+    float* device_abs_max = nullptr;
+    float* device_scale = nullptr;
+    REQUIRE(cudaMalloc(&device_input, kElementCount * sizeof(Input)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_output, kElementCount * sizeof(Output)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_abs_max, sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_scale, sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMemcpy(device_input,
+                       host_input.data(),
+                       kElementCount * sizeof(Input),
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+    REQUIRE(cudaMemcpy(device_abs_max, &host_abs_max, sizeof(float), cudaMemcpyHostToDevice) == cudaSuccess);
+
+    quantize_with_abs_max(device_output,
+                          device_scale,
+                          device_input,
+                          device_abs_max,
+                          kElementCount,
+                          device_properties,
+                          nullptr);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    if constexpr (!std::is_same_v<Output, std::int8_t>) {
+        float host_scale = 0.0F;
+        REQUIRE(cudaMemcpy(&host_scale, device_scale, sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+        REQUIRE(host_scale == Catch::Approx(expected_inverse_scale));
+    }
+
+    REQUIRE(cudaFree(device_scale) == cudaSuccess);
+    REQUIRE(cudaFree(device_abs_max) == cudaSuccess);
+    REQUIRE(cudaFree(device_output) == cudaSuccess);
+    REQUIRE(cudaFree(device_input) == cudaSuccess);
+}
+
+template <class Output, class Input>
+void require_delayed_quant_launch(const cudaDeviceProp& device_properties) {
+    const std::vector<Input> host_input = make_input<Input>();
+    const float host_delayed_scale = 2.0F;
+    const float zero = 0.0F;
+
+    Input* device_input = nullptr;
+    Output* device_output = nullptr;
+    float* device_recorded_amax = nullptr;
+    float* device_inverse_scale = nullptr;
+    float* device_delayed_scale = nullptr;
+    REQUIRE(cudaMalloc(&device_input, kElementCount * sizeof(Input)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_output, kElementCount * sizeof(Output)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_recorded_amax, sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_inverse_scale, sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_delayed_scale, sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMemcpy(device_input,
+                       host_input.data(),
+                       kElementCount * sizeof(Input),
+                       cudaMemcpyHostToDevice) == cudaSuccess);
+    REQUIRE(cudaMemcpy(device_recorded_amax, &zero, sizeof(float), cudaMemcpyHostToDevice) == cudaSuccess);
+    REQUIRE(cudaMemcpy(
+                device_delayed_scale, &host_delayed_scale, sizeof(float), cudaMemcpyHostToDevice) == cudaSuccess);
+
+    quantize_with_delayed_scale(device_output,
+                                device_recorded_amax,
+                                device_inverse_scale,
+                                device_input,
+                                device_delayed_scale,
+                                kElementCount,
+                                device_properties,
+                                nullptr);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    float host_recorded_amax = 0.0F;
+    float host_inverse_scale = 0.0F;
+    REQUIRE(cudaMemcpy(
+                &host_recorded_amax, device_recorded_amax, sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(cudaMemcpy(
+                &host_inverse_scale, device_inverse_scale, sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+    REQUIRE(host_recorded_amax == Catch::Approx(7.5F));
+    REQUIRE(host_inverse_scale == Catch::Approx(0.5F));
+
+    REQUIRE(cudaFree(device_delayed_scale) == cudaSuccess);
+    REQUIRE(cudaFree(device_inverse_scale) == cudaSuccess);
+    REQUIRE(cudaFree(device_recorded_amax) == cudaSuccess);
+    REQUIRE(cudaFree(device_output) == cudaSuccess);
+    REQUIRE(cudaFree(device_input) == cudaSuccess);
+}
+
+}  // namespace
+
+TEST_CASE("FP8 abs-max reduction uses a launchable occupancy shape", "[fp8][quant][cuda]") {
+    int device_count = 0;
+    const cudaError_t count_status = cudaGetDeviceCount(&device_count);
+    if (count_status != cudaSuccess || device_count == 0) {
+        SKIP("No CUDA device available");
+    }
+
+    REQUIRE(cudaSetDevice(0) == cudaSuccess);
+    cudaDeviceProp device_properties{};
+    REQUIRE(cudaGetDeviceProperties(&device_properties, 0) == cudaSuccess);
+
+    // Keep N divisible by the 128-bit vector width used by both FP32 and BF16
+    // specializations.  A full-size tensor is unnecessary to exercise the
+    // occupancy-selected launch configuration that regressed on SM120.
+    SECTION("FP32 specialization") {
+        std::vector<float> host_input(kElementCount, 0.25F);
+        host_input[173] = -7.5F;
+
+        float* device_input = nullptr;
+        float* device_result = nullptr;
+        REQUIRE(cudaMalloc(&device_input, kElementCount * sizeof(float)) == cudaSuccess);
+        REQUIRE(cudaMalloc(&device_result, sizeof(float)) == cudaSuccess);
+        REQUIRE(cudaMemcpy(device_input,
+                           host_input.data(),
+                           kElementCount * sizeof(float),
+                           cudaMemcpyHostToDevice) == cudaSuccess);
+
+        abs_max(device_result, device_input, kElementCount, device_properties, nullptr);
+        REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+        float host_result = 0.0F;
+        REQUIRE(cudaMemcpy(&host_result, device_result, sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+        REQUIRE(host_result == Catch::Approx(7.5F));
+
+        REQUIRE(cudaFree(device_result) == cudaSuccess);
+        REQUIRE(cudaFree(device_input) == cudaSuccess);
+    }
+
+    SECTION("BF16 specialization used by imported model weights") {
+        std::vector<nv_bfloat16> host_input(kElementCount, nv_bfloat16(0.25F));
+        host_input[173] = nv_bfloat16(-7.5F);
+
+        nv_bfloat16* device_input = nullptr;
+        float* device_result = nullptr;
+        REQUIRE(cudaMalloc(&device_input, kElementCount * sizeof(nv_bfloat16)) == cudaSuccess);
+        REQUIRE(cudaMalloc(&device_result, sizeof(float)) == cudaSuccess);
+        REQUIRE(cudaMemcpy(device_input,
+                           host_input.data(),
+                           kElementCount * sizeof(nv_bfloat16),
+                           cudaMemcpyHostToDevice) == cudaSuccess);
+
+        abs_max(device_result, device_input, kElementCount, device_properties, nullptr);
+        REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+        float host_result = 0.0F;
+        REQUIRE(cudaMemcpy(&host_result, device_result, sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess);
+        REQUIRE(host_result == Catch::Approx(7.5F));
+
+        REQUIRE(cudaFree(device_result) == cudaSuccess);
+        REQUIRE(cudaFree(device_input) == cudaSuccess);
+    }
+}
+
+TEST_CASE("FP8 quantization launchers use exact-kernel occupancy shapes", "[fp8][quant][cuda]") {
+    int device_count = 0;
+    const cudaError_t count_status = cudaGetDeviceCount(&device_count);
+    if (count_status != cudaSuccess || device_count == 0) {
+        SKIP("No CUDA device available");
+    }
+
+    REQUIRE(cudaSetDevice(0) == cudaSuccess);
+    cudaDeviceProp device_properties{};
+    REQUIRE(cudaGetDeviceProperties(&device_properties, 0) == cudaSuccess);
+
+    SECTION("absolute-max FP32 to BF16") {
+        require_abs_quant_launch<nv_bfloat16, float>(device_properties, 1.0F);
+    }
+    SECTION("absolute-max FP32 to INT8") {
+        require_abs_quant_launch<std::int8_t, float>(device_properties, 0.0F);
+    }
+    SECTION("absolute-max FP32 to FP8 E4M3") {
+        require_abs_quant_launch<__nv_fp8_e4m3, float>(device_properties, 7.5F / 448.0F);
+    }
+    SECTION("absolute-max FP32 to FP8 E5M2") {
+        require_abs_quant_launch<__nv_fp8_e5m2, float>(device_properties, 7.5F / 57344.0F);
+    }
+    SECTION("absolute-max BF16 to INT8") {
+        require_abs_quant_launch<std::int8_t, nv_bfloat16>(device_properties, 0.0F);
+    }
+    SECTION("absolute-max BF16 to FP8 E4M3") {
+        require_abs_quant_launch<__nv_fp8_e4m3, nv_bfloat16>(device_properties, 7.5F / 448.0F);
+    }
+    SECTION("absolute-max BF16 to FP8 E5M2") {
+        require_abs_quant_launch<__nv_fp8_e5m2, nv_bfloat16>(device_properties, 7.5F / 57344.0F);
+    }
+    SECTION("delayed-scale FP32 to FP8 E4M3") {
+        require_delayed_quant_launch<__nv_fp8_e4m3, float>(device_properties);
+    }
+    SECTION("delayed-scale FP32 to FP8 E5M2") {
+        require_delayed_quant_launch<__nv_fp8_e5m2, float>(device_properties);
+    }
+    SECTION("delayed-scale BF16 to FP8 E4M3") {
+        require_delayed_quant_launch<__nv_fp8_e4m3, nv_bfloat16>(device_properties);
+    }
+    SECTION("delayed-scale BF16 to FP8 E5M2") {
+        require_delayed_quant_launch<__nv_fp8_e5m2, nv_bfloat16>(device_properties);
+    }
+}

--- a/csrc/src/testing/kernels/test-grpo-replay.cpp
+++ b/csrc/src/testing/kernels/test-grpo-replay.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: Apache-2.0
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cuda_runtime.h>
+
+#include <array>
+#include <cstdint>
+
+#include "kernels/kernels.h"
+
+TEST_CASE("native GRPO replay is CE-only", "[grpo][replay][cuda]") {
+    int device_count = 0;
+    const cudaError_t count_status = cudaGetDeviceCount(&device_count);
+    if (count_status != cudaSuccess || device_count == 0) {
+        SKIP("No CUDA device available");
+    }
+    REQUIRE(cudaSetDevice(0) == cudaSuccess);
+
+    constexpr int kBT = 4;
+    constexpr int kMetricCount = 19;
+    const std::array<float, kBT> losses{2.0F, 1.0F, 3.0F, 0.0F};
+    const std::array<float, kBT> inference_logprobs{50.0F, 50.0F, 50.0F, 50.0F};
+    const std::array<float, kBT> advantages{50.0F, 50.0F, 50.0F, 50.0F};
+    const std::array<float, kBT> teacher_logprobs{40.0F, 40.0F, 40.0F, 40.0F};
+    const std::array<float, kBT> opd_reference_logprobs{30.0F, 30.0F, 30.0F, 30.0F};
+    const std::array<float, kBT> hindsight_logprobs{60.0F, 60.0F, 60.0F, 60.0F};
+    const std::array<std::uint8_t, kBT> loss_mask{0, 1, 1, 1};
+    const std::array<std::uint8_t, kBT> hindsight_mask{0, 1, 1, 1};
+    const std::array<std::uint8_t, kBT> replay_mask{0, 1, 1, 1};
+    const std::array<float, kBT> replay_weights{1.0F, 2.0F, 0.5F, 3.0F};
+    const std::array<std::int32_t, 1> sample_starts{0};
+    const std::array<std::int32_t, 1> sample_ends{kBT};
+
+    float* device_custom_dloss = nullptr;
+    float* device_metrics = nullptr;
+    float* device_losses = nullptr;
+    float* device_inference_logprobs = nullptr;
+    float* device_advantages = nullptr;
+    float* device_teacher_logprobs = nullptr;
+    float* device_opd_reference_logprobs = nullptr;
+    float* device_hindsight_logprobs = nullptr;
+    std::uint8_t* device_loss_mask = nullptr;
+    std::uint8_t* device_hindsight_mask = nullptr;
+    std::uint8_t* device_replay_mask = nullptr;
+    float* device_replay_weights = nullptr;
+    std::int32_t* device_sample_starts = nullptr;
+    std::int32_t* device_sample_ends = nullptr;
+
+#define ALLOCATE_AND_COPY(device, host)                          \
+    REQUIRE(cudaMalloc(&(device), sizeof(host)) == cudaSuccess); \
+    REQUIRE(cudaMemcpy((device), (host).data(), sizeof(host), cudaMemcpyHostToDevice) == cudaSuccess)
+
+    REQUIRE(cudaMalloc(&device_custom_dloss, kBT * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMalloc(&device_metrics, kMetricCount * sizeof(float)) == cudaSuccess);
+    REQUIRE(cudaMemset(device_metrics, 0, kMetricCount * sizeof(float)) == cudaSuccess);
+    ALLOCATE_AND_COPY(device_losses, losses);
+    ALLOCATE_AND_COPY(device_inference_logprobs, inference_logprobs);
+    ALLOCATE_AND_COPY(device_advantages, advantages);
+    ALLOCATE_AND_COPY(device_teacher_logprobs, teacher_logprobs);
+    ALLOCATE_AND_COPY(device_opd_reference_logprobs, opd_reference_logprobs);
+    ALLOCATE_AND_COPY(device_hindsight_logprobs, hindsight_logprobs);
+    ALLOCATE_AND_COPY(device_loss_mask, loss_mask);
+    ALLOCATE_AND_COPY(device_hindsight_mask, hindsight_mask);
+    ALLOCATE_AND_COPY(device_replay_mask, replay_mask);
+    ALLOCATE_AND_COPY(device_replay_weights, replay_weights);
+    ALLOCATE_AND_COPY(device_sample_starts, sample_starts);
+    ALLOCATE_AND_COPY(device_sample_ends, sample_ends);
+#undef ALLOCATE_AND_COPY
+
+    compute_grpo_custom_dloss(device_custom_dloss,
+                              device_metrics,
+                              device_losses,
+                              device_inference_logprobs,
+                              device_advantages,
+                              device_loss_mask,
+                              device_teacher_logprobs,
+                              device_opd_reference_logprobs,
+                              device_hindsight_logprobs,
+                              device_hindsight_mask,
+                              device_replay_mask,
+                              device_replay_weights,
+                              device_sample_starts,
+                              device_sample_ends,
+                              1,
+                              kBT,
+                              3.0F,
+                              0.2F,
+                              0.2F,
+                              1.0F,
+                              1.0F,
+                              1.0F,
+                              1.0F,
+                              0.3F,
+                              1.0F,
+                              nullptr);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    std::array<float, kBT> custom_dloss{};
+    std::array<float, kMetricCount> metrics{};
+    REQUIRE(cudaMemcpy(custom_dloss.data(), device_custom_dloss, sizeof(custom_dloss), cudaMemcpyDeviceToHost) ==
+            cudaSuccess);
+    REQUIRE(cudaMemcpy(metrics.data(), device_metrics, sizeof(metrics), cudaMemcpyDeviceToHost) == cudaSuccess);
+
+    REQUIRE(custom_dloss[0] == Catch::Approx(0.2F));
+    REQUIRE(custom_dloss[1] == Catch::Approx(0.05F));
+    REQUIRE(custom_dloss[2] == Catch::Approx(0.3F));
+    REQUIRE(custom_dloss[3] == Catch::Approx(0.0F));
+    REQUIRE(metrics[0] == Catch::Approx(1.35F));   // policy loss
+    REQUIRE(metrics[1] == Catch::Approx(0.0F));    // mismatch KL
+    REQUIRE(metrics[7] == Catch::Approx(0.0F));    // teacher KL
+    REQUIRE(metrics[11] == Catch::Approx(0.0F));   // OPD tokens
+    REQUIRE(metrics[12] == Catch::Approx(4.05F));  // weighted replay CE sum
+    REQUIRE(metrics[13] == Catch::Approx(3.0F));   // replay tokens
+    REQUIRE(metrics[14] == Catch::Approx(1.0F));   // sample count
+    REQUIRE(metrics[15] == Catch::Approx(0.0F));   // kept IPO tokens
+    REQUIRE(metrics[16] == Catch::Approx(3.0F));   // selected tokens
+    REQUIRE(metrics[17] == Catch::Approx(5.5F));   // replay weight sum
+    REQUIRE(metrics[18] == Catch::Approx(0.0F));   // behavior-likelihood policy samples
+
+    REQUIRE(cudaFree(device_sample_ends) == cudaSuccess);
+    REQUIRE(cudaFree(device_sample_starts) == cudaSuccess);
+    REQUIRE(cudaFree(device_replay_mask) == cudaSuccess);
+    REQUIRE(cudaFree(device_replay_weights) == cudaSuccess);
+    REQUIRE(cudaFree(device_hindsight_mask) == cudaSuccess);
+    REQUIRE(cudaFree(device_loss_mask) == cudaSuccess);
+    REQUIRE(cudaFree(device_hindsight_logprobs) == cudaSuccess);
+    REQUIRE(cudaFree(device_opd_reference_logprobs) == cudaSuccess);
+    REQUIRE(cudaFree(device_teacher_logprobs) == cudaSuccess);
+    REQUIRE(cudaFree(device_advantages) == cudaSuccess);
+    REQUIRE(cudaFree(device_inference_logprobs) == cudaSuccess);
+    REQUIRE(cudaFree(device_losses) == cudaSuccess);
+    REQUIRE(cudaFree(device_metrics) == cudaSuccess);
+    REQUIRE(cudaFree(device_custom_dloss) == cudaSuccess);
+}

--- a/docs/guides/rl-training.md
+++ b/docs/guides/rl-training.md
@@ -318,6 +318,36 @@ The CLI applies `CUDA_VISIBLE_DEVICES=<trainer ids>` to the parent process **bef
 
 In split mode, weight broadcasts use the filesystem backend regardless of what is configured in the YAML. Each broadcast writes the LoRA adapter (~10 MB) to `{output_dir}/broadcasts/step_N/`; vLLM polls for the `STABLE` marker file and hot-reloads the adapter.
 
+### Long sequences: chunked GRPO
+
+Agentic rollouts run far longer than a dense activation budget allows. Setting
+`sequence_chunks: N` in `train.yaml` routes the native GRPO step through the
+chunked path: chunks are forwarded left-to-right to fill the attention KV
+caches, then walked in reverse for the GRPO dloss and backward, accumulating
+dK/dV across chunks. Gradients are exact; memory stays at the single-chunk
+footprint. All-padding tail chunks are detected from the per-sample end offsets
+and skipped.
+
+Pair it with `single_sample_bins: true`. Chunked-training attention carries no
+packed-document isolation, so a row holding several samples would let them
+attend across each other.
+
+```yaml
+# train.yaml
+sequence_len: 6144
+sequence_chunks: 4        # 1536-token chunks
+single_sample_bins: true
+per_device_train_batch_size: 1
+```
+
+### Bounding the importance ratio
+
+`loss.ratio_clip` (default `7.389056`, i.e. e²) caps the importance ratio. The
+IPO mask drops tokens whose probability moved too far, but under periodic
+merged-weight reloads the sampling policy and the trainer policy can diverge
+enough that surviving tokens still carry an extreme ratio. `ratio_clip` bounds
+what any single token can contribute.
+
 ### Reading progress from a log file
 
 The orchestrator's rollout progress bar is `tqdm`, which needs a TTY. Under
@@ -885,6 +915,10 @@ Key orchestrator settings:
 | `buffer.hard_threshold`              | `null`               | Reward threshold below which a problem is "hard"        |
 | `buffer.easy_fraction`               | `0.0`                | Fraction of easy problems to promote to normal on start |
 | `buffer.hard_fraction`               | `0.0`                | Fraction of hard problems to promote to normal on start |
+| `buffer.normal_pool_min_examples`    | `0`                  | Recycle easy/hard examples when normal pool is this low |
+| `buffer.recycle_easy_fraction`       | `0.0`                | Fraction of easy examples recycled when normal is low   |
+| `buffer.recycle_hard_fraction`       | `0.0`                | Fraction of hard examples recycled when normal is low   |
+| `buffer.sample_without_replacement`  | `false`              | Permanently consume an example when its rollout group is scheduled (one-attempt agentic tasks). Cannot be combined with recycling. |
 | `buffer.hash_keys`                   | `["task", "prompt"]` | Keys used for example deduplication                     |
 | `buffer.skip_verification`           | `false`              | If true, disable reward scoring (rewards always 0)      |
 | `buffer.env_ratios`                  | `null`               | Per-environment sampling ratios (list, must sum to >0)  |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -37,7 +37,7 @@ Recomputation trades compute for memory by recomputing activations during the ba
 
 ## Chunked-Sequence Training (long sequences)
 
-Train sequences far longer than activation memory would normally allow by processing the layer stack in fixed-size chunks with attention KV carried across chunks. Memory stays at the single-chunk footprint plus a small KV/state budget (KV is `2 * kv_heads * head_dim` bytes per token per attention layer), while gradients remain exact: backward walks chunks in reverse and accumulates dK/dV in FP32. Trailing all-padding chunks are skipped automatically (nothing attends to them). Works with `sample_packing` (per-document attention across chunk boundaries is preserved, including documents split across rows) and with GDN hybrid models (Qwen3.5/3.6 — the delta-rule recurrent state and causal-conv tail are carried across chunks exactly). Requires `per_device_train_batch_size: 1`, BF16 attention, and `lora_dropout: 0`; CUDA graphs are disabled automatically.
+Train sequences far longer than activation memory would normally allow by processing the layer stack in fixed-size chunks with attention KV carried across chunks. Memory stays at the single-chunk footprint plus a small KV/state budget (KV is `2 * kv_heads * head_dim` bytes per token per attention layer), while gradients remain exact: backward walks chunks in reverse and accumulates dK/dV in FP32. Trailing all-padding chunks are skipped automatically (nothing attends to them). Works with `sample_packing` (per-document attention across chunk boundaries is preserved, including documents split across rows) and with GDN hybrid models (Qwen3.5/3.6 — the delta-rule recurrent state and causal-conv tail are carried across chunks exactly). Requires `per_device_train_batch_size: 1`, BF16 attention, and `lora_dropout: 0`; CUDA graphs are disabled automatically. Applies to GRPO as well as SFT: when `sequence_chunks > 1`, the native GRPO step dispatches to the chunked path, which windows the GRPO dloss per chunk and skips all-padding tail chunks.
 
 | Option            | Type | Default | Description                                                                                                        |
 | ----------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------ |
@@ -443,6 +443,7 @@ than from `datasets`, which is forced empty. See the
 | `max_async_level`       | int    | `1`            | How many steps the orchestrator may run ahead of the trainer. `1` is one step of off-policy staleness. |
 | `pad_to_multiple_of`    | int    | `1`            | Padding multiple for packed micro-batches.                                                       |
 | `doc_masking`           | bool   | `true`         | Document-level attention masking so packed samples cannot attend across each other.              |
+| `single_sample_bins`    | bool   | `false`        | Pack one sample per row instead of filling each row. Chunked-training attention has no packed-doc isolation, so multi-sample rows would let samples attend across each other. |
 | `turn_diagnostics`      | bool   | `false`        | Route the micro-step through the Python loss instead of the fused native step so per-token logprobs are visible. Same gradients, slower — measurement only. |
 
 `gradient_dtype` defaults to `fp32` for GRPO (the per-token gradient is 10-100x
@@ -458,6 +459,7 @@ where it matters comes from `lora_dtype`, which stays `fp32`.
 | `adv_tau`       | float | `1.0`   | Advantage scaling.                                                                |
 | `teacher_tau`   | float | `0.0`   | Weight on the teacher term for on-policy distillation. `0.0` disables it.         |
 | `kl_tau`        | float | `1e-3`  | KL penalty coefficient. Raise if the policy diverges from the reference too fast. |
+| `ratio_clip`    | float | `7.389056` | Hard ceiling on the importance ratio (default e²). Bounds the update when the sampling policy and the trainer policy drift apart — e.g. under periodic merged-weight reloads, where the baseline mismatch is larger than the IPO mask alone can absorb. |
 
 ### QeRL noise scheduler (`noise_scheduler:` block)
 
@@ -495,6 +497,8 @@ save cadence, and the step number weights are broadcast under — so an
 orchestrator already waiting on the step-`S` broadcast is unblocked rather than
 desynchronized. Set `resume_from_checkpoint: false` to force a fresh run.
 
+`adapter_path` is honored by GRPO: the adapter is applied before weight import (`adapter_init_mode: merge`) or loaded as the initial trainable adapter (`adapter_init_mode: trainable`), matching the SFT trainer.
+
 ## Memory Optimization Settings
 
 | Option                     | Type | Default | Description                                                                                               |
@@ -516,6 +520,7 @@ desynchronized. Set `resume_from_checkpoint: false` to force a fresh run.
 | `lora_target_modules` | list   | `["all"]` | List of module names to apply LoRA adapters to.                            |
 | `train_router`        | bool   | `false`   | Train MoE router gate during LoRA fine-tuning. Only applies to MoE models. |
 | `adapter_path`        | string | `null`    | Path to a PEFT adapter directory to merge into base weights before training. Requires `lora: true`. Not supported with pre-quantized models. |
+| `adapter_init_mode`   | string | `"merge"`  | How `adapter_path` is applied: `merge` folds it into the base weights and trains a fresh adapter; `trainable` loads it as the initial trainable adapter and continues training it. Honored by SFT, DPO, and GRPO. |
 | `merge_adapter`       | bool   | `false`   | Whether to merge LoRA adapters into the base model after training.         |
 
 ## MoE Settings

--- a/surogate/_surogate.pyi
+++ b/surogate/_surogate.pyi
@@ -1456,6 +1456,8 @@ class SurogateTrainer:
         - path: Output directory path.
         - base_model_path: Optional path/name of base model for adapter_config.json.
         """
+    def import_adapter(self, file_name: str) -> None:
+        """Import PEFT LoRA weights into the trainable adapter state."""
     def compute_logprobs(
         self,
         input_ids: npt.NDArray[np.int32],
@@ -1630,6 +1632,8 @@ class SurogateTrainer:
 
         Returns: dict with keys {loss: float, norm: float}.
         """
+    def preflight_grpo_native_lora_gradient_norms(self, grad_clip: float) -> list[float]:
+        """Compute each replica's LoRA gradient norm without applying an optimizer update."""
     def train_step_graphed(
         self, inputs: npt.NDArray[np.int32], targets: npt.NDArray[np.int32], config: OptimizerConfig, step: int
     ) -> dict:

--- a/surogate/core/config/grpo_inference_config.py
+++ b/surogate/core/config/grpo_inference_config.py
@@ -41,6 +41,7 @@ class GRPOInferenceConfig:
         max_num_seqs: Maximum number of concurrent sequences. Passed to vLLM as `--max-num-seqs`.
         kv_cache_dtype: KV cache data type, e.g. `fp8`. Passed to vLLM as `--kv-cache-dtype`.
         enforce_eager: Whether to enforce eager mode. Passed to vLLM as `--enforce-eager`.
+        attention_backend: Optional vLLM attention backend override.
         trust_remote_code: Whether to trust remote code. Passed to vLLM engine init.
         enable_auto_tool_choice: Whether to enable auto tool choice. Passed to vLLM as `--enable-auto-tool-choice`.
         tool_call_parser: The tool call parser to use. Passed to vLLM as `--tool-call-parser`.
@@ -71,16 +72,17 @@ class GRPOInferenceConfig:
     dtype: Literal["auto", "float16", "bfloat16", "float32"] | None = "auto"
     max_model_len: int | None = None
     # Concurrency cap. Sizes the CUDA-graph/activation buffers, so it is the
-    # knob that decides whether a big model + LoRA fits: enabling LoRA on a
+    # knob that decides whether a big model + LoRA fits: enabling LoRA on the
     # 27B TP2 server OOMs at the vLLM default and fits at a small value
     # (measured 2026-07-31). Lowering gpu_memory_utilization does NOT help --
     # it shrinks the very budget the allocation draws from.
     max_num_seqs: int | None = None
-    # fp8 KV halves cache bytes/token, raising concurrency on a KV-bound
-    # server. It also perturbs sampled logprobs, which feed GRPO's importance
-    # ratio -- watch mismatch_kl before adopting.
+    # fp8 KV halves cache bytes/token, ~doubling concurrency on a
+    # KV-bound server. It also perturbs sampled logprobs, which feed
+    # GRPO's importance ratio — measure mismatch_kl before adopting.
     kv_cache_dtype: str | None = None
     enforce_eager: bool | None = False
+    attention_backend: str | None = None
     trust_remote_code: bool | None = False
     enable_auto_tool_choice: bool | None = False
     tool_call_parser: str | None = "hermes"
@@ -116,6 +118,7 @@ class GRPOInferenceConfig:
         self.max_num_seqs = cfg.get("max_num_seqs", self.max_num_seqs)
         self.kv_cache_dtype = cfg.get("kv_cache_dtype", self.kv_cache_dtype)
         self.enforce_eager = cfg.get("enforce_eager", self.enforce_eager)
+        self.attention_backend = cfg.get("attention_backend", self.attention_backend)
         self.trust_remote_code = cfg.get("trust_remote_code", self.trust_remote_code)
         self.enable_auto_tool_choice = cfg.get("enable_auto_tool_choice", self.enable_auto_tool_choice)
         self.tool_call_parser = cfg.get("tool_call_parser", self.tool_call_parser)
@@ -162,6 +165,7 @@ class GRPOInferenceConfig:
             "max_num_seqs": "max_num_seqs",
             "kv_cache_dtype": "kv_cache_dtype",
             "enforce_eager": "enforce_eager",
+            "attention_backend": "attention_backend",
             "trust_remote_code": "trust_remote_code",
             "enable_auto_tool_choice": "enable_auto_tool_choice",
             "tool_call_parser": "tool_call_parser",
@@ -191,7 +195,7 @@ class GRPOInferenceConfig:
         # Leave vLLM's own default in place when unset (None is not a valid
         # value for these scalars).
         for _scalar in ("max_num_seqs", "kv_cache_dtype"):
-            if hasattr(namespace, _scalar) and getattr(namespace, _scalar) is None:
+            if getattr(namespace, _scalar, None) is None and hasattr(namespace, _scalar):
                 delattr(namespace, _scalar)
 
         # Remove reasoning_parser if not set (vLLM doesn't accept None)

--- a/surogate/core/config/grpo_orch_config.py
+++ b/surogate/core/config/grpo_orch_config.py
@@ -349,7 +349,12 @@ class GRPOBufferConfig:
         easy_fraction: Fraction of easy problems to convert to normal when resuming or starting training. Only problems with difficulty 'normal' are sampled.
         hard_fraction: Fraction of hard problems to convert to normal when resuming or starting training. Only problems with difficulty 'normal' are sampled.
         online_difficulty_filtering: Whether to filter rollouts based on difficulty. If True, rollouts with average reward 0.0 or 1.0 are not added to the buffer.
+        normal_pool_min_examples: Recycle examples from easy/hard pools when the normal pool has this many examples or fewer.
+        recycle_easy_fraction: Fraction of easy examples to recycle to normal when the normal pool is low.
+        recycle_hard_fraction: Fraction of hard examples to recycle to normal when the normal pool is low.
         hash_keys: Keys to use for computing example hashes. Will be used to match examples from buffer checkpoints and determine buffer resume behavior.
+        sample_without_replacement: Permanently consume an example when its rollout
+            group is scheduled. Intended for one-attempt agentic training tasks.
     """
 
     seed: int | None = None
@@ -359,7 +364,11 @@ class GRPOBufferConfig:
     easy_fraction: float | None = 0.0
     hard_fraction: float | None = 0.0
     online_difficulty_filtering: bool | None = False
+    normal_pool_min_examples: int | None = 0
+    recycle_easy_fraction: float | None = 0.0
+    recycle_hard_fraction: float | None = 0.0
     hash_keys: list[str] | None = field(default_factory=lambda: ["task", "prompt"])
+    sample_without_replacement: bool = False
 
     def __init__(self, cfg: DictDefault):
         self.seed = cfg.get("seed", self.seed)
@@ -369,7 +378,13 @@ class GRPOBufferConfig:
         self.easy_fraction = cfg.get("easy_fraction", self.easy_fraction)
         self.hard_fraction = cfg.get("hard_fraction", self.hard_fraction)
         self.online_difficulty_filtering = cfg.get("online_difficulty_filtering", self.online_difficulty_filtering)
+        self.normal_pool_min_examples = cfg.get("normal_pool_min_examples", self.normal_pool_min_examples)
+        self.recycle_easy_fraction = cfg.get("recycle_easy_fraction", self.recycle_easy_fraction)
+        self.recycle_hard_fraction = cfg.get("recycle_hard_fraction", self.recycle_hard_fraction)
         self.hash_keys = cfg.get("hash_keys", ["task", "prompt"])
+        self.sample_without_replacement = cfg.get(
+            "sample_without_replacement", self.sample_without_replacement
+        )
         self.__post_init__()
 
     def __post_init__(self):
@@ -378,6 +393,30 @@ class GRPOBufferConfig:
 
         if self.env_ratios is not None:
             assert all(ratio > 0 for ratio in self.env_ratios), "All env_ratios must be positive."
+
+        for name, value in [
+            ("easy_fraction", self.easy_fraction),
+            ("hard_fraction", self.hard_fraction),
+            ("recycle_easy_fraction", self.recycle_easy_fraction),
+            ("recycle_hard_fraction", self.recycle_hard_fraction),
+        ]:
+            assert value is not None and 0.0 <= value <= 1.0, f"{name} must be in [0.0, 1.0]."
+
+        assert self.normal_pool_min_examples is not None and self.normal_pool_min_examples >= 0, (
+            "normal_pool_min_examples must be non-negative."
+        )
+        if not isinstance(self.sample_without_replacement, bool):
+            raise ValueError("sample_without_replacement must be boolean")
+        if self.sample_without_replacement and any(
+            value > 0.0
+            for value in (
+                self.recycle_easy_fraction,
+                self.recycle_hard_fraction,
+            )
+        ):
+            raise ValueError(
+                "sample_without_replacement cannot recycle consumed examples"
+            )
 
 
 @dataclass
@@ -924,6 +963,7 @@ class GRPOOrchestratorConfig:
                 self.filters.append(filter_config)
         else:
             self.filters = [GRPOGibberishFilterConfig({}), GRPORepetitionFilterConfig({})]
+
 
         self.log = GRPOLogConfig(cfg.get("log", {}))
 

--- a/surogate/core/config/sft_config.py
+++ b/surogate/core/config/sft_config.py
@@ -445,7 +445,8 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
     ep_plan_refresh_interval: int | None = 16  # LLEP sticky plans: recompute LPT every N steps (1 = every step)
     sequence_chunks: int | None = 1  # KV-checkpointed chunked training: process sequence_len as N chunks (1 = off)
 
-    adapter_path: str | None = None  # PEFT adapter dir to merge into base weights before training
+    adapter_path: str | None = None  # PEFT adapter used to initialize the training run
+    adapter_init_mode: Literal["merge", "trainable"] = "merge"
     merge_adapter: bool | None = False
 
     debug_time_breakdown: bool | None = False
@@ -593,6 +594,9 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
         self.sequence_chunks = int(cfg.get("sequence_chunks", self.sequence_chunks or 1))
 
         self.adapter_path = cfg.get("adapter_path", self.adapter_path)
+        self.adapter_init_mode = cfg.get("adapter_init_mode", self.adapter_init_mode)
+        if self.adapter_init_mode not in {"merge", "trainable"}:
+            raise ValueError("adapter_init_mode must be 'merge' or 'trainable'")
         self.merge_adapter = cfg.get("merge_adapter", self.merge_adapter)
         # use_chat_template removed — native tokenizer always applies chat template
         self.debug_time_breakdown = cfg.get("debug_time_breakdown", self.debug_time_breakdown)
@@ -1193,11 +1197,12 @@ class SFTConfig(ModelConfig, TrainDatasetConfig):
             )
 
         # Validate: adapter_path + pre-quantized = error
-        if self.adapter_path and is_prequantized:
+        if self.adapter_path and is_prequantized and self.adapter_init_mode == "merge":
             raise ValueError(
                 f"Cannot merge adapter into a pre-quantized model ({prequant_method}). "
                 "Pre-quantized weights are loaded directly without BF16 intermediate stage, "
-                "so adapter merging is not supported. Merge the adapter offline first."
+                "so adapter merging is not supported. Use adapter_init_mode: trainable "
+                "to continue the adapter without modifying the frozen base."
             )
 
         # Validate: adapter_path requires lora

--- a/surogate/grpo/batch.py
+++ b/surogate/grpo/batch.py
@@ -73,19 +73,31 @@ def prepare_sample(training_example: TrainingSample, seq_len: int) -> MicroBatch
 
 
 def packed_samples_into_micro_bs(
-    samples: list[tuple[int, MicroBatch]], max_seq_len: int, num_loras: int
+    samples: list[tuple[int, MicroBatch]],
+    max_seq_len: int,
+    num_loras: int,
+    single_sample_bins: bool = False,
 ) -> list[MicroBatch]:
     """Pack samples into micro-batches using First Fit Decreasing.
 
     Minimizes padding while never truncating. Multimodal samples are
     NOT packed together (variable-sized vision data).
+
+    `single_sample_bins` disables packing entirely — one sample per
+    micro-batch. Required for chunked-sequence GRPO: packed-document
+    isolation does not exist in the chunked TRAINING attention path
+    (kvprefix doc metadata is eval-only), so multi-sample rows would
+    attend across sample boundaries (measured 2026-07-27: B-grad cosine
+    0.5 vs unchunked). Tail padding chunks are skipped natively, so the
+    cost is bounded by pad_to_multiple_of, not seq_len.
     """
     samples.sort(key=lambda x: (x[0], -len(x[1].input_ids)))
 
     micro_batches: list[MicroBatch] = []
 
     for idx, sample in samples:
-        for bin_content in micro_batches:
+        bins = [] if single_sample_bins else micro_batches
+        for bin_content in bins:
             if len(bin_content.input_ids) + len(sample.input_ids) <= max_seq_len:
                 bin_len_before = len(bin_content.input_ids)
                 bin_content.input_ids.extend(sample.input_ids)
@@ -145,6 +157,7 @@ def prepare_batch(
     idxs: list[int],
     num_loras: int,
     pad_to_multiple_of: int = 1,
+    single_sample_bins: bool = False,
 ) -> list[list[MicroBatch]]:
     """Prepare a batch of samples for each data-parallel worker.
 
@@ -153,7 +166,8 @@ def prepare_batch(
     """
     all_samples = [(idx, prepare_sample(rollout, seq_len)) for idx, rollout in zip(idxs, rollouts)]
 
-    micro_batches = packed_samples_into_micro_bs(all_samples, seq_len, num_loras)
+    micro_batches = packed_samples_into_micro_bs(
+        all_samples, seq_len, num_loras, single_sample_bins=single_sample_bins)
     micro_batches = [pad_micro_batch(micro_batch, pad_to_multiple_of) for micro_batch in micro_batches]
 
     num_padding_batch = -len(micro_batches) % num_train_workers

--- a/surogate/grpo/config.py
+++ b/surogate/grpo/config.py
@@ -24,6 +24,20 @@ class GRPOLossConfig:
     adv_tau: float = 1.0
     teacher_tau: float = 0.0
     kl_tau: float = 1e-3  # The tau for KL divergence
+    # OPD / replay knobs used by the reference loss (surogate/grpo/loss.py);
+    # off by default. These fields were referenced by loss.py and its tests
+    # but never added here (pre-existing gap, fixed 2026-07-27).
+    opd_tau: float = 0.0
+    opd_beta: float = 1.0
+    replay_tau: float = 0.0
+    # Hard cap on exp(trainer - inference) in the policy-gradient seed. The
+    # IPO probability-difference mask does NOT bound the ratio: a rare token
+    # (both probs tiny, trainer >> inference in ratio terms) passes the mask
+    # with a ratio of 1e3-1e5 and dominates the batch gradient. e^2 keeps
+    # ~all honest off-policy correction (periodic-reload staleness) while
+    # bounding single-token influence. Uncapped values still feed the
+    # mismatch_kl metric so staleness monitoring sees the truth.
+    ratio_clip: float = 7.389056  # e^2
 
 
 @dataclass
@@ -65,6 +79,11 @@ class GRPOTrainConfig(SFTConfig):
     max_async_level: int = 1
     # Padding multiple for packed micro-batches.
     pad_to_multiple_of: int = 1
+    # One sample per micro-batch (disables FFD packing). REQUIRED with
+    # sequence_chunks > 1: chunked training attention has no packed-doc
+    # isolation. Pair with pad_to_multiple_of = chunk size; all-padding
+    # tail chunks are skipped natively.
+    single_sample_bins: bool = False
     # Document-level attention masking for packed sequences.
     doc_masking: bool = True
     # Turn-resolved supervision diagnostics (TurnOPD arXiv:2607.05804 §4).
@@ -125,6 +144,7 @@ class GRPOTrainConfig(SFTConfig):
             self.noise_scheduler = NoiseSchedulerConfig()
 
         self.transport_type = cfg.get("transport_type", self.transport_type)
+        self.single_sample_bins = bool(cfg.get("single_sample_bins", self.single_sample_bins))
         self.weight_broadcast_type = cfg.get("weight_broadcast_type", self.weight_broadcast_type)
         self.max_async_level = cfg.get("max_async_level", self.max_async_level)
         self.pad_to_multiple_of = cfg.get("pad_to_multiple_of", self.pad_to_multiple_of)

--- a/surogate/grpo/inference/patches.py
+++ b/surogate/grpo/inference/patches.py
@@ -395,11 +395,17 @@ def monkey_patch_tokenizer_thread_safety():
 
 
 def _patch_qwen35_lora():
-    """Fix Qwen3.5 LoRA: align packed_modules_mapping with output_sizes.
+    """Fix Qwen3.5 LoRA loading and packed-module alignment.
 
     Qwen3.5's GDN layers use create_qkvz_proj with 4 output_sizes (q, k, v, z)
     but packed_modules_mapping only lists 2 entries, causing an IndexError
     during LoRA initialization.
+
+    PEFT adapters trained through the text-only Qwen3.5 wrapper use
+    ``model.layers.*`` keys.  The full conditional-generation wrapper nests
+    those same modules at ``language_model.model.layers.*``.  Extend its
+    weight mapper so vLLM attaches the canonical adapter tensors to the actual
+    runtime modules instead of silently leaving every LoRA wrapper at zero.
 
     Also generalizes MergedColumnParallelLinearWithLoRA.can_replace_layer
     to accept any number of packed modules (not just 2), and generalizes
@@ -416,11 +422,20 @@ def _patch_qwen35_lora():
         Qwen3_5ForCausalLMBase,
         Qwen3_5ForConditionalGeneration,
     )
+    from vllm.model_executor.models.utils import WeightsMapper
 
     qkvz_fix = ["in_proj_q", "in_proj_k", "in_proj_v", "in_proj_z"]
 
     Qwen3_5ForCausalLMBase.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
     Qwen3_5ForConditionalGeneration.packed_modules_mapping["in_proj_qkvz"] = qkvz_fix
+    Qwen3_5ForConditionalGeneration.hf_to_vllm_mapper = (
+        Qwen3_5ForConditionalGeneration.hf_to_vllm_mapper
+        | WeightsMapper(
+            orig_to_new_prefix={
+                "model.layers.": "language_model.model.layers.",
+            }
+        )
+    )
 
     from vllm.lora.layers.utils import _not_fully_sharded_can_replace
 

--- a/surogate/grpo/loss.py
+++ b/surogate/grpo/loss.py
@@ -15,6 +15,12 @@ def _safe_mean(values: np.ndarray, mask: np.ndarray) -> float:
     return float(values[mask].sum() / denom)
 
 
+def _sigmoid(values: np.ndarray) -> np.ndarray:
+    """Numerically stable sigmoid for detached SEED confidence gates."""
+    clipped = np.clip(values, -60.0, 60.0)
+    return 1.0 / (1.0 + np.exp(-clipped))
+
+
 def _compute_sample_grads(
     trainer_logprobs: np.ndarray,
     inference_logprobs: np.ndarray,
@@ -22,6 +28,11 @@ def _compute_sample_grads(
     loss_mask: np.ndarray,
     loss_config: GRPOLossConfig,
     teacher_logprobs: np.ndarray | None = None,
+    opd_reference_logprobs: np.ndarray | None = None,
+    hindsight_logprobs: np.ndarray | None = None,
+    hindsight_mask: np.ndarray | None = None,
+    replay_mask: np.ndarray | None = None,
+    replay_weights: np.ndarray | None = None,
 ) -> tuple[np.ndarray, dict[str, float]]:
     """Compute IPO per-token gradient multipliers for a single sample.
 
@@ -36,12 +47,36 @@ def _compute_sample_grads(
         loss_mask: [S] bool mask (True = completion token, False = prompt)
         loss_config: GRPO loss hyperparameters
         teacher_logprobs: [S] optional teacher log-probs for this sample
+        opd_reference_logprobs: [S] ordinary-branch log-probs from the matched deterministic scorer
+        hindsight_logprobs: [S] skill-conditioned log-probs aligned to sampled tokens
+        hindsight_mask: [S] bool mask selecting conductor tokens with valid hindsight scores
+        replay_mask: [S] bool mask selecting train-split parent-action rehearsal tokens
+        replay_weights: [S] optional positive CE multipliers on replay tokens
 
     Returns:
         (per_token_grads [S], metrics dict)
     """
+    replay_token_mask = np.zeros_like(loss_mask, dtype=bool)
+    if replay_mask is not None:
+        replay_token_mask = loss_mask & replay_mask.astype(bool)
+    policy_token_mask = loss_mask & ~replay_token_mask
+    replay_token_weights = np.ones_like(trainer_logprobs, dtype=np.float32)
+    if replay_weights is not None:
+        replay_token_weights = np.asarray(replay_weights, dtype=np.float32)
+        if replay_token_weights.shape != trainer_logprobs.shape:
+            raise ValueError("replay_weights must match trainer_logprobs shape")
+        if not np.isfinite(replay_token_weights).all():
+            raise ValueError("replay_weights must be finite")
+        if np.any(replay_token_weights[replay_token_mask] <= 0.0):
+            raise ValueError("replay_weights must be positive on replay tokens")
+        if np.any(replay_token_weights[~replay_token_mask] != 1.0):
+            raise ValueError("replay_weights may differ from 1 only on replay tokens")
+
     log_importance_ratio = trainer_logprobs - inference_logprobs
     importance_ratio = np.exp(log_importance_ratio)
+    # Gradient-side ratio cap (see GRPOLossConfig.ratio_clip). Metrics below
+    # (mismatch_kl) keep the UNCAPPED ratio: monitoring must see real drift.
+    capped_ratio = np.minimum(importance_ratio, loss_config.ratio_clip)
 
     # IPO masking based on probability difference (DPPO-Binary TV)
     trainer_probs = np.exp(trainer_logprobs)
@@ -50,7 +85,7 @@ def _compute_sample_grads(
     ipo_mask_high = probs_diff > loss_config.ipo_mask_high
     ipo_mask_low = probs_diff < -loss_config.ipo_mask_low
     is_masked = ipo_mask_high | ipo_mask_low
-    keep_mask = loss_mask & ~is_masked
+    keep_mask = policy_token_mask & ~is_masked
 
     # KL mismatch (for metrics)
     mismatch_kl = importance_ratio - log_importance_ratio - 1.0
@@ -69,31 +104,72 @@ def _compute_sample_grads(
     # We need dloss = -d(loss)/d(trainer_logprob_t), giving:
     #   dloss = keep_mask_t * adv_t * ratio_t - 2 * kl_tau * loss_mask_t * log_ratio_t
     per_token_grads = np.zeros_like(trainer_logprobs)
-    per_token_grads[keep_mask] = scaled_advantages[keep_mask] * importance_ratio[keep_mask]
-    per_token_grads[loss_mask] -= 2.0 * loss_config.kl_tau * log_importance_ratio[loss_mask]
+    per_token_grads[keep_mask] = scaled_advantages[keep_mask] * capped_ratio[keep_mask]
+    per_token_grads[policy_token_mask] -= 2.0 * loss_config.kl_tau * log_importance_ratio[policy_token_mask]
+
+    opd_fields = (opd_reference_logprobs, hindsight_logprobs, hindsight_mask)
+    if any(value is not None for value in opd_fields) and any(value is None for value in opd_fields):
+        raise ValueError("opd_reference_logprobs, hindsight_logprobs, and hindsight_mask must be provided together")
+    opd_mask = np.zeros_like(loss_mask, dtype=bool)
+    opd_shift = np.zeros_like(trainer_logprobs)
+    opd_gate = np.zeros_like(trainer_logprobs)
+    if opd_reference_logprobs is not None and hindsight_logprobs is not None and hindsight_mask is not None:
+        opd_mask = policy_token_mask & hindsight_mask.astype(bool)
+        # Both detached branches must come from one deterministic scorer loaded
+        # with the same parent adapter. Rollout logprobs remain independent and
+        # are used only for the on-policy importance ratio above.
+        opd_shift = hindsight_logprobs - opd_reference_logprobs
+        opd_gate = _sigmoid(loss_config.opd_beta * opd_shift)
+        # The gate and privileged branch are detached. Positive CE seeds increase
+        # ordinary-context likelihood only on conductor tokens selected by opd_mask.
+        per_token_grads[opd_mask] += loss_config.opd_tau * opd_gate[opd_mask]
+
+    if replay_mask is not None:
+        # Replay is explicit behavior rehearsal, independent of outcome
+        # advantages, behavior-policy importance ratios, KL, and privileged
+        # hindsight. It keeps known-good parent actions on the ordinary prompt
+        # surface even when replay scores are stale or deliberately absent.
+        per_token_grads[replay_token_mask] += loss_config.replay_tau * replay_token_weights[replay_token_mask]
 
     # Policy loss metric
     loss_mask_count = max(loss_mask.sum(), 1)
     pg_loss = np.zeros_like(trainer_logprobs)
-    pg_loss[keep_mask] = scaled_advantages[keep_mask] * importance_ratio[keep_mask]
+    pg_loss[keep_mask] = scaled_advantages[keep_mask] * capped_ratio[keep_mask]
     kl_loss = np.zeros_like(trainer_logprobs)
-    kl_loss[loss_mask] = loss_config.kl_tau * log_importance_ratio[loss_mask] ** 2
-    policy_loss = float((-pg_loss + kl_loss).sum() / loss_mask_count)
+    kl_loss[policy_token_mask] = loss_config.kl_tau * log_importance_ratio[policy_token_mask] ** 2
+    opd_loss = np.zeros_like(trainer_logprobs)
+    opd_loss[opd_mask] = -loss_config.opd_tau * opd_gate[opd_mask] * trainer_logprobs[opd_mask]
+    replay_loss = np.zeros_like(trainer_logprobs)
+    replay_loss[replay_token_mask] = (
+        -loss_config.replay_tau * replay_token_weights[replay_token_mask] * trainer_logprobs[replay_token_mask]
+    )
+    policy_loss = float((-pg_loss + kl_loss + opd_loss + replay_loss).sum() / loss_mask_count)
 
     metrics = {
         "policy_loss": policy_loss,
-        "mismatch_kl": _safe_mean(mismatch_kl, loss_mask),
-        "masked_mismatch_kl": _safe_mean(mismatch_kl, loss_mask & is_masked),
+        "mismatch_kl": _safe_mean(mismatch_kl, policy_token_mask),
+        "masked_mismatch_kl": _safe_mean(mismatch_kl, policy_token_mask & is_masked),
         "unmasked_mismatch_kl": _safe_mean(mismatch_kl, keep_mask),
-        "is_masked": float(is_masked[loss_mask].mean()) if loss_mask.any() else 0.0,
-        "is_masked_low": float(ipo_mask_low[loss_mask].mean()) if loss_mask.any() else 0.0,
-        "is_masked_high": float(ipo_mask_high[loss_mask].mean()) if loss_mask.any() else 0.0,
+        "is_masked": (float(is_masked[policy_token_mask].mean()) if policy_token_mask.any() else 0.0),
+        "is_masked_low": (float(ipo_mask_low[policy_token_mask].mean()) if policy_token_mask.any() else 0.0),
+        "is_masked_high": (float(ipo_mask_high[policy_token_mask].mean()) if policy_token_mask.any() else 0.0),
         "keep_tokens": int(keep_mask.sum()),
         "total_tokens": int(loss_mask.sum()),
+        "ratio_clipped": (
+            float((importance_ratio[keep_mask]
+                   > loss_config.ratio_clip).mean())
+            if keep_mask.any() else 0.0),
+        "opd_loss": _safe_mean(opd_loss, opd_mask),
+        "opd_gate": _safe_mean(opd_gate, opd_mask),
+        "opd_shift": _safe_mean(opd_shift, opd_mask),
+        "opd_tokens": int(opd_mask.sum()),
+        "replay_loss": _safe_mean(replay_loss, replay_token_mask),
+        "replay_tokens": int(replay_token_mask.sum()),
+        "replay_weight_sum": float(replay_token_weights[replay_token_mask].sum()),
     }
 
     if teacher_logprobs is not None:
-        metrics["teacher_kl"] = _safe_mean(teacher_logprobs - trainer_logprobs, loss_mask)
+        metrics["teacher_kl"] = _safe_mean(teacher_logprobs - trainer_logprobs, policy_token_mask)
 
     return per_token_grads, metrics
 
@@ -106,6 +182,11 @@ def compute_grpo_per_token_grads(
     loss_config: GRPOLossConfig,
     sample_ranges: list[tuple[int, int]],
     teacher_logprobs: np.ndarray | None = None,
+    opd_reference_logprobs: np.ndarray | None = None,
+    hindsight_logprobs: np.ndarray | None = None,
+    hindsight_mask: np.ndarray | None = None,
+    replay_mask: np.ndarray | None = None,
+    replay_weights: np.ndarray | None = None,
 ) -> tuple[np.ndarray, dict[str, float]]:
     """Compute GRPO per-token gradient multipliers for a packed batch.
 
@@ -124,6 +205,11 @@ def compute_grpo_per_token_grads(
         loss_config: GRPO loss hyperparameters
         sample_ranges: list of (start, end) tuples for each sample in the packed sequence
         teacher_logprobs: [T] optional teacher log-probs for KL distillation
+        opd_reference_logprobs: [T] optional ordinary matched-branch log-probs
+        hindsight_logprobs: [T] optional skill-conditioned log-probs
+        hindsight_mask: [T] optional mask for valid conductor-token OPD targets
+        replay_mask: [T] optional mask for train-split parent-action rehearsal
+        replay_weights: [T] optional positive CE multipliers on replay tokens
 
     Returns:
         (per_token_grads [T], aggregated metrics dict)
@@ -140,8 +226,17 @@ def compute_grpo_per_token_grads(
         "is_masked": 0.0,
         "is_masked_low": 0.0,
         "is_masked_high": 0.0,
+        "ratio_clipped": 0.0,
         "keep_tokens": 0,
         "total_tokens": 0,
+        "opd_loss": 0.0,
+        "opd_gate": 0.0,
+        "opd_shift": 0.0,
+        "opd_tokens": 0,
+        "replay_loss": 0.0,
+        "replay_tokens": 0,
+        "replay_weight_sum": 0.0,
+        "policy_sample_count": 0,
     }
     n_samples = 0
 
@@ -151,6 +246,11 @@ def compute_grpo_per_token_grads(
             continue
 
         s_teacher = teacher_logprobs[s_start:s_end] if teacher_logprobs is not None else None
+        s_opd_reference = opd_reference_logprobs[s_start:s_end] if opd_reference_logprobs is not None else None
+        s_hindsight = hindsight_logprobs[s_start:s_end] if hindsight_logprobs is not None else None
+        s_hindsight_mask = hindsight_mask[s_start:s_end] if hindsight_mask is not None else None
+        s_replay_mask = replay_mask[s_start:s_end] if replay_mask is not None else None
+        s_replay_weights = replay_weights[s_start:s_end] if replay_weights is not None else None
 
         s_grads, s_metrics = _compute_sample_grads(
             trainer_logprobs=trainer_logprobs[s_start:s_end],
@@ -159,43 +259,68 @@ def compute_grpo_per_token_grads(
             loss_mask=s_loss_mask,
             loss_config=loss_config,
             teacher_logprobs=s_teacher,
+            opd_reference_logprobs=s_opd_reference,
+            hindsight_logprobs=s_hindsight,
+            hindsight_mask=s_hindsight_mask,
+            replay_mask=s_replay_mask,
+            replay_weights=s_replay_weights,
         )
 
         per_token_grads[s_start:s_end] = s_grads
         n_samples += 1
 
         # Accumulate metrics
-        for key in (
-            "policy_loss",
-            "mismatch_kl",
-            "masked_mismatch_kl",
-            "unmasked_mismatch_kl",
-            "is_masked",
-            "is_masked_low",
-            "is_masked_high",
-        ):
-            agg_metrics[key] += s_metrics[key]
+        agg_metrics["policy_loss"] += s_metrics["policy_loss"]
+        policy_tokens = s_metrics["total_tokens"] - s_metrics["replay_tokens"]
+        if policy_tokens > 0:
+            agg_metrics["policy_sample_count"] += 1
+            for key in (
+                "mismatch_kl",
+                "masked_mismatch_kl",
+                "unmasked_mismatch_kl",
+                "is_masked",
+                "is_masked_low",
+                "is_masked_high",
+                "ratio_clipped",
+            ):
+                agg_metrics[key] += s_metrics[key]
+        for key in ("opd_loss", "opd_gate", "opd_shift"):
+            agg_metrics[key] += s_metrics[key] * s_metrics["opd_tokens"]
+        agg_metrics["replay_loss"] += s_metrics["replay_loss"] * s_metrics["replay_tokens"]
         agg_metrics["keep_tokens"] += s_metrics["keep_tokens"]
         agg_metrics["total_tokens"] += s_metrics["total_tokens"]
+        agg_metrics["opd_tokens"] += s_metrics["opd_tokens"]
+        agg_metrics["replay_tokens"] += s_metrics["replay_tokens"]
+        agg_metrics["replay_weight_sum"] += s_metrics["replay_weight_sum"]
 
-        if s_teacher is not None and "teacher_kl" in s_metrics:
+        if policy_tokens > 0 and s_teacher is not None and "teacher_kl" in s_metrics:
             agg_metrics.setdefault("teacher_kl", 0.0)
             agg_metrics["teacher_kl"] += s_metrics["teacher_kl"]
 
-    # Average float metrics over samples
+    # Policy loss includes both policy and CE-only replay rows, but
+    # behavior-likelihood metrics must never be diluted by replay-only rows.
     if n_samples > 0:
+        agg_metrics["policy_loss"] /= n_samples
+    policy_samples = agg_metrics["policy_sample_count"]
+    if policy_samples > 0:
         for key in (
-            "policy_loss",
             "mismatch_kl",
             "masked_mismatch_kl",
             "unmasked_mismatch_kl",
             "is_masked",
             "is_masked_low",
             "is_masked_high",
+            "ratio_clipped",
         ):
-            agg_metrics[key] /= n_samples
+            agg_metrics[key] /= policy_samples
         if "teacher_kl" in agg_metrics:
-            agg_metrics["teacher_kl"] /= n_samples
+            agg_metrics["teacher_kl"] /= policy_samples
+    if n_samples > 0:
+        if agg_metrics["opd_tokens"] > 0:
+            for key in ("opd_loss", "opd_gate", "opd_shift"):
+                agg_metrics[key] /= agg_metrics["opd_tokens"]
+        if agg_metrics["replay_tokens"] > 0:
+            agg_metrics["replay_loss"] /= agg_metrics["replay_tokens"]
 
     return per_token_grads, agg_metrics
 
@@ -208,6 +333,11 @@ def compute_native_shifted_grpo_dloss_reference(
     loss_config: GRPOLossConfig,
     sample_ranges: list[tuple[int, int]],
     teacher_logprobs: np.ndarray | None = None,
+    opd_reference_logprobs: np.ndarray | None = None,
+    hindsight_logprobs: np.ndarray | None = None,
+    hindsight_mask: np.ndarray | None = None,
+    replay_mask: np.ndarray | None = None,
+    replay_weights: np.ndarray | None = None,
     loss_scale: float = 1.0,
 ) -> np.ndarray:
     """Reference for the native CUDA GRPO dloss layout.
@@ -225,6 +355,11 @@ def compute_native_shifted_grpo_dloss_reference(
         loss_config=loss_config,
         sample_ranges=sample_ranges,
         teacher_logprobs=teacher_logprobs,
+        opd_reference_logprobs=opd_reference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=hindsight_mask,
+        replay_mask=replay_mask,
+        replay_weights=replay_weights,
     )
     shifted = np.zeros_like(per_token_grads)
     for start, end in sample_ranges:
@@ -243,6 +378,11 @@ def compute_native_grpo_metrics_reference(
     loss_config: GRPOLossConfig,
     sample_ranges: list[tuple[int, int]],
     teacher_logprobs: np.ndarray | None = None,
+    opd_reference_logprobs: np.ndarray | None = None,
+    hindsight_logprobs: np.ndarray | None = None,
+    hindsight_mask: np.ndarray | None = None,
+    replay_mask: np.ndarray | None = None,
+    replay_weights: np.ndarray | None = None,
 ) -> dict[str, float]:
     """Reference metrics for the native GRPO CUDA accumulator."""
     _, metrics = compute_grpo_per_token_grads(
@@ -253,5 +393,10 @@ def compute_native_grpo_metrics_reference(
         loss_config=loss_config,
         sample_ranges=sample_ranges,
         teacher_logprobs=teacher_logprobs,
+        opd_reference_logprobs=opd_reference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=hindsight_mask,
+        replay_mask=replay_mask,
+        replay_weights=replay_weights,
     )
     return metrics

--- a/surogate/grpo/orchestrator/advantage.py
+++ b/surogate/grpo/orchestrator/advantage.py
@@ -45,6 +45,19 @@ def default_advantage_fn(inputs: AdvantageInputs, length_weighted_mean: bool = F
     return AdvantageOutputs(advantages=inputs.rewards - baseline)
 
 
+def std_normalized_advantage(inputs: AdvantageInputs, eps: float = 1e-4) -> AdvantageOutputs:
+    """GRPO advantage with per-group std normalization: A = (r - mean) / (std + eps).
+
+    Matches Shao et al. (2024) eq. 4 as used by the Conductor (Nielsen et al., 2025, eq. 2):
+    the group baseline is the mean and the residual is scaled by the group's reward std,
+    so nearly-uniform groups still yield unit-scale advantages. Zero-variance groups get
+    zero advantage from the mean subtraction; eps only guards the division.
+    """
+    mean = inputs.rewards.mean(dim=1, keepdim=True)
+    std = inputs.rewards.std(dim=1, keepdim=True)
+    return AdvantageOutputs(advantages=(inputs.rewards - mean) / (std + eps))
+
+
 def setup_advantage_fn(config: AdvantageConfigType) -> AdvantageFn:
     """Setup advantage function from config."""
     if isinstance(config, GRPOCustomAdvantageConfig):

--- a/surogate/grpo/orchestrator/buffer.py
+++ b/surogate/grpo/orchestrator/buffer.py
@@ -72,6 +72,7 @@ class Buffer:
         # Initialize buffers for easy/ hard examples
         self.easy_examples: list[dict] = []
         self.hard_examples: list[dict] = []
+        self.consumed_examples: list[dict] = []
 
         # Initialize rollout buffer (flat list of rollouts)
         self.rollout_buffer: list[vf.RolloutOutput] = []
@@ -95,6 +96,7 @@ class Buffer:
 
         write_jsonl(self.easy_examples, path / "easy_examples.jsonl")
         write_jsonl(self.hard_examples, path / "hard_examples.jsonl")
+        write_jsonl(self.consumed_examples, path / "consumed_examples.jsonl")
         write_jsonl(self.rollout_buffer, path / "rollout_buffer.jsonl")
 
     def load(self, path: Path) -> None:
@@ -106,9 +108,22 @@ class Buffer:
 
         saved_easy_examples = read_jsonl(path / "easy_examples.jsonl")
         saved_hard_examples = read_jsonl(path / "hard_examples.jsonl")
+        consumed_path = path / "consumed_examples.jsonl"
+        if self.config.sample_without_replacement and not consumed_path.is_file():
+            raise ValueError(
+                "one-use buffer checkpoint has no consumed_examples.jsonl ledger"
+            )
+        saved_consumed_examples = (
+            read_jsonl(consumed_path) if consumed_path.is_file() else []
+        )
         saved_rollout_buffer = cast(list[vf.RolloutOutput], read_jsonl(path / "rollout_buffer.jsonl"))
 
-        if any(saved_easy_examples) or any(saved_hard_examples) or any(saved_rollout_buffer):
+        if (
+            any(saved_easy_examples)
+            or any(saved_hard_examples)
+            or any(saved_consumed_examples)
+            or any(saved_rollout_buffer)
+        ):
             # Build hash lookup for example buffer (env -> (example_hash -> example_id))
             example_hash_lookup = defaultdict(dict)
             all_hashes = set()
@@ -155,6 +170,19 @@ class Buffer:
                         f"Could not move {num_not_moved} example(s) from checkpoint to hard pool. This usually means you resumed with an env mix that does not contain all previous examples."
                     )
 
+            if any(saved_consumed_examples):
+                num_moved = move_saved_pool(
+                    saved_consumed_examples,
+                    self.consumed_examples,
+                )
+                if num_moved != len(saved_consumed_examples):
+                    raise ValueError(
+                        "one-use buffer checkpoint does not match the current dataset"
+                    )
+                logger.debug(
+                    f"Restored {num_moved} consumed one-use example(s) from checkpoint."
+                )
+
             if any(saved_rollout_buffer):
                 # Extend rollout buffer, but only include rollouts for which the example still exists in the example buffer
                 valid_saved_rollouts = [
@@ -164,32 +192,79 @@ class Buffer:
                 logger.debug(f"Loaded {len(valid_saved_rollouts)} rollout(s) from checkpoint.")
 
             # Load rollouts, filtering out removed environments and problems
-            def convert_examples_to_normal(examples: list[dict], fraction: float) -> int:
-                """Moves a fraction of examples from the given pool back to normal."""
-                if fraction <= 0.0 or not examples:
-                    return 0
-                num_moved = round(len(examples) * fraction)
-                if num_moved <= 0:
-                    return 0
-                for _ in range(num_moved):
-                    example = random.choice(examples)
-                    env_name = example["task"]
-                    example_id = example["example_id"]
-                    examples.remove(example)
-                    self.example_buffer[env_name][example_id] = example
-                return num_moved
-
             num_easy_examples = len(self.easy_examples)
-            num_moved = convert_examples_to_normal(self.easy_examples, self.config.easy_fraction)
+            num_moved = self._move_examples_to_normal(self.easy_examples, self.config.easy_fraction)
             logger.debug(f"Converted {num_moved}/{num_easy_examples} example(s) back to normal from easy pool.")
             num_hard_examples = len(self.hard_examples)
-            num_moved = convert_examples_to_normal(self.hard_examples, self.config.hard_fraction)
+            num_moved = self._move_examples_to_normal(self.hard_examples, self.config.hard_fraction)
             logger.debug(f"Converted {num_moved}/{num_hard_examples} example(s) back to normal from hard pool.")
         else:
             logger.debug("No easy/ hard examples or rollouts found in checkpoint")
 
+    def _normal_example_count(self) -> int:
+        return sum(len(examples) for examples in self.example_buffer.values())
+
+    def _move_examples_to_normal(self, examples: list[dict], fraction: float | None) -> int:
+        """Moves a fraction of examples from an easy/hard pool back to normal."""
+        if fraction is None or fraction <= 0.0 or not examples:
+            return 0
+        num_moved = round(len(examples) * fraction)
+        if num_moved <= 0:
+            num_moved = 1
+        num_moved = min(num_moved, len(examples))
+        for _ in range(num_moved):
+            example = random.choice(examples)
+            env_name = example["task"]
+            example_id = example["example_id"]
+            examples.remove(example)
+            self.example_buffer[env_name][example_id] = example
+        return num_moved
+
+    def _recycle_examples_if_needed(self) -> None:
+        min_normal = self.config.normal_pool_min_examples or 0
+        if self._normal_example_count() > min_normal:
+            return
+
+        moved_easy = self._move_examples_to_normal(self.easy_examples, self.config.recycle_easy_fraction)
+        moved_hard = self._move_examples_to_normal(self.hard_examples, self.config.recycle_hard_fraction)
+        self.recycled_examples_per_step["easy"] += moved_easy
+        self.recycled_examples_per_step["hard"] += moved_hard
+
+        if moved_easy or moved_hard:
+            logger.info(
+                "Recycled %d easy and %d hard example(s) into the normal pool "
+                "(normal=%d, easy=%d, hard=%d)",
+                moved_easy,
+                moved_hard,
+                self._normal_example_count(),
+                len(self.easy_examples),
+                len(self.hard_examples),
+            )
+
     def sample_examples(self, n: int) -> list[dict]:
         """Samples n examples from the buffer, respecting env ratios."""
+
+        self._recycle_examples_if_needed()
+        if self.config.sample_without_replacement:
+            sampled_examples = []
+            for _ in range(n):
+                non_empty_envs = [
+                    env for env, examples in self.example_buffer.items() if examples
+                ]
+                if not non_empty_envs:
+                    raise ValueError("No environments left with examples.")
+                sampled_env = random.choices(
+                    non_empty_envs,
+                    weights=[self.env_probs[env] for env in non_empty_envs],
+                    k=1,
+                )[0]
+                sampled_example = random.choice(
+                    list(self.example_buffer[sampled_env].values())
+                )
+                self.example_buffer[sampled_env].pop(sampled_example["example_id"])
+                self.consumed_examples.append(sampled_example)
+                sampled_examples.append(sampled_example)
+            return sampled_examples
 
         non_empty_envs = [env for env, examples in self.example_buffer.items() if examples]
 
@@ -253,6 +328,7 @@ class Buffer:
         self.num_examples_per_step = {env: zero_per_pool() for env in self.env_names}
         # num rollouts per env per step per pool (env_name -> (pool -> num_rollouts))
         self.num_rollouts_per_step = {env: zero_per_pool() for env in self.env_names}
+        self.recycled_examples_per_step = {"easy": 0, "hard": 0}
 
     def get_metrics(self) -> dict[str, float]:
         """Returns the buffer metrics for the current step."""
@@ -280,6 +356,9 @@ class Buffer:
         pool_ratios = mean_normalize(pool_counts)
         for pool, pool_ratio in zip(self.POOLS, pool_ratios):
             metrics[f"pool/{pool}"] = pool_ratio
+
+        for pool in ["easy", "hard"]:
+            metrics[f"recycled_examples/{pool}"] = self.recycled_examples_per_step[pool]
 
         self.reset_step_metrics()
 

--- a/surogate/grpo/orchestrator/ckpt.py
+++ b/surogate/grpo/orchestrator/ckpt.py
@@ -1,3 +1,4 @@
+import shutil
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -7,6 +8,7 @@ import torch
 from surogate.core.config.grpo_orch_config import GRPOCheckpointConfig
 from surogate.grpo.orchestrator.buffer import Buffer
 from surogate.grpo.utils.logger import get_logger
+from surogate.grpo.utils.pathing import get_all_ckpt_steps
 from surogate.grpo.utils.utils import get_ckpt_dir, get_step_path
 
 
@@ -90,6 +92,28 @@ class CheckpointManager:
         ckpt_path = self.get_ckpt_path(step)
         ckpt_path.mkdir(parents=True, exist_ok=True)
         self._save_to_path(ckpt_path, progress, buffer)
+        self._cleanup_old_ckpts()
+
+    def _cleanup_old_ckpts(self) -> None:
+        """Enforces keep_last/keep_interval: removes old step_N checkpoint dirs, keeping the
+        newest keep_last and any step that is a keep_interval multiple. No-op when keep_last
+        is unset. Only step_N directories are touched (other files in the dir are left alone)."""
+        keep_last = self.config.keep_last
+        if keep_last is None:
+            return
+        steps = get_all_ckpt_steps(self.ckpt_dir)
+        protected = set(steps[-keep_last:]) if keep_last > 0 else set()
+        keep_interval = self.config.keep_interval
+        for s in steps:
+            if s in protected or (keep_interval and s % keep_interval == 0):
+                continue
+            step_dir = get_step_path(self.ckpt_dir, s)
+            if not (step_dir.is_dir() and step_dir.name.startswith("step_")):
+                continue
+            try:
+                shutil.rmtree(step_dir)
+            except Exception as e:
+                logger.warning(f"Failed to clean old orchestrator checkpoint {step_dir}: {e}")
 
 
 def setup_ckpt_manager(output_dir: Path, config: GRPOCheckpointConfig | None) -> CheckpointManager | None:

--- a/surogate/grpo/packer.py
+++ b/surogate/grpo/packer.py
@@ -96,6 +96,7 @@ class SinglePacker(BasePacker):
             num_train_workers=self.dp_world_size,
             idxs=[0] * len(batch.examples),
             num_loras=self.multi_run_manager.max_runs,
+            single_sample_bins=getattr(self, 'single_sample_bins', False),
         )
 
         self.sender.send(micro_batch_grid)
@@ -288,6 +289,7 @@ class MultiPacker(BasePacker):
                 num_train_workers=self.dp_world_size,
                 idxs=[run_idx] * len(run_samples),
                 num_loras=self.multi_run_manager.max_runs,
+                single_sample_bins=getattr(self, 'single_sample_bins', False),
             )
             for worker_idx, worker_batches in enumerate(run_micro_batch_grid):
                 all_micro_batches[worker_idx].extend(worker_batches)

--- a/surogate/grpo/runs.py
+++ b/surogate/grpo/runs.py
@@ -17,6 +17,19 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
+def _start_step_override() -> int | None:
+    raw = os.environ.get("SUROGATE_GRPO_START_STEP")
+    if raw is None or raw == "":
+        return None
+    try:
+        step = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"Invalid SUROGATE_GRPO_START_STEP={raw!r}; expected an integer") from exc
+    if step < 0:
+        raise ValueError(f"Invalid SUROGATE_GRPO_START_STEP={raw!r}; expected a non-negative integer")
+    return step
+
+
 # ---------------------------------------------------------------------------
 # Local replacements for prime_rl.trainer utilities
 # ---------------------------------------------------------------------------
@@ -329,10 +342,14 @@ class MultiRunManager:
         # Set progress based on resume_step config (match orchestrator behavior)
         self.progress[new_id] = Progress()
         if config.ckpt is None or config.ckpt.resume_step is None:
-            self.progress[new_id].step = 0
+            self.progress[new_id].step = _start_step_override() or 0
         elif config.ckpt.resume_step == -1:
             stable_steps = get_stable_ckpt_steps(self.get_run_dir(new_id) / "checkpoints")
-            self.progress[new_id].step = max(stable_steps) if stable_steps else 0
+            # No orchestrator checkpoint yet (resume_step=-1 configured but the orch is still
+            # mid-first-batch): fall back to the explicit start-step override, NOT 0 — a 0
+            # pointer makes the receiver replay the run's entire rollout history as fresh
+            # batches (observed 2026-07-05: 8 phantom trainer steps on years-old bins).
+            self.progress[new_id].step = max(stable_steps) if stable_steps else (_start_step_override() or 0)
         else:
             self.progress[new_id].step = config.ckpt.resume_step
 

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -28,7 +28,7 @@ from surogate.train.lr_schedule import LRSchedule
 from surogate.train.metrics_writer import MetricsWriter
 from surogate.utils.hf import get_model_weights_path
 from surogate.utils.logger import get_logger
-from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
+from surogate.utils.lora_compat import ensure_vllm_lora_compat
 from surogate.utils.tensor import to_surogate_dtype
 
 logger = get_logger()
@@ -99,7 +99,13 @@ class GRPOTrainer:
             config=_surogate.PretrainedConfig.from_pretrained(config.model_dir, to_surogate_dtype(config.torch_dtype)),
             options=config.runtime_config,
             batch_size=config.per_device_train_batch_size,
-            seq_len=config.sequence_len,
+            # Graph sequence length is the CHUNK size under chunked-sequence
+            # training (trainer_seq_len = sequence_len // sequence_chunks),
+            # exactly as the SFT wrapper passes it. Passing the full
+            # sequence_len here built an unchunked graph whose saved-tensor
+            # cache cannot fit long sequences (found 2026-07-27 bringing up
+            # the first chunked GRPO run, on the 27B hybrid).
+            seq_len=config.trainer_seq_len,
             grad_accum=1,  # Set dynamically per step via set_grad_accumulation()
             memcpy_all_gather=config.memcpy_all_gather,
             memcpy_send_recv=config.memcpy_send_recv,
@@ -118,7 +124,35 @@ class GRPOTrainer:
         if vocab_size:
             self._pad_logprob = float(np.log(1.0 / float(vocab_size)))
 
-        # Import pretrained weights
+        # Import pretrained weights.
+        #
+        # Adapter-init protocol (2026-07-27): the SFT wrapper calls
+        # configure_initial_adapter BEFORE import (adapter_init_mode=merge
+        # registers the adapter via set_adapter_path so the native import
+        # merges it in-stream) and import_initial_trainable_adapter after.
+        # GRPOTrainer skipped both, silently IGNORING adapter_path — a run
+        # configured to start from base+adapter would have trained from the
+        # raw base.
+        from surogate.train.adapter_init import (
+            configure_initial_adapter,
+            import_initial_trainable_adapter,
+        )
+
+        # Resume protocol (2026-07-29, mirrors the SFT wrapper): before this,
+        # resume_from_checkpoint was silently IGNORED — every restart began
+        # at step 0 with a fresh adapter and re-trained all on-disk batches
+        # (2h of redundant GPU on the r5b relaunch), and the re-run's
+        # broadcast sequence desynced the orchestrator's get_weight_dir.
+        # ``self.start_step`` is the NEXT batch to train: checkpoint at step
+        # S = trained through batch S, so resume trains S+1.
+        resume_step = -1
+        if getattr(config, "resume_from_checkpoint", False) and config.checkpoint_dir:
+            resume_step = _surogate.find_latest_checkpoint(str(config.checkpoint_dir))
+        self.start_step = 0
+        fresh_run = resume_step < 0
+
+        initial_adapter = configure_initial_adapter(
+            config, self.trainer, fresh_run=fresh_run)
         model_weights_path = get_model_weights_path(config.model_dir)
         if external_weights is not None:
             # Zero-copy import from external GPU pointers (colocate mode with vLLM)
@@ -127,26 +161,18 @@ class GRPOTrainer:
         else:
             logger.info(f"Importing weights from {model_weights_path}")
             self.trainer.import_weights(model_weights_path)
+        if fresh_run:
+            import_initial_trainable_adapter(self.trainer, initial_adapter)
+        else:
+            from surogate.utils.lora_compat import ensure_surogate_lora_compat
 
-        # Checkpoint resume. `resume_from_checkpoint` is inherited from
-        # SFTConfig and defaults to True, but GRPOTrainer never acted on it:
-        # every restart began at step 0 with a fresh adapter, re-trained the
-        # batches already on disk, and re-emitted weight broadcasts under step
-        # numbers the orchestrator had already consumed.
-        #
-        # `self.start_step` is the NEXT batch to train: a checkpoint at step S
-        # means "trained through batch S", so a resumed run starts at S + 1.
-        self.start_step = 0
-        resume_step = -1
-        if config.resume_from_checkpoint and config.checkpoint_dir:
-            resume_step = _surogate.find_latest_checkpoint(str(config.checkpoint_dir))
-        if resume_step >= 0:
             if config.lora:
                 ensure_surogate_lora_compat(
                     Path(config.checkpoint_dir) / f"step_{resume_step:08d}",
                     config.model_dir,
                 )
-            logger.info(f"Resuming from checkpoint step {resume_step} (next batch: {resume_step + 1})")
+            logger.info(f"Resuming from checkpoint step {resume_step} "
+                        f"(next batch: {resume_step + 1})")
             self.trainer.load_checkpoint(str(config.checkpoint_dir), resume_step)
             self.start_step = resume_step + 1
 
@@ -583,6 +609,8 @@ class GRPOTrainer:
             transport_config=transport_config,
             start_step=start_step,
         )
+        # chunked GRPO: no packed-doc isolation in chunked training attention
+        self.packer.single_sample_bins = bool(getattr(config, 'single_sample_bins', False))
 
         # Setup data loader (receives packed MicroBatches)
         self.data_loader = GRPODataLoader(
@@ -597,10 +625,10 @@ class GRPOTrainer:
         config = self.config
         max_steps = config.max_steps
 
-        # start_step comes from checkpoint resume (the next batch to train).
-        # It drives the packer (which batch to pack next), the data loader
+        # start_step comes from checkpoint resume (next batch to train);
+        # it drives the packer (which batch to pack next), the data loader
         # (which batch to read), and the internal step counter (save cadence
-        # and LR). All three must agree or a restart re-trains from batch 0.
+        # + LR). All three must agree or a restart re-trains from batch 0.
         self._setup_data(start_step=self.start_step)
 
         logger.info("Starting GRPO training loop")
@@ -627,18 +655,19 @@ class GRPOTrainer:
         else:
             logger.info("  Running indefinitely (waiting for orchestrator)")
 
-        # Internal trainer step (one per grad_accum chunk, for LR schedule and
+        # Internal trainer step (one per grad_accum chunk, for LR schedule +
         # logging). Starts at the resume point so save cadence and metrics
         # continue the same sequence instead of restarting at 0.
         step = self.start_step
-        # Trainer-owned batch counter. mrm.progress[0].step is initialized from
-        # the ORCHESTRATOR's checkpoints on run discovery, and the orchestrator
-        # runs ahead of a resumed trainer by up to max_async_level — reading it
-        # here misnames weight broadcasts after a restart (e.g. checkpoint-5
-        # weights emitted as step_9). `start_step + packs_done` is identical to
-        # the old value on a fresh run (0 + N) and correct on resume: the first
-        # iteration re-emits the checkpoint weights under the resume step,
-        # unblocking an orchestrator already waiting on that broadcast.
+        # Trainer-owned batch counter (2026-07-29). mrm.progress[0].step is
+        # initialized from the ORCHESTRATOR's checkpoints on run discovery,
+        # which runs ahead of a resumed trainer by up to max_async_level —
+        # reading it here misnames weight broadcasts after a restart (e.g.
+        # ckpt-5 weights emitted as step_9). start_step + packs_done is
+        # byte-identical to the old value on fresh runs (0 + N) and correct
+        # on resume: the first iteration re-emits the checkpoint weights
+        # under the resume step, unblocking an orchestrator already waiting
+        # on that broadcast.
         packs_done = 0
         while True:
             orch_step = self.start_step + packs_done
@@ -840,6 +869,7 @@ class GRPOTrainer:
                     adv_tau=float(config.loss.adv_tau),
                     teacher_tau=float(config.loss.teacher_tau),
                     kl_tau=float(config.loss.kl_tau),
+                    ratio_clip=float(config.loss.ratio_clip),
                 )
 
             # 5. Optimizer step — one per orchestrator step (lr/opt_config built above)
@@ -871,8 +901,9 @@ class GRPOTrainer:
 
             step += 1
 
-        # Final weight broadcast — same trainer-owned counter as the loop, so a
-        # resumed run does not publish under an orchestrator step number.
+        # Final weight broadcast
+        # Same trainer-owned counter as the loop, so a resumed run does not
+        # publish the final weights under an orchestrator step number.
         self.broadcast.broadcast(self.trainer, self.start_step + packs_done)
 
         # Save final adapter/model

--- a/surogate/train/adapter_init.py
+++ b/surogate/train/adapter_init.py
@@ -1,0 +1,51 @@
+"""Validated LoRA parent initialization shared by SFT trainer paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def configure_initial_adapter(config, trainer: object, *, fresh_run: bool) -> Path | None:
+    """Configure merged initialization or return a trainable parent to import."""
+    adapter_path = getattr(config, "adapter_path", None)
+    if not adapter_path:
+        return None
+    path = Path(adapter_path).expanduser().resolve()
+    config_path = path / "adapter_config.json"
+    weights_path = path / "adapter_model.safetensors"
+    missing = [item.name for item in (config_path, weights_path) if not item.is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"initial adapter is incomplete at {path}: missing {', '.join(missing)}"
+        )
+
+    mode = getattr(config, "adapter_init_mode", "merge")
+    if mode == "merge":
+        set_adapter_path = getattr(trainer, "set_adapter_path", None)
+        if not callable(set_adapter_path):
+            raise RuntimeError("SFT trainer does not support merged adapter initialization")
+        set_adapter_path(str(path))
+        return None
+    if mode != "trainable":
+        raise ValueError("adapter_init_mode must be 'merge' or 'trainable'")
+    if not fresh_run:
+        return None
+
+    adapter_config = json.loads(config_path.read_text(encoding="utf-8"))
+    if int(adapter_config.get("r", -1)) != int(config.lora_rank):
+        raise ValueError("trainable parent adapter rank does not match trainer LoRA rank")
+    if float(adapter_config.get("lora_alpha", -1.0)) != float(config.lora_alpha):
+        raise ValueError("trainable parent adapter alpha does not match trainer LoRA alpha")
+    if set(adapter_config.get("target_modules", ())) != set(config.lora_target_modules):
+        raise ValueError("trainable parent adapter targets do not match trainer LoRA targets")
+    return weights_path
+
+
+def import_initial_trainable_adapter(trainer: object, weights_path: Path | None) -> None:
+    if weights_path is None:
+        return
+    import_adapter = getattr(trainer, "import_adapter", None)
+    if not callable(import_adapter):
+        raise RuntimeError("SFT trainer does not support trainable adapter initialization")
+    import_adapter(str(weights_path))

--- a/surogate/train/distributed.py
+++ b/surogate/train/distributed.py
@@ -10,6 +10,10 @@ from typing import Any
 import numpy as np
 
 from surogate.core.config.sft_config import SFTConfig
+from surogate.train.adapter_init import (
+    configure_initial_adapter,
+    import_initial_trainable_adapter,
+)
 from surogate.train.vision import OnTheFlyMultimodalBatcher, init_mm_helpers, load_multimodal_datasets
 from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_lora_compat
 
@@ -503,12 +507,9 @@ class NodeTrainer:
                     # Fallback to base model if checkpoint doesn't have model.safetensors
                     weights_path = model_weights_path
             logger.info(f"Node {self.node_rank}: Importing base model weights from {weights_path}...")
-            if self._config.adapter_path:
-                logger.info(
-                    f"Node {self.node_rank}: Merging adapter from {self._config.adapter_path} into base weights..."
-                )
-                self._trainer.set_adapter_path(self._config.adapter_path)
+            initial_adapter = configure_initial_adapter(self._config, self._trainer, fresh_run=False)
             self._trainer.import_weights(weights_path)
+            import_initial_trainable_adapter(self._trainer, initial_adapter)
             logger.info(f"Node {self.node_rank}: Loading checkpoint from step {self.start_step}...")
             if self._config.lora:
                 ensure_surogate_lora_compat(
@@ -519,12 +520,9 @@ class NodeTrainer:
             logger.info(f"Node {self.node_rank}: Checkpoint loaded successfully")
         else:
             # Import weights from pretrained model
-            if self._config.adapter_path:
-                logger.info(
-                    f"Node {self.node_rank}: Merging adapter from {self._config.adapter_path} into base weights..."
-                )
-                self._trainer.set_adapter_path(self._config.adapter_path)
+            initial_adapter = configure_initial_adapter(self._config, self._trainer, fresh_run=True)
             self._trainer.import_weights(model_weights_path)
+            import_initial_trainable_adapter(self._trainer, initial_adapter)
 
         if self._train_vision:
             (

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -10,6 +10,10 @@ import numpy as np
 
 from surogate import _surogate
 from surogate.core.config.sft_config import SFTConfig
+from surogate.train.adapter_init import (
+    configure_initial_adapter,
+    import_initial_trainable_adapter,
+)
 from surogate.train.early_stopping import EarlyStopping
 from surogate.train.gradient_tracker import GradientTracker
 from surogate.train.loss_guard import LossGuard
@@ -466,10 +470,9 @@ class SurogateTrainerWrapper:
                         if not Path(base_weights_path).exists():
                             base_weights_path = config.model_dir
                 logger.info(f"Importing base model weights from {base_weights_path}...")
-                if config.adapter_path:
-                    logger.info(f"Merging adapter from {config.adapter_path} into base weights...")
-                    self.trainer.set_adapter_path(config.adapter_path)
+                initial_adapter = configure_initial_adapter(config, self.trainer, fresh_run=False)
                 self.trainer.import_weights(base_weights_path)
+                import_initial_trainable_adapter(self.trainer, initial_adapter)
                 logger.info(f"Loading checkpoint from step {self.start_step}...")
                 if config.lora:
                     ensure_surogate_lora_compat(
@@ -497,10 +500,9 @@ class SurogateTrainerWrapper:
                     lora_config=config.lora_config,
                     qlora_config=config.qlora_config,
                 )
-                if config.adapter_path:
-                    logger.info(f"Merging adapter from {config.adapter_path} into base weights...")
-                    self.trainer.set_adapter_path(config.adapter_path)
+                initial_adapter = configure_initial_adapter(config, self.trainer, fresh_run=True)
                 self.trainer.import_weights(model_weights_path)
+                import_initial_trainable_adapter(self.trainer, initial_adapter)
 
             elif config.from_scratch:
                 self.trainer = _surogate.SurogateTrainer(

--- a/tests/grpo/test_buffer.py
+++ b/tests/grpo/test_buffer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+from datasets import Dataset
+
+from surogate.core.config.grpo_orch_config import GRPOBufferConfig
+from surogate.grpo.orchestrator.buffer import Buffer
+from surogate.utils.dict import DictDefault
+
+
+def _dataset() -> Dataset:
+    return Dataset.from_list(
+        [
+            {"example_id": 0, "task": "env_a", "prompt": [{"role": "user", "content": "a"}]},
+            {"example_id": 1, "task": "env_a", "prompt": [{"role": "user", "content": "b"}]},
+        ]
+    )
+
+
+def _rollout(example_id: int, reward: float) -> dict:
+    return {
+        "example_id": example_id,
+        "task": "env_a",
+        "reward": reward,
+        "trajectory": [{"role": "assistant", "content": "{}"}],
+        "error": None,
+    }
+
+
+def _buffer(**config_overrides) -> Buffer:
+    config = GRPOBufferConfig(
+        DictDefault(
+            {
+                "easy_threshold": 1.0,
+                "hard_threshold": 0.0,
+                "online_difficulty_filtering": True,
+                **config_overrides,
+            }
+        )
+    )
+    return Buffer(_dataset(), ["env_a"], config)
+
+
+def test_online_difficulty_filtering_evicts_saturated_examples():
+    buffer = _buffer()
+
+    buffer.update([_rollout(0, 0.0), _rollout(0, 0.0)])
+    buffer.update([_rollout(1, 1.0), _rollout(1, 1.0)])
+
+    assert sum(len(examples) for examples in buffer.example_buffer.values()) == 0
+    assert len(buffer.hard_examples) == 1
+    assert len(buffer.easy_examples) == 1
+    assert buffer.rollout_buffer == []
+
+
+def test_sampling_empty_normal_pool_still_raises_without_recycling():
+    buffer = _buffer()
+    buffer.update([_rollout(0, 0.0), _rollout(0, 0.0)])
+    buffer.update([_rollout(1, 1.0), _rollout(1, 1.0)])
+
+    with pytest.raises(ValueError, match="No environments left with examples"):
+        buffer.sample_examples(n=1)
+
+
+def test_sampling_recycles_easy_and_hard_examples_when_normal_pool_is_empty():
+    buffer = _buffer(recycle_easy_fraction=1.0, recycle_hard_fraction=1.0)
+    buffer.update([_rollout(0, 0.0), _rollout(0, 0.0)])
+    buffer.update([_rollout(1, 1.0), _rollout(1, 1.0)])
+
+    sampled = buffer.sample_examples(n=1)
+
+    assert sampled[0]["example_id"] in {0, 1}
+    assert sum(len(examples) for examples in buffer.example_buffer.values()) == 2
+    metrics = buffer.get_metrics()
+    assert metrics["recycled_examples/easy"] == 1
+    assert metrics["recycled_examples/hard"] == 1
+
+
+def test_one_use_sampling_never_returns_a_task_twice_and_persists_consumption(
+    tmp_path,
+):
+    buffer = _buffer(sample_without_replacement=True)
+
+    sampled = buffer.sample_examples(n=2)
+
+    assert {row["example_id"] for row in sampled} == {0, 1}
+    assert len(buffer.consumed_examples) == 2
+    with pytest.raises(ValueError, match="No environments left with examples"):
+        buffer.sample_examples(n=1)
+
+    checkpoint = tmp_path / "buffer"
+    buffer.save(checkpoint)
+    restored = _buffer(sample_without_replacement=True)
+    restored.load(checkpoint)
+    assert {row["example_id"] for row in restored.consumed_examples} == {0, 1}
+    with pytest.raises(ValueError, match="No environments left with examples"):
+        restored.sample_examples(n=1)

--- a/tests/grpo/test_inference_config.py
+++ b/tests/grpo/test_inference_config.py
@@ -20,3 +20,22 @@ def test_unset_scalars_are_dropped_so_vllm_defaults_apply():
     ns = cfg.to_vllm()
     assert not hasattr(ns, "max_num_seqs")
     assert not hasattr(ns, "kv_cache_dtype")
+
+
+def test_attention_backend_is_forwarded_to_vllm() -> None:
+    cfg = GRPOInferenceConfig(
+        DictDefault(
+            {
+                "model": "local-model",
+                "attention_backend": "TORCH_SDPA",
+                "enforce_eager": True,
+                "enable_prefix_caching": False,
+            }
+        )
+    )
+
+    args = cfg.to_vllm()
+
+    assert args.attention_backend == "TORCH_SDPA"
+    assert args.enforce_eager is True
+    assert args.enable_prefix_caching is False

--- a/tests/grpo/test_native_formula.py
+++ b/tests/grpo/test_native_formula.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from surogate.grpo.config import GRPOLossConfig
 from surogate.grpo.loss import (
@@ -131,3 +132,337 @@ def test_native_metrics_reference_matches_existing_grpo_metrics():
     for key, expected_value in expected.items():
         assert key in actual
         assert actual[key] == expected_value
+
+
+def test_sparse_outcome_advantage_preserves_full_completion_kl() -> None:
+    trainer_logprobs = np.array(
+        [-8.0, -1.8, -1.7, -1.6],
+        dtype=np.float32,
+    )
+    inference_logprobs = np.array(
+        [-8.0, -2.0, -2.0, -2.0],
+        dtype=np.float32,
+    )
+    advantages = np.array(
+        [0.0, 0.0, 5.0, 0.0],
+        dtype=np.float32,
+    )
+    loss_mask = np.array([False, True, True, True])
+    config = GRPOLossConfig(
+        ipo_mask_low=1.0,
+        ipo_mask_high=1.0,
+        adv_tau=1.0,
+        kl_tau=0.1,
+    )
+
+    grads, _ = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 4)],
+    )
+
+    log_ratio = trainer_logprobs - inference_logprobs
+    expected_kl = -2.0 * config.kl_tau * log_ratio
+    assert grads[0] == 0.0
+    assert grads[1] == pytest.approx(expected_kl[1])
+    assert grads[3] == pytest.approx(expected_kl[3])
+    assert grads[2] == pytest.approx(
+        5.0 * np.exp(log_ratio[2]) + expected_kl[2]
+    )
+
+
+def test_seed_opd_supplies_dense_credit_when_group_rewards_tie():
+    trainer_logprobs = np.array([-8.0, -2.0, -1.0, -3.0], dtype=np.float32)
+    inference_logprobs = trainer_logprobs.copy()
+    hindsight_logprobs = np.array([-8.0, -1.0, -1.0, -4.0], dtype=np.float32)
+    advantages = np.zeros(4, dtype=np.float32)
+    loss_mask = np.array([False, True, True, True])
+    hindsight_mask = np.array([False, True, False, True])
+    config = GRPOLossConfig(adv_tau=1.0, kl_tau=0.0, opd_tau=0.4, opd_beta=2.0)
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 4)],
+        opd_reference_logprobs=inference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=hindsight_mask,
+    )
+
+    supported_gate = 1.0 / (1.0 + np.exp(-2.0))
+    unsupported_gate = 1.0 / (1.0 + np.exp(2.0))
+    np.testing.assert_allclose(
+        grads,
+        [0.0, 0.4 * supported_gate, 0.0, 0.4 * unsupported_gate],
+        rtol=2e-7,
+    )
+    assert metrics["opd_tokens"] == 2
+    assert metrics["opd_gate"] == pytest.approx(np.mean([supported_gate, unsupported_gate]))
+    assert metrics["opd_shift"] == pytest.approx(0.0)
+    assert metrics["policy_loss"] > 0.0
+
+
+def test_seed_opd_is_inert_when_disabled():
+    trainer_logprobs = np.array([-8.0, -2.0, -1.0], dtype=np.float32)
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=trainer_logprobs.copy(),
+        advantages=np.zeros(3, dtype=np.float32),
+        loss_mask=np.array([False, True, True]),
+        loss_config=GRPOLossConfig(kl_tau=0.0, opd_tau=0.0, opd_beta=2.0),
+        sample_ranges=[(0, 3)],
+        opd_reference_logprobs=trainer_logprobs.copy(),
+        hindsight_logprobs=np.array([-8.0, -1.0, -2.0], dtype=np.float32),
+        hindsight_mask=np.array([False, True, True]),
+    )
+
+    np.testing.assert_array_equal(grads, np.zeros(3, dtype=np.float32))
+    assert metrics["opd_tokens"] == 2
+    assert metrics["opd_loss"] == 0.0
+
+
+def test_seed_opd_gate_uses_matched_direct_branches_not_rollout_drift():
+    trainer_logprobs = np.array([-8.0, -2.5, -0.5], dtype=np.float32)
+    inference_logprobs = np.array([-8.0, -1.0, -2.0], dtype=np.float32)
+    opd_reference_logprobs = np.array([-8.0, -1.0, -2.0], dtype=np.float32)
+    hindsight_logprobs = np.array([-8.0, -0.5, -2.5], dtype=np.float32)
+    loss_mask = np.array([False, True, True])
+    config = GRPOLossConfig(adv_tau=0.0, kl_tau=0.0, opd_tau=0.4, opd_beta=2.0)
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=np.zeros(3, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 3)],
+        opd_reference_logprobs=opd_reference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=loss_mask,
+    )
+
+    supported_gate = 1.0 / (1.0 + np.exp(-1.0))
+    unsupported_gate = 1.0 / (1.0 + np.exp(1.0))
+    np.testing.assert_allclose(
+        grads,
+        [0.0, 0.4 * supported_gate, 0.4 * unsupported_gate],
+        rtol=2e-7,
+    )
+    assert metrics["opd_gate"] == pytest.approx(np.mean([supported_gate, unsupported_gate]))
+
+    drifted_grads, drifted_metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=np.array([-8.0, -4.0, -0.1], dtype=np.float32),
+        advantages=np.zeros(3, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 3)],
+        opd_reference_logprobs=opd_reference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=loss_mask,
+    )
+    np.testing.assert_allclose(drifted_grads, grads, rtol=2e-7)
+    assert drifted_metrics["opd_gate"] == pytest.approx(metrics["opd_gate"])
+
+
+def test_replay_anchor_supplies_outcome_independent_parent_action_credit():
+    trainer_logprobs = np.array([-8.0, -2.0, -1.0, -3.0], dtype=np.float32)
+    loss_mask = np.array([False, True, True, True])
+    replay_mask = np.array([False, True, False, True])
+    config = GRPOLossConfig(
+        adv_tau=0.0,
+        kl_tau=0.0,
+        opd_tau=0.0,
+        replay_tau=0.3,
+    )
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=trainer_logprobs.copy(),
+        advantages=np.zeros(4, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 4)],
+        replay_mask=replay_mask,
+    )
+
+    np.testing.assert_allclose(grads, [0.0, 0.3, 0.0, 0.3])
+    assert metrics["replay_tokens"] == 2
+    assert metrics["replay_loss"] == pytest.approx(0.75)
+    assert metrics["opd_tokens"] == 0
+
+
+def test_replay_is_ce_only_and_ignores_behavior_ratio_advantage_and_kl():
+    trainer_logprobs = np.array([-8.0, -2.0, -1.0, -3.0], dtype=np.float32)
+    loss_mask = np.array([False, True, True, True])
+    replay_mask = np.array([False, True, True, True])
+    config = GRPOLossConfig(
+        adv_tau=1.0,
+        kl_tau=0.7,
+        opd_tau=0.0,
+        replay_tau=0.3,
+    )
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=np.zeros(4, dtype=np.float32),
+        advantages=np.full(4, 50.0, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 4)],
+        replay_mask=replay_mask,
+    )
+
+    np.testing.assert_allclose(grads, [0.0, 0.3, 0.3, 0.3])
+    assert metrics["replay_tokens"] == 3
+    assert metrics["replay_weight_sum"] == 3.0
+    assert metrics["replay_loss"] == pytest.approx(0.6)
+    assert metrics["mismatch_kl"] == 0.0
+    assert metrics["keep_tokens"] == 0
+    assert metrics["total_tokens"] == 3
+
+
+def test_replay_only_sample_does_not_dilute_behavior_mismatch_metric():
+    trainer_logprobs = np.array([-8.0, -1.0, -8.0, -1.0], dtype=np.float32)
+    inference_logprobs = np.array([-8.0, -2.0, -8.0, 50.0], dtype=np.float32)
+    loss_mask = np.array([False, True, False, True])
+
+    _, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=np.zeros(4, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=GRPOLossConfig(adv_tau=0.0, kl_tau=0.0, replay_tau=0.3),
+        sample_ranges=[(0, 2), (2, 4)],
+        replay_mask=np.array([False, False, False, True]),
+    )
+
+    assert metrics["policy_sample_count"] == 1
+    assert metrics["mismatch_kl"] == pytest.approx(np.e - 2.0)
+
+
+def test_replay_weights_balance_ce_without_entering_policy_objective():
+    trainer_logprobs = np.array([-8.0, -2.0, -1.0, -3.0], dtype=np.float32)
+    loss_mask = np.array([False, True, True, True])
+    replay_mask = np.array([False, True, True, True])
+    replay_weights = np.array([1.0, 2.0, 0.5, 3.0], dtype=np.float32)
+    config = GRPOLossConfig(adv_tau=1.0, kl_tau=0.7, replay_tau=0.3)
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=np.zeros(4, dtype=np.float32),
+        advantages=np.full(4, 50.0, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 4)],
+        replay_mask=replay_mask,
+        replay_weights=replay_weights,
+    )
+
+    np.testing.assert_allclose(grads, [0.0, 0.6, 0.15, 0.9])
+    assert metrics["replay_tokens"] == 3
+    assert metrics["replay_weight_sum"] == pytest.approx(5.5)
+    assert metrics["replay_loss"] == pytest.approx(1.35)
+    assert metrics["mismatch_kl"] == 0.0
+
+
+def test_replay_weights_reject_policy_token_weighting():
+    with pytest.raises(ValueError, match="only on replay tokens"):
+        compute_grpo_per_token_grads(
+            trainer_logprobs=np.array([-1.0, -1.0], dtype=np.float32),
+            inference_logprobs=np.array([-1.0, -1.0], dtype=np.float32),
+            advantages=np.zeros(2, dtype=np.float32),
+            loss_mask=np.array([False, True]),
+            loss_config=GRPOLossConfig(replay_tau=0.3),
+            sample_ranges=[(0, 2)],
+            replay_mask=np.array([False, False]),
+            replay_weights=np.array([1.0, 2.0], dtype=np.float32),
+        )
+
+
+def test_sparse_objective_metrics_use_selected_token_denominators():
+    trainer_logprobs = np.array([-8.0, -2.0, -8.0, -3.0], dtype=np.float32)
+    inference_logprobs = trainer_logprobs.copy()
+    hindsight_logprobs = np.array([-8.0, -1.0, -8.0, -3.0], dtype=np.float32)
+    loss_mask = np.array([False, True, False, True])
+    config = GRPOLossConfig(
+        adv_tau=0.0,
+        kl_tau=0.0,
+        opd_tau=0.1,
+        opd_beta=2.0,
+        replay_tau=0.2,
+    )
+
+    _, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=np.zeros(4, dtype=np.float32),
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 2), (2, 4)],
+        opd_reference_logprobs=inference_logprobs,
+        hindsight_logprobs=hindsight_logprobs,
+        hindsight_mask=np.array([False, True, False, False]),
+        replay_mask=np.array([False, False, False, True]),
+    )
+
+    assert metrics["opd_tokens"] == 1
+    assert metrics["opd_gate"] == pytest.approx(1.0 / (1.0 + np.exp(-2.0)))
+    assert metrics["opd_shift"] == pytest.approx(1.0)
+    assert metrics["replay_tokens"] == 1
+    assert metrics["replay_loss"] == pytest.approx(0.6)
+
+
+def test_ratio_clip_bounds_rare_token_gradient_but_not_metrics():
+    """Pre-flight review item 7: a rare token (both probs tiny) passes the
+    |dp| IPO mask with an importance ratio of ~1e5 and would dominate the
+    batch gradient. The clip bounds the GRADIENT at ratio_clip while the
+    mismatch metrics keep the uncapped ratio (staleness monitoring must see
+    real drift)."""
+    # trainer p=1e-3, inference p=1e-8: ratio e^11.5 ~ 1e5, probs_diff ~1e-3
+    trainer_logprobs = np.array([0.0, np.log(1e-3), -1.0], dtype=np.float32)
+    inference_logprobs = np.array([0.0, np.log(1e-8), -1.0], dtype=np.float32)
+    advantages = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    loss_mask = np.array([False, True, True])
+    config = GRPOLossConfig(adv_tau=1.0, kl_tau=0.0)
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 3)],
+    )
+    raw_ratio = np.exp(trainer_logprobs[1] - inference_logprobs[1])
+    assert raw_ratio > 1e4                       # the hazard is real
+    assert grads[1] == pytest.approx(config.ratio_clip)   # capped at e^2
+    assert metrics["ratio_clipped"] == pytest.approx(0.5)  # 1 of 2 kept
+    # uncapped ratio still visible to monitoring
+    assert metrics["mismatch_kl"] > 1e3
+
+
+def test_ratio_clip_leaves_honest_off_policy_correction_alone():
+    trainer_logprobs = np.array([-1.2, -0.8], dtype=np.float32)
+    inference_logprobs = np.array([-1.4, -0.7], dtype=np.float32)
+    advantages = np.array([1.5, -0.2], dtype=np.float32)
+    loss_mask = np.array([True, True])
+    config = GRPOLossConfig(adv_tau=1.0, kl_tau=0.0)
+
+    grads, metrics = compute_grpo_per_token_grads(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_config=config,
+        sample_ranges=[(0, 2)],
+    )
+    expected = advantages * np.exp(trainer_logprobs - inference_logprobs)
+    np.testing.assert_allclose(grads, expected, rtol=1e-6)
+    assert metrics["ratio_clipped"] == 0.0

--- a/tests/grpo/test_teacher_model_config.py
+++ b/tests/grpo/test_teacher_model_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import dataclasses
+
+from surogate.core.config.grpo_orch_config import GRPOOrchestratorConfig
+from surogate.utils.dict import DictDefault
+
+
+def test_teacher_model_config_serializes_only_nested_model_and_client() -> None:
+    config = GRPOOrchestratorConfig(
+        DictDefault(
+            {
+                "model": {"name": "policy"},
+                "teacher_model": {
+                    "model": {"name": "teacher"},
+                    "client": {
+                        "base_url": ["http://localhost:8007/v1"],
+                        "timeout": 1200,
+                    },
+                },
+                "env": [{"id": "test"}],
+            }
+        )
+    )
+
+    serialized = dataclasses.asdict(config)["teacher_model"]
+
+    assert set(serialized) == {"model", "client"}
+    assert serialized["model"]["name"] == "teacher"
+    assert serialized["client"]["base_url"] == ["http://localhost:8007/v1"]


### PR DESCRIPTION
Trainer-side work from `feature/director-ultra`, ported to main. Stacked on #70 — merge that first, then this retargets to `main` cleanly.

Fugu-Ultra scripts, manifests, environments, and the `ultra`/`director` packages are excluded, along with every module that depends on them.

## Engine (csrc)

- **`step_grpo_native_chunked`** — when `sequence_chunks > 1` the native GRPO step dispatches to a chunked path. Chunks are forwarded left-to-right to fill the attention KV caches, then walked in reverse for a windowed GRPO dloss and backward, accumulating dK/dV across chunks. Gradients are exact; memory stays at the single-chunk footprint. All-padding tail chunks are detected from the per-sample end offsets and skipped.
- **`chunk_pack_meta_from_positions`** — derives chunk-local document geometry from the sliced position ids. The SFT chunked path (`step_chunked`) now uses it too, and sweeps *every* chunk in Phase A: unlike the GRPO path it has no per-sample end offsets to prove a tail chunk is padding, and Phase B walks the full range, so the two passes must cover the same chunks.
- **`ratio_clip`** threaded end to end: `GRPOLossConfig` → binding → `GrpoNativeLossConfig` → `fused_classifier`. Bounds a single token's importance ratio (default e²) when the sampling policy and the trainer policy drift apart — which the IPO mask alone does not cover under periodic merged-weight reloads.
- Saved-tensor lifetimes bounded for hybrid models (`dsl_run_state`).
- New native tests: `test-grpo-replay.cpp`, `test-fp8-quant.cpp`.

## Trainer (python)

- The graph is built at `trainer_seq_len` (the chunk size), matching the SFT wrapper. Passing the full `sequence_len` built an unchunked graph whose saved-tensor cache cannot hold long sequences.
- **Adapter init** — `GRPOTrainer` now calls `configure_initial_adapter` before weight import and `import_initial_trainable_adapter` after, so `adapter_path` and `adapter_init_mode` are honored. Previously a GRPO run configured to start from base+adapter silently trained from the raw base.
- **`single_sample_bins`** packs one sample per row. Chunked-training attention has no packed-document isolation, so multi-sample rows would let samples attend across each other.
- SFT/DPO gain `adapter_init_mode: trainable`, to continue an existing adapter instead of merging it.

## Orchestrator

- Buffer recycling (`normal_pool_min_examples`, `recycle_easy_fraction`, `recycle_hard_fraction`) and `sample_without_replacement` for one-attempt agentic tasks.
- Orchestrator checkpoint/progress fixes (`ckpt.py`, `runs.py`, `advantage.py`).

## Build

- `Makefile` resolves `CUDA_HOME` through version-switching symlinks before handing it to CMake, so a stale cache cannot mix one toolkit's libraries with another's `cudaDeviceProp` ABI.

## Deliberately NOT ported

These do not work on `feature/director-ultra` either — porting them would move 27 failing tests onto main:

| Dropped | Why |
| --- | --- |
| OPD/replay/hindsight subsystem (`hindsight.py`, `replay.py`, `direct_scorer.py`, `trainability.py`) + tests | `TrainingSample` never gained `opd_reference_logprobs` / `hindsight_logprobs` / `hindsight_mask` / `replay_mask`, so 21 of its tests fail on that branch. Nothing else imports these modules. The optional kwargs in `loss.py` and the inert loss-config fields are kept — they default to off, and the `ratio_clip` work shares the same function. |
| `orchestrator/spool.py` + `spool_inflight` config | Nothing wires it; the scheduler/orchestrator side was clobbered by a later merge. Also dropped the unwired `replay:` orch config block and `trainable_metric`. |
| director-ultra's `test_native_runtime_source.py` | Asserts csrc text that commit `3273653a` ("take main's csrc wholesale") removed, so it fails there. Main's revision is kept and **passes** against this engine. |
| `ale_*` / `synthetic_*` modules and tests | They `import ultra`. |

## Tests

- `tests/grpo`: **131 passed**, 0 failed
- `tests/train`: 15 passed, 20 skipped
- dpo/distill/adapter config tests: 43 passed

Run against this branch's code, not the editable install (the venv's editable finder resolves `surogate` to the feature checkout and silently shadows a worktree).

## Docs

`sequence_chunks` for GRPO, `ratio_clip`, `single_sample_bins`, `adapter_init_mode`, and the new buffer keys are documented in the config reference and the RL guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)