### PR TITLE
fix(dpo): make DPO runnable at the default context length

### DIFF
--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -199,7 +199,16 @@ def tokenize_preference_pairs(
         else:
             for start, end in diff_segments:
                 loss_mask[k, prompt_len + start : prompt_len + end] = 1
-        position_ids[k, :L] = np.arange(L, dtype=np.int32)
+        # Across the whole width, not just the used prefix. The engine reads
+        # a document boundary wherever the position id fails to advance by one
+        # (compute_doc_masking), so a zero-filled tail declared every pad token
+        # its own length-1 document, and the flash-varlen backward sizes
+        # dq_accum per document. Padding then drove the allocation instead of
+        # data: 4027 MB against a 1298 MB arena for 101 real tokens. Padding is
+        # absorbed into the row's single document this way, and loss_mask and
+        # targets are already zero there, so nothing about the loss moves. The
+        # SFT tokenizer does the same, for the same reason (train/tokenize.py).
+        position_ids[k] = np.arange(max_len, dtype=np.int32)
         seq_len[k] = L
 
     return PrefBatch(

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -181,10 +181,16 @@ def tokenize_preference_pairs(
         )
 
     n_seq = 2 * n_pairs
-    input_ids = np.full((n_seq, max_len), pad_id, dtype=np.int32)
-    targets = np.zeros((n_seq, max_len), dtype=np.int32)
-    loss_mask = np.zeros((n_seq, max_len), dtype=np.uint8)
-    position_ids = np.zeros((n_seq, max_len), dtype=np.int32)
+    # Width is the longest row that survived, not the configured cap. `max_len`
+    # is the most a row *may* be, and allocating at it made a 50-token pair cost
+    # a 2048-token forward, paid three times per step: the policy pass, the
+    # frozen reference pass, and the backward. Rows too long for the cap have
+    # already been dropped above, so this can only shrink the buffer.
+    width = min(int(max_len), max(len(ids) for ids, _ in seqs))
+    input_ids = np.full((n_seq, width), pad_id, dtype=np.int32)
+    targets = np.zeros((n_seq, width), dtype=np.int32)
+    loss_mask = np.zeros((n_seq, width), dtype=np.uint8)
+    position_ids = np.zeros((n_seq, width), dtype=np.int32)
     seq_len = np.zeros((n_seq,), dtype=np.int32)
 
     for k, (ids, prompt_len) in enumerate(seqs):
@@ -208,11 +214,11 @@ def tokenize_preference_pairs(
         # absorbed into the row's single document this way, and loss_mask and
         # targets are already zero there, so nothing about the loss moves. The
         # SFT tokenizer does the same, for the same reason (train/tokenize.py).
-        position_ids[k] = np.arange(max_len, dtype=np.int32)
+        position_ids[k] = np.arange(width, dtype=np.int32)
         seq_len[k] = L
 
     return PrefBatch(
-        max_len=max_len,
+        max_len=width,
         n_pairs=n_pairs,
         input_ids=input_ids,
         targets=targets,

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -111,7 +111,12 @@ def _diff_segments(
 
 
 def tokenize_preference_pairs(
-    rows: list[dict], tok, max_len: int, pad_id: int | None = None, span_mask: bool = False
+    rows: list[dict],
+    tok,
+    max_len: int,
+    pad_id: int | None = None,
+    span_mask: bool = False,
+    width_multiple: int = 1,
 ) -> PrefBatch:
     """Tokenize {prompt, chosen, rejected} rows into a one-sequence-per-row PrefBatch.
 
@@ -121,6 +126,14 @@ def tokenize_preference_pairs(
     span_mask=True confines loss_mask to the disjoint token blocks where chosen
     and rejected differ. Identical-tokenization rows, and rows where truncation
     removes every differing token from either side, are dropped.
+
+    width_multiple rounds the row width up, clamped by max_len. The engine
+    slices the fused lm-head into `lmhead_chunks` equal nano-batches by
+    truncating division (`fused_lm_head_loss.cpp`), so a `B * width` that is not
+    divisible silently drops the remainder rather than erroring, and in the
+    reference forward those tokens come back as logprob 0.0. `sequence_len` is
+    validated against `lmhead_chunks` at config time; a trimmed width has to
+    carry that property forward itself.
     """
     if pad_id is None:
         pad_id = tok.pad_token_id
@@ -193,6 +206,8 @@ def tokenize_preference_pairs(
     # `max_len` made a short pair cost a full-length forward. `_layout_sequence`
     # has already left-truncated every row to `max_len`, so this cannot exceed it.
     width = max(len(ids) for ids, _ in seqs)
+    if width_multiple > 1:
+        width = min(int(max_len), -(-width // width_multiple) * width_multiple)
     input_ids = np.full((n_seq, width), pad_id, dtype=np.int32)
     targets = np.zeros((n_seq, width), dtype=np.int32)
     loss_mask = np.zeros((n_seq, width), dtype=np.uint8)
@@ -292,7 +307,12 @@ def precompute_ref_logprobs(trainer, batch: PrefBatch, engine_b: int, host_rows:
         rows = end - start
         ids = np.zeros((chunk, max_len), dtype=np.int32)
         tgt = np.zeros((chunk, max_len), dtype=np.int32)
-        pos = np.zeros((chunk, max_len), dtype=np.int32)
+        # Filler rows get the same monotonic ramp as real ones. Zero-filling
+        # them would make each of their pad tokens a length-1 document and flip
+        # doc masking on for this chunk alone (see the module docstring).
+        pos = np.broadcast_to(
+            np.arange(max_len, dtype=np.int32), (chunk, max_len)
+        ).copy()
         ids[:rows] = batch.input_ids[start:end]
         tgt[:rows] = batch.targets[start:end]
         pos[:rows] = batch.position_ids[start:end]

--- a/surogate/dpo/data.py
+++ b/surogate/dpo/data.py
@@ -2,7 +2,8 @@
 
 Each preference row is {prompt, chosen, rejected}. We render prompt+chosen and
 prompt+rejected, mask the prompt (loss only on the response continuation), and
-lay each sequence out as its own right-padded row of width `max_len`. A
+lay each sequence out as its own right-padded row. Rows are laid out at the
+width the data needs, capped by `max_len`, not at `max_len` itself. A
 micro-batch of B rows is therefore B/2 atomic pairs (pair k = rows 2k, 2k+1);
 the trainer (surogate/dpo/data.py packing → step_dpo_native) keeps both rows of a
 pair in the same optimizer step.
@@ -12,8 +13,13 @@ Engine conventions (must match step_dpo_native / the dpo_dloss kernel):
 - loss_mask[j] = 1 iff position j holds a scored response token. The logprob of
   token j is read from losses[j-1] (shifted layout), so the FIRST response token
   (position = prompt_len) and the LAST response token are both scored.
-- position_ids restart at 0 per row; padding uses position 0 and loss_mask 0.
-  Right padding + causal attention means padding never affects real-token logits.
+- position_ids advance by one across the WHOLE row, padding included. The
+  engine reads a document boundary wherever they fail to advance
+  (`compute_doc_masking`), and the flash-varlen backward sizes `dq_accum` per
+  document, so a zero-filled pad tail makes every pad token its own length-1
+  document and the allocation scales with padding instead of data. Right
+  padding plus causal attention already keeps padding out of real-token
+  logits; the ramp is about the document count, not the logits.
 """
 
 from __future__ import annotations
@@ -36,14 +42,16 @@ logger = get_logger()
 class PrefBatch:
     """Tokenized preference pairs, one sequence per row (chosen=2k, rejected=2k+1)."""
 
-    max_len: int
+    # The realised row width, which is the longest row the batch kept. Not the
+    # `max_len` cap the caller passed: that is a ceiling, this is what was used.
+    width: int
     n_pairs: int
-    input_ids: np.ndarray  # int32 [2*n_pairs, max_len]
-    targets: np.ndarray  # int32 [2*n_pairs, max_len]
-    loss_mask: np.ndarray  # uint8 [2*n_pairs, max_len]
-    position_ids: np.ndarray  # int32 [2*n_pairs, max_len]
+    input_ids: np.ndarray  # int32 [2*n_pairs, width]
+    targets: np.ndarray  # int32 [2*n_pairs, width]
+    loss_mask: np.ndarray  # uint8 [2*n_pairs, width]
+    position_ids: np.ndarray  # int32 [2*n_pairs, width]
     seq_len: np.ndarray  # int32 [2*n_pairs] real (unpadded) length per row
-    ref: np.ndarray | None = None  # float32 [2*n_pairs, max_len] reference logprobs (filled by precompute)
+    ref: np.ndarray | None = None  # float32 [2*n_pairs, width] reference logprobs (filled by precompute)
 
     @property
     def n_seq(self) -> int:
@@ -181,16 +189,19 @@ def tokenize_preference_pairs(
         )
 
     n_seq = 2 * n_pairs
-    # Width is the longest row that survived, not the configured cap. `max_len`
-    # is the most a row *may* be, and allocating at it made a 50-token pair cost
-    # a 2048-token forward, paid three times per step: the policy pass, the
-    # frozen reference pass, and the backward. Rows too long for the cap have
-    # already been dropped above, so this can only shrink the buffer.
-    width = min(int(max_len), max(len(ids) for ids, _ in seqs))
+    # The width the data needs, not the configured ceiling: allocating at
+    # `max_len` made a short pair cost a full-length forward. `_layout_sequence`
+    # has already left-truncated every row to `max_len`, so this cannot exceed it.
+    width = max(len(ids) for ids, _ in seqs)
     input_ids = np.full((n_seq, width), pad_id, dtype=np.int32)
     targets = np.zeros((n_seq, width), dtype=np.int32)
     loss_mask = np.zeros((n_seq, width), dtype=np.uint8)
-    position_ids = np.zeros((n_seq, width), dtype=np.int32)
+    # Identical for every row: one document running the full width. See the
+    # position_ids bullet in the module docstring for why the ramp continues
+    # through padding.
+    position_ids = np.broadcast_to(
+        np.arange(width, dtype=np.int32), (n_seq, width)
+    ).copy()
     seq_len = np.zeros((n_seq,), dtype=np.int32)
 
     for k, (ids, prompt_len) in enumerate(seqs):
@@ -205,20 +216,10 @@ def tokenize_preference_pairs(
         else:
             for start, end in diff_segments:
                 loss_mask[k, prompt_len + start : prompt_len + end] = 1
-        # Across the whole width, not just the used prefix. The engine reads
-        # a document boundary wherever the position id fails to advance by one
-        # (compute_doc_masking), so a zero-filled tail declared every pad token
-        # its own length-1 document, and the flash-varlen backward sizes
-        # dq_accum per document. Padding then drove the allocation instead of
-        # data: 4027 MB against a 1298 MB arena for 101 real tokens. Padding is
-        # absorbed into the row's single document this way, and loss_mask and
-        # targets are already zero there, so nothing about the loss moves. The
-        # SFT tokenizer does the same, for the same reason (train/tokenize.py).
-        position_ids[k] = np.arange(width, dtype=np.int32)
         seq_len[k] = L
 
     return PrefBatch(
-        max_len=width,
+        width=width,
         n_pairs=n_pairs,
         input_ids=input_ids,
         targets=targets,

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -150,16 +150,9 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     checkpoint_dir = config.checkpoint_dir or str(Path(config.output_dir))
 
     # --- tokenize preference pairs, before anything is sized to T -----------
-    # The trainer's arena and buffers are allocated for `seq_len` at
-    # construction, so T has to be known first. Reading the data here rather
-    # than after the build is what lets it be the length the data actually
-    # needs instead of the configured ceiling; `sequence_len` stays the cap,
-    # and rows that do not fit it are still dropped during tokenization.
-    #
-    # Nothing between here and the old position reads the data: the IR build
-    # and JIT compile depend only on `config.model_dir`. Doing it first also
-    # means a dataset that cannot be tokenized fails before the JIT compile
-    # rather than after it.
+    # The trainer's buffers are allocated for `seq_len` at construction, so T
+    # has to come from the tokenized batch: `sequence_len` is the cap, the batch
+    # reports the width the data actually needed.
     rows = _load_pref_datasets(config.datasets or [], num_workers=config.dataloader_num_workers or 1)
     batch = tokenize_preference_pairs(
         rows,
@@ -167,8 +160,13 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
         max_len=int(config.sequence_len),
         span_mask=config.loss.span_mask,
     )
-    T = int(batch.max_len)
-    logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
+    T = batch.width
+    n_rows = len(rows)
+    # The raw rows are only needed for the count from here on, and would
+    # otherwise stay resident through the JIT compile and weight import.
+    del rows
+    logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {n_rows} rows)")
+    Path(config.output_dir).mkdir(parents=True, exist_ok=True)
 
     # --- compile the DSL IR + JIT kernels (mirrors SurogateTrainerWrapper) ---
     from surogate.dsl.ir_builder import build_dsl_ir_for_model
@@ -228,7 +226,6 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
         else:
             logger.info("No DPO checkpoint found; starting from step 0")
 
-    Path(config.output_dir).mkdir(parents=True, exist_ok=True)
     # Reference log-probs are computed INLINE per micro-step (see module docstring):
     # the frozen-ref forward must share the policy step's exact batch so fp8's
     # current-batch activation scaling produces a matching scale (margin == 0 at init).

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -144,11 +144,31 @@ def _reference_free_logprobs(
 def dpo_main(config: DPOTrainConfig, args=None) -> None:
     ngpu = max(1, int(config.gpus or 1))
     B = int(config.per_device_train_batch_size)
-    T = int(config.sequence_len)
     if B % 2 != 0:
         raise ValueError(f"per_device_train_batch_size must be even (pairs are 2 rows); got {B}")
     pairs_per_gpu = B // 2
     checkpoint_dir = config.checkpoint_dir or str(Path(config.output_dir))
+
+    # --- tokenize preference pairs, before anything is sized to T -----------
+    # The trainer's arena and buffers are allocated for `seq_len` at
+    # construction, so T has to be known first. Reading the data here rather
+    # than after the build is what lets it be the length the data actually
+    # needs instead of the configured ceiling; `sequence_len` stays the cap,
+    # and rows that do not fit it are still dropped during tokenization.
+    #
+    # Nothing between here and the old position reads the data: the IR build
+    # and JIT compile depend only on `config.model_dir`. Doing it first also
+    # means a dataset that cannot be tokenized fails before the JIT compile
+    # rather than after it.
+    rows = _load_pref_datasets(config.datasets or [], num_workers=config.dataloader_num_workers or 1)
+    batch = tokenize_preference_pairs(
+        rows,
+        config.tokenizer,
+        max_len=int(config.sequence_len),
+        span_mask=config.loss.span_mask,
+    )
+    T = int(batch.max_len)
+    logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
 
     # --- compile the DSL IR + JIT kernels (mirrors SurogateTrainerWrapper) ---
     from surogate.dsl.ir_builder import build_dsl_ir_for_model
@@ -208,10 +228,6 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
         else:
             logger.info("No DPO checkpoint found; starting from step 0")
 
-    # --- tokenize preference pairs -----------------------------------------
-    rows = _load_pref_datasets(config.datasets or [], num_workers=config.dataloader_num_workers or 1)
-    batch = tokenize_preference_pairs(rows, config.tokenizer, max_len=T, span_mask=config.loss.span_mask)
-    logger.info(f"Tokenized {batch.n_pairs} preference pairs (from {len(rows)} rows)")
     Path(config.output_dir).mkdir(parents=True, exist_ok=True)
     # Reference log-probs are computed INLINE per micro-step (see module docstring):
     # the frozen-ref forward must share the policy step's exact batch so fp8's

--- a/surogate/dpo/trainer.py
+++ b/surogate/dpo/trainer.py
@@ -25,6 +25,7 @@ forward and optimizes the chosen-vs-rejected likelihood gap directly.
 """
 
 import json
+import math
 import shutil
 import tempfile
 import time
@@ -45,6 +46,12 @@ from surogate.utils.lora_compat import ensure_surogate_lora_compat, ensure_vllm_
 from surogate.utils.tensor import to_surogate_dtype
 
 logger = get_logger()
+
+# NVFP4's RHT transform hard-throws unless B*T is a multiple of 16
+# (csrc/.../nvfp4_recipe.cpp). Only reachable on a full-finetune DPO run, but
+# folding it into the width alignment costs a few pad tokens and removes the
+# failure mode entirely.
+_NVFP4_BT_MULTIPLE = 16
 
 
 def _normalize_pref_row(row: dict) -> dict:
@@ -154,11 +161,19 @@ def dpo_main(config: DPOTrainConfig, args=None) -> None:
     # has to come from the tokenized batch: `sequence_len` is the cap, the batch
     # reports the width the data actually needed.
     rows = _load_pref_datasets(config.datasets or [], num_workers=config.dataloader_num_workers or 1)
+    # The trimmed width has to keep the divisibility `sequence_len` was
+    # validated for. The fused lm-head splits `B * T` into `lmhead_chunks` equal
+    # nano-batches by truncating division and silently drops the remainder; the
+    # NVFP4 path additionally hard-requires a multiple of 16. Aligning the width
+    # covers both, and can only round up to at most `sequence_len`, which is
+    # already a valid width by construction.
+    align = math.lcm(max(1, int(config.lmhead_chunks or 1)), _NVFP4_BT_MULTIPLE)
     batch = tokenize_preference_pairs(
         rows,
         config.tokenizer,
         max_len=int(config.sequence_len),
         span_mask=config.loss.span_mask,
+        width_multiple=align,
     )
     T = batch.width
     n_rows = len(rows)

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -164,55 +164,34 @@ def test_span_mask_drops_pair_when_only_one_side_has_surviving_edit_tokens():
 # ── padding must not look like document boundaries ─────────────────
 
 
-def _doc_count(position_ids_row) -> int:
-    """Documents the engine would see in one row.
-
-    Mirrors `compute_doc_masking` (csrc/.../causal_lm_execution_profile.cpp):
-    a new document starts wherever the position id does not advance by one.
-    """
-    row = np.asarray(position_ids_row)
-    return 1 + int(np.sum(np.diff(row) != 1))
-
-
 def test_position_ids_advance_across_padding():
-    """Zero-filled padding made every pad token its own document.
+    """A padded row must read as ONE document to the engine, not as one per
+    pad token.
 
-    `dq_accum` in the flash-varlen backward is sized per document, so a short
-    row at a large `max_len` asked for gigabytes: 4027 MB against a 1298 MB
-    arena on a 0.6B model, for 101 real tokens in 4096 slots.
+    `compute_doc_masking` starts a new document wherever a position id fails to
+    advance by one, and the flash-varlen backward sizes `dq_accum` per
+    document, so a zero-filled pad tail made the allocation scale with padding:
+    4027 MB against a 1298 MB arena for 101 real tokens in 4096 slots.
+
+    The fixture must contain rows of DIFFERING length. Rows are trimmed to the
+    longest one, so a uniform fixture ends up with no padding at all and this
+    would assert nothing.
     """
-    tok = FakeTok()
-    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
-    b = tokenize_preference_pairs(rows, tok, max_len=512)
-
-    for k in range(b.n_seq):
-        assert np.all(np.diff(b.position_ids[k]) == 1), (
-            "position ids must advance by one across the whole row, padding included"
-        )
-
-
-def test_a_row_is_one_document_however_much_padding_it_has():
     tok = FakeTok()
     rows = [
-        {"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"},
-        {"prompt": "alt prompt", "chosen": "da", "rejected": "nu"},
+        {"prompt": "un prompt ceva mai lung aici", "chosen": "raspuns lung", "rejected": "raspuns scurt"},
+        {"prompt": "scurt", "chosen": "da", "rejected": "nu"},
     ]
-    b = tokenize_preference_pairs(rows, tok, max_len=512)
+    b = tokenize_preference_pairs(rows, tok, max_len=2048)
 
-    total_docs = sum(_doc_count(b.position_ids[k]) for k in range(b.n_seq))
-    assert total_docs == 2 * b.n_pairs, (
-        f"expected one document per sequence, got {total_docs} for {b.n_seq} sequences"
-    )
-
-
-def test_padding_change_does_not_touch_the_loss():
-    """The fix must be invisible to the loss: `loss_mask` and `targets` are
-    already zero across padding, so only `position_ids` may differ."""
-    tok = FakeTok()
-    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
-    b = tokenize_preference_pairs(rows, tok, max_len=512)
+    padding = [b.width - int(L) for L in b.seq_len]
+    assert max(padding) > 0, "fixture must actually pad, or this test is vacuous"
 
     for k in range(b.n_seq):
+        # Every step is exactly one, so the engine sees a single document
+        # spanning the row however much of it is padding.
+        assert np.all(np.diff(b.position_ids[k]) == 1)
+        # And the padding stays out of the loss, as it always did.
         L = int(b.seq_len[k])
         assert b.loss_mask[k, L:].sum() == 0
         assert np.all(b.targets[k, L:] == 0)
@@ -229,15 +208,16 @@ def test_batch_width_tracks_the_data_not_the_cap():
     b = tokenize_preference_pairs(rows, tok, max_len=2048)
 
     longest = int(b.seq_len.max())
-    assert b.max_len == longest, f"width {b.max_len} should track the longest row {longest}"
+    assert b.width == longest, f"width {b.width} should track the longest row {longest}"
     assert b.input_ids.shape == (b.n_seq, longest)
     assert b.position_ids.shape == (b.n_seq, longest)
     assert b.loss_mask.shape == (b.n_seq, longest)
 
 
-def test_the_cap_still_drops_what_does_not_fit():
-    """Trimming must not turn the cap into a suggestion: rows too long for
-    `max_len` are still dropped, and the width never exceeds it."""
+def test_width_never_exceeds_the_cap():
+    """Trimming must not turn the cap into a suggestion. Note rows longer than
+    `max_len` are left-truncated to it rather than dropped, so what this checks
+    is that the realised width still honours the ceiling."""
     tok = FakeTok()
     rows = [
         {"prompt": "a b c d e f g h", "chosen": "x y z", "rejected": "p q r"},
@@ -245,7 +225,7 @@ def test_the_cap_still_drops_what_does_not_fit():
     ]
     b = tokenize_preference_pairs(rows, tok, max_len=4)
 
-    assert b.max_len <= 4
+    assert b.width <= 4
     assert int(b.seq_len.max()) <= 4
 
 
@@ -261,6 +241,6 @@ def test_padding_still_present_when_rows_differ_in_length():
 
     lengths = {int(x) for x in b.seq_len}
     assert len(lengths) > 1, "fixture must contain rows of differing length"
-    assert b.max_len == max(lengths)
+    assert b.width == max(lengths)
     for k in range(b.n_seq):
         assert np.all(np.diff(b.position_ids[k]) == 1)

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -244,3 +244,51 @@ def test_padding_still_present_when_rows_differ_in_length():
     assert b.width == max(lengths)
     for k in range(b.n_seq):
         assert np.all(np.diff(b.position_ids[k]) == 1)
+
+
+# ── the width must keep the divisibility the config was validated for ──
+
+
+def test_width_is_rounded_up_to_the_requested_multiple():
+    """`sequence_len` is validated against `lmhead_chunks` at config time; a
+    trimmed width has to carry that forward itself.
+
+    The fused lm-head splits `B * T` into `lmhead_chunks` equal nano-batches by
+    truncating division and runs exactly that many, so a non-divisible width
+    silently drops the remainder. In the reference forward those tokens come
+    back as logprob 0.0, and because the width is the *longest* row, the dropped
+    tail belongs to a row with real scored tokens: wrong margins, no error.
+    """
+    tok = FakeTok()
+    rows = [
+        {"prompt": "un prompt ceva mai lung aici", "chosen": "raspuns lung", "rejected": "raspuns scurt"},
+        {"prompt": "scurt", "chosen": "da", "rejected": "nu"},
+    ]
+    natural = tokenize_preference_pairs(rows, tok, max_len=2048)
+    aligned = tokenize_preference_pairs(rows, tok, max_len=2048, width_multiple=16)
+
+    assert aligned.width % 16 == 0
+    assert aligned.width >= natural.width
+    assert aligned.width - natural.width < 16  # rounded up, not inflated
+
+
+def test_alignment_never_exceeds_the_cap():
+    """Rounding up must not push the width past `max_len`, whatever multiple is
+    asked for."""
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=8, width_multiple=64)
+
+    assert b.width <= 8
+
+
+def test_padding_from_alignment_is_still_one_document():
+    """The pad cells alignment adds are padding like any other, and must not
+    read as document boundaries."""
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=2048, width_multiple=16)
+
+    assert b.width > int(b.seq_len.max()), "alignment must have added padding here"
+    for k in range(b.n_seq):
+        assert np.all(np.diff(b.position_ids[k]) == 1)

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -157,3 +157,60 @@ def test_span_mask_drops_pair_when_only_one_side_has_surviving_edit_tokens():
 
     with pytest.raises(ValueError, match="no preference pair"):
         tokenize_preference_pairs(rows, tok, max_len=8, span_mask=True)
+
+
+# ── padding must not look like document boundaries ─────────────────
+
+
+def _doc_count(position_ids_row) -> int:
+    """Documents the engine would see in one row.
+
+    Mirrors `compute_doc_masking` (csrc/.../causal_lm_execution_profile.cpp):
+    a new document starts wherever the position id does not advance by one.
+    """
+    row = np.asarray(position_ids_row)
+    return 1 + int(np.sum(np.diff(row) != 1))
+
+
+def test_position_ids_advance_across_padding():
+    """Zero-filled padding made every pad token its own document.
+
+    `dq_accum` in the flash-varlen backward is sized per document, so a short
+    row at a large `max_len` asked for gigabytes: 4027 MB against a 1298 MB
+    arena on a 0.6B model, for 101 real tokens in 4096 slots.
+    """
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=512)
+
+    for k in range(b.n_seq):
+        assert np.all(np.diff(b.position_ids[k]) == 1), (
+            "position ids must advance by one across the whole row, padding included"
+        )
+
+
+def test_a_row_is_one_document_however_much_padding_it_has():
+    tok = FakeTok()
+    rows = [
+        {"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"},
+        {"prompt": "alt prompt", "chosen": "da", "rejected": "nu"},
+    ]
+    b = tokenize_preference_pairs(rows, tok, max_len=512)
+
+    total_docs = sum(_doc_count(b.position_ids[k]) for k in range(b.n_seq))
+    assert total_docs == 2 * b.n_pairs, (
+        f"expected one document per sequence, got {total_docs} for {b.n_seq} sequences"
+    )
+
+
+def test_padding_change_does_not_touch_the_loss():
+    """The fix must be invisible to the loss: `loss_mask` and `targets` are
+    already zero across padding, so only `position_ids` may differ."""
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=512)
+
+    for k in range(b.n_seq):
+        L = int(b.seq_len[k])
+        assert b.loss_mask[k, L:].sum() == 0
+        assert np.all(b.targets[k, L:] == 0)

--- a/tests/dpo/test_preference_tokenize.py
+++ b/tests/dpo/test_preference_tokenize.py
@@ -41,7 +41,9 @@ def test_masks_and_targets_and_pairing():
 
     assert b.n_pairs == 1
     assert b.n_seq == 2
-    assert b.input_ids.shape == (2, 32)
+    # Width tracks the data, not the `max_len` cap: these rows are far short
+    # of 32, and allocating at the cap was the padding waste bug 26 removes.
+    assert b.input_ids.shape == (2, int(b.seq_len.max()))
 
     for k in range(2):
         L = int(b.seq_len[k])
@@ -214,3 +216,51 @@ def test_padding_change_does_not_touch_the_loss():
         L = int(b.seq_len[k])
         assert b.loss_mask[k, L:].sum() == 0
         assert np.all(b.targets[k, L:] == 0)
+
+
+# ── the batch is sized to the data, not to the config ──────────────
+
+
+def test_batch_width_tracks_the_data_not_the_cap():
+    """A 50-token pair used to cost a 2048-token forward, three times over:
+    the policy pass, the frozen reference pass, and the backward."""
+    tok = FakeTok()
+    rows = [{"prompt": "scrie un cuvant", "chosen": "mergeam acasa", "rejected": "mergeram acasa"}]
+    b = tokenize_preference_pairs(rows, tok, max_len=2048)
+
+    longest = int(b.seq_len.max())
+    assert b.max_len == longest, f"width {b.max_len} should track the longest row {longest}"
+    assert b.input_ids.shape == (b.n_seq, longest)
+    assert b.position_ids.shape == (b.n_seq, longest)
+    assert b.loss_mask.shape == (b.n_seq, longest)
+
+
+def test_the_cap_still_drops_what_does_not_fit():
+    """Trimming must not turn the cap into a suggestion: rows too long for
+    `max_len` are still dropped, and the width never exceeds it."""
+    tok = FakeTok()
+    rows = [
+        {"prompt": "a b c d e f g h", "chosen": "x y z", "rejected": "p q r"},
+        {"prompt": "scurt", "chosen": "da", "rejected": "nu"},
+    ]
+    b = tokenize_preference_pairs(rows, tok, max_len=4)
+
+    assert b.max_len <= 4
+    assert int(b.seq_len.max()) <= 4
+
+
+def test_padding_still_present_when_rows_differ_in_length():
+    """Trimming is to the longest row, not per row: shorter rows keep their
+    padding, and it still must not read as document boundaries."""
+    tok = FakeTok()
+    rows = [
+        {"prompt": "un prompt ceva mai lung aici", "chosen": "raspuns lung", "rejected": "raspuns scurt"},
+        {"prompt": "scurt", "chosen": "da", "rejected": "nu"},
+    ]
+    b = tokenize_preference_pairs(rows, tok, max_len=2048)
+
+    lengths = {int(x) for x in b.seq_len}
+    assert len(lengths) > 1, "fixture must contain rows of differing length"
+    assert b.max_len == max(lengths)
+    for k in range(b.n_seq):
+        assert np.all(np.diff(b.position_ids[k]) == 1)


### PR DESCRIPTION
## Why

DPO could not run at the default context length. A real run asked for 4090 MB of
attention scratch against a 1298 MB arena and died in the first backward, before
step 0, after provisioning a GPU. It had failed that way three times.

## What was wrong

**Padding became attention documents.** Position ids were written over each row's
used prefix and the padded tail left zero-filled. The engine starts a new document
wherever a position id fails to advance by one (`compute_doc_masking`), and the
flash-varlen backward sizes `dq_accum` per document, so the allocation scaled with
padding rather than data. Position ids now advance across the whole row. `loss_mask`
and `targets` were already zero there, so the loss cannot move. Same convention the
SFT tokenizer already uses.

**The batch was sized to the config, not the data.** Arrays were allocated at
`sequence_len`, so a 50-token pair cost a 2048-token forward, paid three times per
step. Trimming alone would not have worked: `T` was handed to
`SurogateTrainer(seq_len=T)` before the data was tokenized, so the data is now read
first and `T` comes from the batch. `sequence_len` stays the cap.

**That broke an invariant the config had validated.** Found in review, and the one
that fails silently. `lmhead_chunks` is chosen so `B * sequence_len` divides evenly;
taking `T` from the batch left the check guarding a number the run no longer used.
`fused_lm_head_loss.cpp` divides `BT / lmhead_chunks` by truncation and runs exactly
that many iterations, so the remainder is never processed, and in the reference
forward those tokens read back as logprob 0.0. Wrong margins, no error. Width is now
rounded to `lcm(lmhead_chunks, 16)`, clamped by `sequence_len`.

## Verification

Against the published image, in a container, so this is the real engine and not a
rebuild. The image's `surogate/dpo/` was byte-identical to `main`, so this branch's
diff was applied to the image's own copy and mounted over the installed package;
every line changed here is pure Python. Control and test differ by exactly this diff,
same GPU, same config.

| | control (`main`) | this branch |
|---|---|---|
| `T` | 2048 | **64** |
| `dq_accum` | **4090 MB** vs a 1298 MB arena, `std::bad_alloc` | no failure |
| steps | none, died before step 0 | **5/5**, adapter written |

`step=0 dpo_loss=0.6931 margin=0.0000` is `ln(2)` exactly, which holds only if the
policy and its frozen reference agree on every scored token: the evidence for the
third fix specifically.

Also passing: `reference_free`, `span_mask`, long rows at `sequence_len: 512`
(`T=512`, so the trim only shrinks when data is short), and checkpoint at `T=64`
resumed at `T=112`. That last one is what this change put at risk, since `T` used to
be pinned to `sequence_len`; it is safe because LoRA checkpoints carry no
sequence-length dimension.

18 unit tests, pure numpy, no GPU. The padding regression test counts documents the
way the engine does; before the fix it saw 2032 for four sequences.

## Not covered

- **Multi-GPU and full finetune both fail**, but identically on unmodified `main`,
  A/B'd at a matched `T`. Pre-existing, filed separately.
- Because full finetune does not run at all, the NVFP4 multiple-of-16 half of the
  alignment is reasoned rather than exercised. The `lmhead_chunks` half, which is the
  one that was failing, is exercised.
- No run has gone through Studio with this code and none can until a release ships.
  Nothing ops-side changes here.
