### PR TITLE
fix(grpo): never apply an optimizer step whose token accounting is corrupt

### DIFF
--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -877,6 +877,30 @@ class GRPOTrainer:
             vtc = self.trainer.get_valid_token_count(0)
             expected_loss_scale = loss_scale
 
+            # vtc==0 with work done means the step's loss accounting is
+            # corrupt (observed 2026-08-03 on a chunked-GRPO run: the loss op
+            # skipped all step, so ValidTokenCount — which is ALSO the
+            # gradient normalization denominator — stayed 0 and gradients
+            # came out ~1e5x too large; only max_grad_norm bounded the
+            # damage; the step also reported masked=2198% because the metric
+            # denominators share the same accounting). Never apply such a
+            # step: flush the poisoned accumulation through the normal
+            # optimizer path at lr=0 so state resets without moving the
+            # policy.
+            if vtc == 0 and n_mb > 0:
+                logger.error(
+                    f"vtc=0 with {n_mb} micro-batches — corrupt step accounting; "
+                    f"applying ZERO-LR update to flush gradients without moving the policy")
+                opt_config = _surogate.OptimizerConfig(
+                    optimizer=config.optimizer,
+                    learning_rate=0.0,
+                    weight_decay=0.0,
+                    grad_clip=config.max_grad_norm,
+                    adamw_beta1=config.adamw_beta1,
+                    adamw_beta2=config.adamw_beta2,
+                    adamw_epsilon=config.adamw_epsilon,
+                )
+
             result = self.trainer.update_with_config(opt_config, step + 1)
             # The diagnostic path computes the loss in Python, so the native
             # accumulator is empty — use the Python metrics from the last

--- a/tests/grpo/test_vtc_zero_guard.py
+++ b/tests/grpo/test_vtc_zero_guard.py
@@ -1,0 +1,39 @@
+"""The vtc==0 optimizer guard: a corrupt-accounting step must not move the policy.
+
+Observed 2026-08-03 on a chunked-GRPO run: one step's loss op computed nothing
+(stuck chunk-sweep state), leaving ValidTokenCount at 0. That buffer is also
+the gradient normalization denominator, so gradients came out ~1e5x too large
+(grad_norm 1.88 vs a 0.003-0.03 band) and the metrics denominators produced an
+impossible masked=2198%. The guard swaps in a zero-lr, zero-decay optimizer
+config so the poisoned accumulation flushes without a policy update.
+"""
+
+import ast
+from pathlib import Path
+
+TRAINER = Path(__file__).resolve().parents[2] / "surogate/grpo/trainer.py"
+
+
+def test_guard_precedes_optimizer_update():
+    src = TRAINER.read_text()
+    guard = src.index("if vtc == 0 and n_mb > 0:")
+    update = src.index("result = self.trainer.update_with_config(opt_config, step + 1)")
+    read = src.index("vtc = self.trainer.get_valid_token_count(0)")
+    assert read < guard < update, "guard must sit between the vtc read and the optimizer update"
+
+
+def test_guard_zeroes_both_lr_and_decay():
+    src = TRAINER.read_text()
+    block = src[src.index("if vtc == 0 and n_mb > 0:"):src.index("result = self.trainer.update_with_config")]
+    assert "learning_rate=0.0" in block
+    assert "weight_decay=0.0" in block, "decoupled decay must be zeroed too — lr=0 alone is not sufficient by contract"
+
+
+def test_guard_flushes_through_normal_path_not_skip():
+    """The guard must still call update_with_config (state flush), not skip it —
+    skipping would leak the poisoned gradient accumulation into the next step."""
+    src = TRAINER.read_text()
+    block = src[src.index("if vtc == 0 and n_mb > 0:"):]
+    # no `continue` between the guard and the update call
+    upto_update = block[:block.index("update_with_config")]
+    assert "\ncontinue" not in upto_update and " continue\n" not in upto_update


### PR DESCRIPTION
## The incident (production, 2026-08-03)

One chunked-GRPO step reported four impossible numbers at once:

```
step=14 loss=45.9434 grad_norm=1.8756 kl=32.1102 masked=2198.40% vtc=0
```

All four trace to **one zeroed buffer**. The fused LM-head loss op computed nothing all step (engine-state glitch — most likely the chunked schedule's KV-sweep skip branch staying active), so `ValidTokenCount` stayed 0 while 348 micro-batches of gradients accumulated. That buffer is **also the gradient normalization denominator**, so gradients came out ~10⁵× too large; and the metrics share the same accounting, which is where the arithmetically-impossible `masked=2198%` comes from (fraction entries ÷ a near-zero sample count).

The batch data was clean — no length mismatches, no pathological logprobs, sane rewards/advantages. Only `max_grad_norm` stood between that step and the policy.

## The fix

The trainer reads `ValidTokenCount` **before** calling the optimizer, so the guard is pure Python: on `vtc == 0` with micro-batches processed, log an error and swap in a **zero-lr, zero-weight-decay** `OptimizerConfig`. The poisoned accumulation flushes through the normal `update_with_config` path — resetting optimizer-side state exactly as a real step would — while moving the policy by nothing. A recurrence costs one logged no-op step instead of a clip-bounded garbage step.

## Tests

Three contract points pinned (`tests/grpo/test_vtc_zero_guard.py`):
- the guard sits between the vtc read and the update call
- it zeroes **both** lr and decoupled weight decay
- it flushes through `update_with_config` rather than skipping (a skip would leak the poisoned accumulation into the next step)

Full `tests/grpo` suite: **134 passed**.

## Not fixed here

The engine-side root cause (stuck chunk-sweep state in `fused_lm_head_loss`'s skip branch) remains open — it needs a deterministic replay of the triggering batch. This guard makes recurrence harmless in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)