### PR TITLE
fix(grpo): packing-order guard for the chunked-GRPO ValidTokenCount hazard

### DIFF
--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -51,6 +51,47 @@ def _filtered_config_for_logging(config: GRPOTrainConfig) -> dict:
     return out
 
 
+def reorder_micros_for_vtc_guard(micro_batches: list, chunk_tokens: int) -> int | None:
+    """Move the micro with the largest chunk-0 valid-token count to the last slot.
+
+    In chunked GRPO the engine's step-end ValidTokenCount is the LAST micro's
+    CHUNK-0 count (per-invocation loss-buffer zeroing x reverse phase-B chunk
+    order — see upstream issue #74):
+      * a multi-chunk sample whose prompt fills chunk 0 packed last makes vtc
+        read 0 and corrupts the step (metrics garbage + exploded norm), and
+      * any small last micro shrinks the grad token-scale denominator, so the
+        reported grad norm is packing noise (measured corr(grad_norm, 1/vtc)
+        = 0.83 over 76 steps) and a grad clip suppresses real updates.
+    Batch order within an optimizer step is gradient-neutral (per-token grads
+    are computed python-side and summed), so pinning the max-count micro last
+    stabilizes the denominator without touching the update.
+
+    Returns the index swapped from, or None if no reorder was needed.
+    """
+    if chunk_tokens <= 0 or not micro_batches:
+        return None
+
+    def _chunk0_valid(mb) -> int:
+        # loss_mask arrives (1, T) from the packer — flatten before slicing or
+        # [:chunk_tokens] slices ROWS and sums the WHOLE sample, which selects
+        # multi-chunk long-completion micros whose chunk 0 is empty — i.e. it
+        # manufactures the exact vtc=0 corruption this guard exists to prevent.
+        return int(np.asarray(mb["loss_mask"]).reshape(-1)[:chunk_tokens].sum())
+
+    best = max(range(len(micro_batches)), key=lambda i: _chunk0_valid(micro_batches[i]))
+    if best == len(micro_batches) - 1:
+        return None
+    last_valid = _chunk0_valid(micro_batches[-1])
+    micro_batches[best], micro_batches[-1] = micro_batches[-1], micro_batches[best]
+    logger.info(
+        "vtc guard: moved micro %d (chunk0_valid=%d) to last slot (previous last had %d)",
+        best,
+        _chunk0_valid(micro_batches[-1]),
+        last_valid,
+    )
+    return best
+
+
 def _find_sample_boundaries(position_ids_flat: np.ndarray) -> list[tuple[int, int]]:
     """Find sample boundaries in packed position_ids.
 
@@ -696,6 +737,10 @@ class GRPOTrainer:
             # Accumulate ALL micro-batches from one pack into a single optimizer step.
             # No fixed gradient_accumulation_steps — the count is determined dynamically by the packer each step.
             seq_len = config.sequence_len
+
+
+            chunk_tokens = seq_len // max(1, int(getattr(config, "sequence_chunks", 1) or 1))
+            reorder_micros_for_vtc_guard(micro_batches, chunk_tokens)
             n_mb = len(micro_batches)
 
             # Tell the C++ engine how many micro-steps this optimizer step has.

--- a/tests/grpo/test_vtc_packing_guard.py
+++ b/tests/grpo/test_vtc_packing_guard.py
@@ -1,0 +1,57 @@
+"""Contract tests for reorder_micros_for_vtc_guard (upstream issue #74).
+
+In chunked GRPO the engine's step-end ValidTokenCount is the LAST micro's
+CHUNK-0 valid count; the guard pins the max-count micro last so (a) an
+all-masked-chunk-0 sample can never corrupt the step and (b) the grad
+token-scale denominator is stable across steps.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from surogate.grpo.trainer import reorder_micros_for_vtc_guard
+
+CHUNK = 1536
+
+
+def _c0(mb) -> int:
+    return int(np.asarray(mb["loss_mask"]).reshape(-1)[:CHUNK].sum())
+
+
+def _mb(prompt: int, completion: int) -> dict:
+    # (1, T) — the packer's real shape; the guard must flatten before slicing
+    return {"loss_mask": np.array([[0] * prompt + [1] * completion], dtype=np.int8)}
+
+
+def test_all_masked_chunk0_last_micro_is_replaced():
+    mbs = [_mb(100, 200), _mb(50, 150), _mb(CHUNK, 80)]  # last: prompt fills chunk 0
+    idx = reorder_micros_for_vtc_guard(mbs, CHUNK)
+    assert idx == 0
+    assert _c0(mbs[-1]) == 200
+    assert _c0(mbs[idx]) == 0  # swapped into interior
+
+
+def test_max_count_micro_is_pinned_last_even_when_last_is_nonzero():
+    mbs = [_mb(0, 300), _mb(100, 120), _mb(200, 30)]  # last has 30 valid — small denominator
+    idx = reorder_micros_for_vtc_guard(mbs, CHUNK)
+    assert idx == 0
+    assert _c0(mbs[-1]) == 300
+
+
+def test_noop_when_max_already_last_and_on_empty_inputs():
+    mbs = [_mb(200, 30), _mb(0, 300)]
+    assert reorder_micros_for_vtc_guard(mbs, CHUNK) is None
+    assert _c0(mbs[-1]) == 300
+    assert reorder_micros_for_vtc_guard([], CHUNK) is None
+    assert reorder_micros_for_vtc_guard(mbs, 0) is None
+
+
+def test_2d_mask_never_selects_empty_chunk0_by_total_count():
+    """Regression: with (1, T) masks, a row-slice sums the WHOLE sample and a
+    long-completion multi-chunk micro (huge total, empty chunk 0) wins the
+    max — placing it last manufactures vtc=0. Observed live before the fix."""
+    mbs = [_mb(50, 900), _mb(CHUNK, CHUNK), _mb(100, 200)]  # chunk0: 900, 0, 200
+    idx = reorder_micros_for_vtc_guard(mbs, CHUNK)
+    assert idx == 0
+    assert int(np.asarray(mbs[-1]["loss_mask"]).reshape(-1)[:CHUNK].sum()) == 900


### PR DESCRIPTION
## Problem (issue #74)

In chunked GRPO the engine's step-end `ValidTokenCount` is the **last micro's chunk-0** valid count (per-invocation loss-buffer zeroing × reverse phase-B chunk order). Two consequences, both observed on a live campaign:

1. A multi-chunk sample whose **prompt fills chunk 0**, packed last → vtc reads **0** → garbage step metrics (masked 2384–3613%, kl 35–54) and an exploded reported norm; the #72 zero-lr guard then discards the batch (3 wasted batches in 13 steps once long-prompt lanes ramped).
2. Any **small** last micro shrinks the grad token-scale denominator: **corr(reported grad_norm, 1/vtc) = 0.83** over 76 live steps — norm-based clips react to packing noise and suppress real updates (observed: norm 0.26 at vtc=30 on a fully clean batch → clip cut the applied update ~5×).

## Fix

`reorder_micros_for_vtc_guard(micro_batches, chunk_tokens)`: pin the micro with the **largest** chunk-0 valid count to the last slot. Order within an optimizer step is gradient-neutral (per-token grads are computed python-side and summed), so this changes no update — it makes the zero case impossible whenever any micro has a valid chunk 0 and stabilizes the denominator across steps.

Interim mitigation until the engine carries a step-accumulated counter (tracked in #74).

## Tests

`tests/grpo/test_vtc_packing_guard.py`: 3 contract tests (all-masked-last replaced; max pinned last over a small nonzero last; no-op when already max-last / empty / unchunked). All pass.

## Field validation

Running live on the pool-D campaign since step 90 (guard v1 since step 86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)