### PR TITLE
fix(distill): isolate packed documents without flash-attention-2

### DIFF
--- a/docs/guides/distillation.md
+++ b/docs/guides/distillation.md
@@ -29,17 +29,26 @@ surogate sft config.yaml
 ### Capture CLI flags
 
 ```bash
-surogate distill-capture config.yaml [--api-base URL] [--device cuda:0] [--allow-cross-doc-attention] [--hub_token TOKEN]
+surogate distill-capture config.yaml [--api-base URL] [--device cuda:0] [--hub_token TOKEN]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--api-base` | none | OpenAI-compatible base URL of a served teacher (e.g. `http://localhost:8000/v1`); overrides `distillation.teacher_api_base` and switches capture to the API backend (below). |
 | `--device` | `cuda:0` | Device to run the local teacher model on (e.g. `cuda:1`). Ignored with a warning in API mode. |
-| `--allow-cross-doc-attention` | off | Local backend only: allow the `sdpa` fallback when flash-attention-2 is unavailable. Packed documents will then attend across document boundaries during capture (an approximation). Ignored with a warning in API mode. |
 | `--hub_token` | none | Hugging Face token for private model access |
 
-By default the teacher is loaded locally with `transformers` in bf16. The local backend **requires flash-attention-2** for per-document attention isolation of packed samples (the shard's per-document `position_ids` resets drive varlen attention); without flash-attn it errors out unless you pass `--allow-cross-doc-attention`.
+By default the teacher is loaded locally with `transformers` in bf16 using `sdpa` attention. Packed documents are isolated by transformers' own **packed-sequence support**: it reads the shard's per-document `position_ids` resets and builds a block-diagonal causal mask, so a token can only attend within its own document. **No flash-attn is required.**
+
+This depends on capture passing `use_cache=False`, and the reason is easy to misread from the transformers source. The model's `forward` declares `use_cache: bool | None = None` and allocates a cache only under `if use_cache and past_key_values is None`, which looks as though omitting the argument is safe. It is not: a `@merge_with_config_defaults` decorator substitutes `config.use_cache` (normally `True`) before the body runs, a cache is allocated, packed detection is skipped, and the teacher attends straight across document boundaries — silently. Measured: omitting the argument diverges from per-document gold by 0.535, identical to passing `use_cache=True`.
+
+Measured against a per-document reference (each document run alone, which is what capture is meant to reproduce), scored on the top-64 id set the sidecar stores, at `sequence_len` 2048 with `teacher_batch_size` 4 on one L4: this path reaches **98.46%** overlap versus flash-attention varlen's **98.32%** — a tie inside bf16 kernel noise — while attention with *no* isolation reaches only **42.67%**. Cost is about +18% capture time versus flash-attn, and +0.4% peak memory **at that
+`sequence_len`**. Read the memory figure as scale-dependent: this path materialises a
+dense `[batch, 1, S, S]` mask where flash-attn's varlen kernel materialised none, so it
+grows with the square of `sequence_len`. The mask is a **bool** `(batch, 1, S, S)` tensor
+(1 byte per element), so with `teacher_batch_size` 4 that is roughly **17 MB at 2048,
+268 MB at 8192 and 1073 MB at 16384**. If that ever binds, `attn_implementation="flex_attention"`
+expresses the same mask sparsely and also needs no flash-attn.
 
 ### Remote teacher (vLLM API)
 
@@ -53,7 +62,7 @@ vllm serve Qwen/Qwen3-32B --max-logprobs 64
 surogate distill-capture config.yaml --api-base http://localhost:8000/v1
 ```
 
-How it works: capture sends **token-id prompts** through vLLM's `prompt_logprobs` completions extension — one request per packed document (split at the shard's position-id resets, with a one-token lookahead), which gives **exact per-document context isolation with no flash-attn requirement**. Up to `teacher_api_concurrency` requests are in flight at once (default 8), each with a `teacher_api_timeout` of 1200 s; transient failures (transport errors, HTTP 429/5xx) are retried 3 times with backoff. The API key is read from the environment variable named by `teacher_api_key_var` (default `VLLM_API_KEY`); if unset, `EMPTY` is sent, which local unauthenticated vLLM servers accept.
+How it works: capture sends **token-id prompts** through vLLM's `prompt_logprobs` completions extension — one request per packed document (split at the shard's position-id resets, with a one-token lookahead), which gives **exact per-document context isolation** (one document per request, so there is nothing to mask). Up to `teacher_api_concurrency` requests are in flight at once (default 8), each with a `teacher_api_timeout` of 1200 s; transient failures (transport errors, HTTP 429/5xx) are retried 3 times with backoff. The API key is read from the environment variable named by `teacher_api_key_var` (default `VLLM_API_KEY`); if unset, `EMPTY` is sent, which local unauthenticated vLLM servers accept.
 
 Two hard requirements:
 
@@ -235,9 +244,6 @@ Captures write to a `.tmp` file and rename atomically on completion, so this nor
 
 **Missing `.tokenize_hash`** — `distillation is enabled but no <output_dir>/.tokenize_hash was found...`
 The output dir has shards but no tokenization hash (e.g. partially copied). Re-run tokenization and the capture.
-
-**Capture: flash-attention-2 not available** — `distill-capture requires flash-attention-2 for per-document attention isolation...`
-Install flash-attn, or accept the cross-document-attention approximation with `--allow-cross-doc-attention` (packed documents will then see each other during teacher capture).
 
 **Capture: token id out of teacher vocab** — `Token shard '<path>' contains token id <X> but the teacher vocab size is <Y>. Student and teacher must share a tokenizer. For cross-tokenizer distillation, first transplant the teacher's tokenizer onto the student ... then re-tokenize and re-capture against the transplanted model.`
 Your teacher does not share the student's tokenizer. Pick a teacher from the same family, or follow the error's advice — see [Cross-tokenizer distillation](#cross-tokenizer-distillation).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,7 +73,6 @@ Options:
 
 - `--api-base <url>`: OpenAI-compatible base URL of a served teacher, e.g. `http://localhost:8000/v1` (overrides `distillation.teacher_api_base`). Requires a vLLM-compatible server started with `--max-logprobs >= distillation.top_k`
 - `--device <device>`: device to run the local teacher model on (default `cuda:0`); ignored with a warning in API mode
-- `--allow-cross-doc-attention`: allow the sdpa fallback when flash-attention-2 is unavailable; packed documents will attend across document boundaries during capture; ignored with a warning in API mode
 - `--hub_token <token>`: optional, Hugging Face token for private model access
 
 ### `transplant-tokenizer`

--- a/docs/superpowers/specs/2026-09-03-distill-capture-attention-mask-design.md
+++ b/docs/superpowers/specs/2026-09-03-distill-capture-attention-mask-design.md
@@ -1,0 +1,213 @@
+# distill-capture: replace flash-attn varlen with a block-diagonal attention mask
+
+## Problem
+
+`surogate distill-capture` cannot run in any shipped image. It aborts before the
+teacher is even downloaded:
+
+```
+RuntimeError: distill-capture requires flash-attention-2 for per-document attention
+isolation (position_ids resets -> varlen). Install flash-attn, or pass
+--allow-cross-doc-attention to accept the cross-document approximation with sdpa.
+```
+
+`_load_teacher` (`surogate/distill/capture.py:66-82`) hard-requires
+flash-attention-2. `flash-attn` is not a dependency and is installed by none of
+`Dockerfile.cu128/129/130`. vLLM's vendored `vllm_flash_attn` is a different
+distribution and does not satisfy `transformers.utils.is_flash_attn_2_available()`.
+
+Live-confirmed 2026-09-03 on Modal (`kd-test-1`): failed in 68 s, `$0.0151`,
+`surogate sft` never invoked, zero metric rows. This blocks knowledge distillation
+end to end on the platform.
+
+## Why the obvious fix is unavailable
+
+Adding `flash-attn` to the images is not a Dockerfile line. Dao-AILab publishes
+prebuilt FA2 wheels (cp312 / linux_x86_64) for torch **2.2 through 2.10**; the
+trainer images ship **torch 2.11.0+cu128**. The remaining routes all have real
+costs: a source compile on every image build, a torch downgrade affecting every
+training method, an indefinite upstream wait, or an engine change to accept FA3
+(which `is_flash_attn_2_available()` cannot see, since FA3 ships as the separate
+`flash_attn_interface` distribution).
+
+## What flash-attn was doing, and why it matters
+
+Tokenized shards **pack** several short documents into one `sequence_len` window
+(real run: 1800 docs, mean 162 tokens, into 2048-token windows) and mark each
+document start by resetting `position_ids` to 0.
+
+The teacher must not let a packed document attend to its neighbours. If it does,
+the stored distribution answers a question that will never be asked at training
+time. flash-attn's varlen mode achieved this by taking document boundaries
+(`cu_seq_lens`) and never computing attention across them. This is also why
+`capture_shard` flattens the batch to `[1, B*S]` before the forward: that shape
+plus boundaries is what triggers transformers' padding-free flash path.
+
+## Design: let transformers build the mask
+
+**Revised during the simplify gate.** The first implementation hand-rolled a 4D
+block-diagonal mask in a new `surogate/distill/mask.py`. That module has been
+deleted: `transformers >= 5.5` already does exactly this, and doing it by hand is
+actively worse (see "Why not a hand-rolled mask" below).
+
+Capture passes `position_ids` and `use_cache=False`, and transformers'
+packed-sequence support (`masking_utils.find_packed_sequence_indices` ->
+`packed_sequence_mask_function` -> `sdpa_mask`) derives the document boundaries
+and builds the mask itself. The mask it produces is what we want. For a window
+holding doc A (3 tokens) and doc B (2 tokens):
+
+```
+tokens        A1  A2  A3  B1  B2
+position_ids   0   1   2   0   1      <- reset marks a new document
+
+        A1 A2 A3 B1 B2
+    A1   x  .  .  .  .
+    A2   x  x  .  .  .
+    A3   x  x  x  .  .
+    B1   .  .  .  x  .       block diagonal: B cannot see A
+    B2   .  .  .  x  x       lower triangular within each block: causal
+```
+
+Allowed iff `same_document(i, j) AND j <= i`.
+
+This needs **no flash-attn, no torch pin and no image change**, and no mask code
+of our own.
+
+### `use_cache=False` is load-bearing
+
+`_preprocess_mask_arguments` runs packed detection only when
+`attention_mask is None and past_key_values is None`.
+
+The trap is that reading the model source suggests omitting `use_cache` is safe:
+`Qwen3Model.forward` declares `use_cache: bool | None = None` and allocates a
+cache only under `if use_cache and past_key_values is None`. But the forward
+carries `@merge_with_config_defaults` (`transformers/utils/generic.py:908`, with
+`use_cache` first in its list), which substitutes `config.use_cache` -- normally
+`True` -- before the body runs. A `DynamicCache` is then allocated, detection is
+skipped, and the teacher attends across document boundaries.
+
+Measured on transformers 5.7.0, max abs divergence from per-document gold:
+`use_cache=False` **1.8e-07**, argument **omitted 0.535**, `use_cache=True`
+**0.535**. An external reviewer read the signature and the `if use_cache` line
+and concluded the argument was inert; it is not. Pinned by a test.
+
+### Why not a hand-rolled mask
+
+Passing a 4D `attention_mask` makes `_preprocess_mask_arguments` early-return it
+verbatim for **both** `create_causal_mask` and `create_sliding_window_causal_mask`.
+A sliding-window teacher (Gemma3, gpt-oss class) therefore loses its sliding
+layers and silently gets full within-document attention. Measured on a 2-layer
+Gemma3 with `layer_types=['sliding_attention','full_attention']`, against
+per-document gold:
+
+| | max abs logit error vs gold |
+|---|---|
+| transformers packed support | **2.76e-07** |
+| hand-rolled 4D block-diagonal mask | **0.51** |
+
+That is the same order as no isolation at all, on any sliding-window teacher, and
+`tests/distill/test_capture.py` only exercises Qwen3 so it would not have caught
+it. On Qwen3 the two paths are bit-identical (max diff exactly 0.0), so the
+hand-rolled mask bought nothing and cost correctness elsewhere.
+
+### Consequence: drop the flattening, which fixes bug 34 for free
+
+The `unsqueeze(0)` flattening exists *only* to trigger the flash path. With an
+explicit mask that reason is gone, so capture returns to a natural `[B, S]`
+batch. `_topk_logprobs` (`capture.py:94-106`) was written to iterate one window
+at a time and only degenerated into converting the whole batch to fp32 because
+flattening made the batch dimension 1. Restoring `[B, S]` makes the loop do what
+its docstring says. Measured cost of the current behaviour: capture peaked at
+**21,569 MiB on a 24 GB L4** for a 1.7B teacher whose weights are ~3.4 GB.
+
+## Evidence
+
+Scored against **gold** (each document run alone, unpacked, which is by
+definition what capture should store) on the top-64 id set the sidecar holds.
+Four mixed documents (English, Romanian, Python source, business prose):
+
+| packing strategy | top-64 overlap vs gold | argmax agreement |
+|---|---|---|
+| `fa2` varlen (today's intended path) | 98.32% | 98.72% |
+| **`sdpa` + block-diagonal mask** | **98.46%** | **98.72%** |
+| `sdpa`, no mask (`--allow-cross-doc-attention`) | **42.67%** | 42.95% |
+
+Isolation with the mask is exact (max delta 0.0). Noise floor: FA2 vs plain sdpa
+on a *single unpacked document*, computing identical maths, still differ by 4.08
+max / 0.045 mean on logits of magnitude 33, with 98.16% top-64 overlap. So
+98.46 vs 98.32 is a tie.
+
+Cost at the real 4x2048 shape, Qwen3-1.7B on an L4:
+
+| arm | peak | median/forward |
+|---|---|---|
+| `fa2`, flattened | 8967 MiB | 0.808 s |
+| `sdpa` + mask, flattened | 9095 MiB | 1.397 s |
+| **`sdpa` + mask, batched `[B, S]`** | **8999 MiB** | **0.952 s** |
+
+Batched is the layout to adopt: +0.4% memory and +18% time versus FA2, and 32%
+faster than masking the flattened layout.
+
+## Decisions
+
+1. **One attention path.** Always masked `sdpa`. No conditional FA2 fast path.
+   A path that cannot be exercised in CI or in the shipped image (no torch 2.11
+   wheel) is permanently untested code, which is the exact mechanism that
+   produced this bug. The 18% is a one-time capture cost, not per-step training.
+2. **Delete `--allow-cross-doc-attention`.** It now means "produce supervision
+   that is 43% correct" and there is nothing left to fall back from.
+3. **Mask memory ceiling is accepted, not guarded.** The dense mask transformers
+   materialises is a **bool** `[B, 1, S, S]` (1 byte/element, confirmed against
+   `create_causal_mask`): ~17 MB at the defaults (B=4, S=2048), 268 MB at
+   `sequence_len` 8192, ~1073 MB at 16384 (which `sft_config` permits up to the
+   model max). O(B*S^2) for structure that is O(#docs). Named here rather than hidden;
+   the upgrade path is `attn_implementation="flex_attention"`, which transformers
+   supports with a sparse BlockMask and which also needs no flash-attn. Add it
+   only if someone hits the ceiling.
+4. **Shards older than version 3 keep today's behaviour.** They carry no
+   `position_ids`, so capture passes `position_ids=None` and transformers
+   defaults to arange per row: one document per window, plain causal. No fake
+   positions are synthesised, so `None` keeps meaning "no information".
+
+## Non-goals
+
+- The vLLM API capture backend (`teacher_api_base`) is untouched. It needs no
+  flash-attn already and is unaffected.
+- Cross-tokenizer / transplant paths are untouched.
+- No image, Dockerfile or torch version change.
+
+## Testing
+
+`tests/distill/test_capture.py` **already implements the gold comparison** ("compares
+each captured row against a reference computed by feeding EVERY DOCUMENT AS ITS
+OWN SEQUENCE"). It has never run: line 25 is
+`pytest.importorskip("flash_attn")`, plus `gpu` and `slow` marks. The check that
+would have caught this has been dark since it was written.
+
+1. **Un-gate it.** Remove the flash-attn skip. It still needs a GPU and weights,
+   so it stays `gpu` + `slow`.
+2. **Add `tests/distill/test_capture_packing.py`**, CPU, tiny random-weight
+   models, no download. Three tests, guarding *our usage* rather than library
+   internals: packed matches per-document gold; `use_cache=True` demonstrably
+   breaks isolation; and a sliding-window teacher stays isolated, which fails if
+   anyone reintroduces a hand-rolled 4D mask.
+
+**Why gold, not isolation.** During the spike a hand-rolled mask was written
+*anti-causal* (the causal term transposed). It **passed an isolation check at
+delta exactly 0.0** while scoring 29.54% against gold, worse than no mask at all:
+cross-document blocking was correct, only the within-document direction was
+reversed. An isolation assertion cannot catch that. Delegating the mask to
+transformers removes this whole bug class, but the gold comparison stays as the
+assertion of record.
+
+## Files
+
+- `surogate/distill/capture.py` — `_load_teacher` (drop the requirement),
+  `capture_shard` (pass `position_ids` + `use_cache=False`, drop flattening),
+  `_topk_logprobs` (docstring), `run_capture` / `distill_capture_main` (flag
+  removal).
+- `surogate/cli/distill_capture.py` — remove `--allow-cross-doc-attention`.
+- `tests/distill/test_capture.py` — un-gate.
+- `tests/distill/test_capture_packing.py` — new CPU tests.
+- `docs/guides/distillation.md` — the flash-attn requirement, the flag, and the
+  troubleshooting entry all describe behaviour that no longer exists.

--- a/examples/distillation/qwen3-kd.yaml
+++ b/examples/distillation/qwen3-kd.yaml
@@ -10,8 +10,8 @@
 #
 # The teacher and student MUST share a tokenizer. Qwen3-0.6B and Qwen3-1.7B
 # are both Qwen3 dense models and use the identical Qwen3 tokenizer.
-# Capture requires flash-attention-2 for packed data (or pass
-# --allow-cross-doc-attention to accept the sdpa approximation).
+# Packed documents are isolated during capture by transformers' packed-sequence
+# support, driven by the shard's position_ids resets; no flash-attn needed.
 
 model: Qwen/Qwen3-0.6B
 output_dir: ./output

--- a/surogate/cli/distill_capture.py
+++ b/surogate/cli/distill_capture.py
@@ -30,13 +30,6 @@ def prepare_command_parser(parser=None):
         help="Device to run the local teacher model on (default cuda:0). "
         "Ignored with a warning in API mode (--api-base).",
     )
-    parser.add_argument(
-        "--allow-cross-doc-attention",
-        action="store_true",
-        help="Allow sdpa fallback when flash-attention-2 is unavailable; packed documents "
-        "will attend across document boundaries during capture. "
-        "Ignored with a warning in API mode (--api-base).",
-    )
     parser.add_argument("--hub_token", type=str, help="Hugging Face token for private model access", default=None)
 
     return parser

--- a/surogate/distill/capture.py
+++ b/surogate/distill/capture.py
@@ -14,7 +14,9 @@ Rows past the last full window are zero-filled.
 
 Two teacher backends:
 - Local HF model (default): teacher loaded via transformers, whole windows per
-  forward, flash-attention-2 varlen for per-document isolation.
+  forward. Packed documents are isolated by transformers' own packed-sequence
+  support, which reads the shard's `position_ids` resets (requires
+  `use_cache=False`).
 - OpenAI-compatible API (`distillation.teacher_api_base`): one vLLM
   `prompt_logprobs` completions request per document (split at position-id
   resets, one-token lookahead), which gives exact context isolation with no
@@ -35,6 +37,7 @@ from pathlib import Path
 import numpy as np
 
 from surogate.core.config.sft_config import SFTConfig
+from surogate.distill.packed import teacher_logits, verify_isolation
 from surogate.distill.sidecar import (
     SidecarWriter,
     read_token_shard_header,
@@ -60,31 +63,15 @@ def _read_shard(path: str) -> tuple[np.ndarray, np.ndarray | None, int]:
     return tokens, position_ids, n_tokens
 
 
-def _load_teacher(teacher_model: str, device: str, allow_cross_doc_attention: bool):
+def _load_teacher(teacher_model: str, device: str):
     import torch
     from transformers import AutoModelForCausalLM
-    from transformers.utils import is_flash_attn_2_available
 
-    if is_flash_attn_2_available():
-        attn_implementation = "flash_attention_2"
-    elif allow_cross_doc_attention:
-        attn_implementation = "sdpa"
-        logger.warning(
-            "flash-attention-2 is not available; falling back to sdpa. Packed documents will "
-            "attend across document boundaries during capture (--allow-cross-doc-attention)."
-        )
-    else:
-        raise RuntimeError(
-            "distill-capture requires flash-attention-2 for per-document attention isolation "
-            "(position_ids resets -> varlen). Install flash-attn, or pass "
-            "--allow-cross-doc-attention to accept the cross-document approximation with sdpa."
-        )
-
-    logger.info(f"Loading teacher model '{teacher_model}' ({attn_implementation}, bf16) on {device}...")
+    logger.info(f"Loading teacher model '{teacher_model}' (sdpa, bf16) on {device}...")
     model = AutoModelForCausalLM.from_pretrained(
         teacher_model,
         torch_dtype=torch.bfloat16,
-        attn_implementation=attn_implementation,
+        attn_implementation="sdpa",
     )
     model.to(device)
     model.eval()
@@ -96,7 +83,10 @@ def _topk_logprobs(logits, top_k: int):
 
     topk indices over raw logits equal those over log_softmax (monotone shift);
     the fp32 normalizer is computed one window at a time to avoid materializing
-    a full fp32 copy of the (bsz, S, V) logits.
+    a full fp32 copy of the (bsz, S, V) logits. This relies on `logits` arriving
+    as [B, S, V], one row per window - capture used to flatten to [1, B*S] for
+    flash-attention's padding-free path, which silently collapsed this loop to a
+    single iteration over the whole batch.
     """
     import torch
 
@@ -117,9 +107,6 @@ def capture_shard(
     tokenize_hash: str,
     device: str,
 ) -> None:
-    import torch
-    from tqdm import tqdm
-
     tokens, position_ids, n_tokens = _read_shard(shard_path)
     student_vocab = read_token_shard_header(shard_path).vocab_size
     max_token_id = int(tokens.max()) if n_tokens > 0 else -1
@@ -140,6 +127,52 @@ def capture_shard(
         )
 
     tmp_path = sidecar_path + ".tmp"
+    try:
+        _capture_shard_into(
+            model, tmp_path, tokens, position_ids, n_tokens, n_windows,
+            top_k=top_k, sequence_len=sequence_len,
+            teacher_batch_size=teacher_batch_size,
+            teacher_vocab_size=teacher_vocab_size,
+            student_vocab=student_vocab, tokenize_hash=tokenize_hash,
+            device=device, shard_path=shard_path,
+        )
+    except BaseException:
+        # SidecarWriter preallocates the full file up front, so an abort part way
+        # through would otherwise strand a full-size .tmp that nothing ever cleans
+        # up -- and the isolation check makes aborting an expected outcome, not
+        # just a crash path.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    os.replace(tmp_path, sidecar_path)
+    tail = n_tokens - n_windows * sequence_len
+    logger.info(
+        f"Wrote {sidecar_path}: {n_windows * sequence_len} rows captured, {tail} tail rows zero-filled."
+    )
+
+
+def _capture_shard_into(
+    model,
+    tmp_path: str,
+    tokens,
+    position_ids,
+    n_tokens: int,
+    n_windows: int,
+    *,
+    top_k: int,
+    sequence_len: int,
+    teacher_batch_size: int,
+    teacher_vocab_size: int,
+    student_vocab: int,
+    tokenize_hash: str,
+    device: str,
+    shard_path: str,
+) -> None:
+    import torch
+    from tqdm import tqdm
+
     with SidecarWriter(
         tmp_path,
         n_tokens=n_tokens,
@@ -155,37 +188,34 @@ def capture_shard(
             ):
                 w1 = min(w0 + teacher_batch_size, n_windows)
                 span = slice(w0 * sequence_len, w1 * sequence_len)
-                n_flat = (w1 - w0) * sequence_len
-                # Flatten the window batch to a single row and pass explicit
-                # varlen boundaries. Batched [B, S] position_ids do NOT trigger
-                # transformers' padding-free flash-attention path, so without
-                # this the teacher silently attends across packed documents.
-                # Segments start at every window boundary and at every
-                # position-id reset (packed doc starts).
-                flat_ids = torch.from_numpy(np.ascontiguousarray(tokens[span], dtype=np.int64)).to(device)
+                bsz = w1 - w0
+                # One row per window. transformers derives the packed-document
+                # boundaries from position_ids itself and builds the
+                # block-diagonal causal mask, so each packed document is isolated
+                # without a hand-rolled mask -- and sliding-window teachers keep
+                # their sliding layers, which a 4D attention_mask would override.
+                #
+                # use_cache=False is load-bearing: with a cache allocated,
+                # _preprocess_mask_arguments skips the packed detection entirely
+                # and the teacher attends straight across document boundaries.
+                batch_ids = torch.from_numpy(
+                    np.ascontiguousarray(tokens[span], dtype=np.int64)
+                ).view(bsz, sequence_len).to(device)
+                batch_pos = None
                 if position_ids is not None:
-                    flat_pos = torch.from_numpy(
+                    batch_pos = torch.from_numpy(
                         np.ascontiguousarray(position_ids[span], dtype=np.int64)
-                    ).to(device)
-                else:
-                    flat_pos = (
-                        torch.arange(sequence_len, dtype=torch.int64, device=device)
-                        .repeat(w1 - w0)
-                    )
-                idx = torch.arange(n_flat, device=device)
-                seg_starts = torch.nonzero((idx % sequence_len == 0) | (flat_pos == 0)).view(-1)
-                cu_seqlens = torch.cat(
-                    [seg_starts.to(torch.int32), torch.tensor([n_flat], dtype=torch.int32, device=device)]
-                )
-                max_len = int((cu_seqlens[1:] - cu_seqlens[:-1]).max())
-                logits = model(
-                    input_ids=flat_ids.unsqueeze(0),
-                    position_ids=flat_pos.unsqueeze(0),
-                    cu_seq_lens_q=cu_seqlens,
-                    cu_seq_lens_k=cu_seqlens,
-                    max_length_q=max_len,
-                    max_length_k=max_len,
-                ).logits
+                    ).view(bsz, sequence_len).to(device)
+                # Pre-v3 shards carry no position_ids: transformers defaults to
+                # arange per row, i.e. one document per window, plain causal.
+                logits = teacher_logits(model, batch_ids, batch_pos)
+                if w0 == 0 and batch_pos is not None:
+                    # Once per shard, against the batch just computed: losing
+                    # isolation is invisible in the output, so prove it held
+                    # rather than write a plausible-looking sidecar built from
+                    # cross-document context. Searches every row of the batch for
+                    # a usable probe; costs one forward over <= 32 tokens.
+                    verify_isolation(model, batch_ids, batch_pos, logits)
                 logprobs, ids = _topk_logprobs(logits, top_k)
                 ids = ids.reshape(-1, top_k).cpu().numpy()
                 logprobs = logprobs.reshape(-1, top_k).cpu().numpy()
@@ -201,11 +231,6 @@ def capture_shard(
                     ids.astype(np.uint32),
                     logprobs.astype(np.float16),
                 )
-    os.replace(tmp_path, sidecar_path)
-    tail = n_tokens - n_windows * sequence_len
-    logger.info(
-        f"Wrote {sidecar_path}: {n_windows * sequence_len} rows captured, {tail} tail rows zero-filled."
-    )
 
 
 def _api_guidance(api_base: str, top_k: int) -> str:
@@ -415,7 +440,6 @@ def run_capture(
     shard_paths: list[str],
     tokenize_hash: str,
     device: str = "cuda:0",
-    allow_cross_doc_attention: bool = False,
 ) -> None:
     dist = config.distillation
     logger.warning(
@@ -471,7 +495,7 @@ def run_capture(
         finally:
             client.close()
     else:
-        model = _load_teacher(dist.teacher_model, device, allow_cross_doc_attention)
+        model = _load_teacher(dist.teacher_model, device)
         teacher_vocab_size = int(model.config.vocab_size)
         if dist.top_k > teacher_vocab_size:
             raise ValueError(
@@ -507,11 +531,9 @@ def distill_capture_main(config: SFTConfig, args: DictDefault) -> None:
 
     if args.get("api_base"):
         config.distillation.teacher_api_base = args["api_base"]
-    if config.distillation.teacher_api_base and (
-        args.get("device") or args.get("allow_cross_doc_attention")
-    ):
+    if config.distillation.teacher_api_base and args.get("device"):
         logger.warning(
-            "--device / --allow-cross-doc-attention are ignored in API mode "
+            "--device is ignored in API mode "
             "(the teacher runs on the server; per-document requests give exact context isolation)."
         )
 
@@ -541,5 +563,4 @@ def distill_capture_main(config: SFTConfig, args: DictDefault) -> None:
         train_files,
         tokenize_hash,
         device=args.get("device") or "cuda:0",
-        allow_cross_doc_attention=bool(args.get("allow_cross_doc_attention", False)),
     )

--- a/surogate/distill/packed.py
+++ b/surogate/distill/packed.py
@@ -1,0 +1,160 @@
+"""The teacher forward for packed capture, and its safety check.
+
+Kept out of `capture.py` on purpose: that module pulls in the compiled runtime
+through `SFTConfig`, so nothing importing it can be exercised on CPU. The two
+things here are the ones worth testing without a GPU, and the ones whose failure
+is silent.
+
+Packed documents are isolated by transformers' own packed-sequence support, which
+reads `position_ids` resets.
+
+`use_cache=False` is load-bearing, for a reason that is easy to misread from the
+source. `Qwen3Model.forward` and friends declare `use_cache: bool | None = None`
+and allocate a cache only under `if use_cache and past_key_values is None`, which
+looks as though omitting the argument is safe. It is not: the forward carries a
+`@merge_with_config_defaults` decorator (`transformers/utils/generic.py`, and
+`use_cache` is the first name in its list) that substitutes `config.use_cache`
+-- normally `True` -- before the body runs. A cache is then allocated,
+`_preprocess_mask_arguments` sees `past_key_values is not None`, packed detection
+is skipped, and the teacher attends straight across document boundaries.
+Measured: omitting the argument diverges from per-document gold by 0.535,
+identical to passing `use_cache=True`.
+"""
+
+from __future__ import annotations
+
+# A correctly isolated capture reproduces the standalone document almost exactly
+# (~98-100% of top-k ids agree; the rest is bf16 kernel noise). A capture that has
+# lost isolation scores ~0.49-0.64 on the scored window below.
+MIN_TOPK_AGREEMENT = 0.80
+
+# Contamination concentrates at the START of a packed document: a token deep
+# inside a long document has so much of its own context that a few leaked
+# neighbouring tokens barely move its distribution. Averaging over a whole
+# document therefore HIDES a total leak -- measured, a 482-token document
+# preceded by 30 tokens scores 0.89 with isolation completely lost, which would
+# pass. Scoring only the leading positions separates cleanly (1.00 vs 0.64).
+PROBE_SCORE_POSITIONS = 32
+
+# A probe document must be long enough to score, and must have enough text in
+# front of it for leakage to be visible at all.
+MIN_PROBE_DOC_LEN = 8
+MIN_PRECEDING_TOKENS = 8
+
+# Fixed, deliberately independent of `distillation.top_k`, which the user may set
+# as low as 1. At top_k=1 the metric degenerates to argmax agreement, where two
+# bf16 flips on a short probe would abort a perfectly good capture.
+PROBE_TOP_K = 64
+
+
+def teacher_logits(model, input_ids, position_ids):
+    """One packed forward. `use_cache=False` is what keeps isolation on."""
+    return model(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        use_cache=False,
+    ).logits
+
+
+def _document_starts(position_ids_row) -> list[int]:
+    """Indices where a packed document begins, matching the runtime's rule.
+
+    The trainer that consumes these shards treats a document as starting wherever
+    the position id does not advance by exactly one
+    (`csrc/.../causal_lm_execution_profile.cpp`), which also covers positions that
+    restart at 0. Index 0 always begins a document: the DataLoader serves each row
+    independently, so a row start is a document start even when a document spans
+    the window boundary.
+    """
+    starts = [0]
+    prev = int(position_ids_row[0])
+    for i in range(1, len(position_ids_row)):
+        curr = int(position_ids_row[i])
+        if curr - prev != 1:
+            starts.append(i)
+        prev = curr
+    return starts
+
+
+def _find_probe(position_ids_row, seq_len: int):
+    """First document in the row usable as an isolation probe, or None.
+
+    Must not be the row's first document (only later documents can be
+    contaminated), must have enough preceding text for a leak to show, and must
+    be long enough to score.
+    """
+    starts = _document_starts(position_ids_row)
+    for i in range(1, len(starts)):
+        a = starts[i]
+        b = starts[i + 1] if i + 1 < len(starts) else seq_len
+        if a >= MIN_PRECEDING_TOKENS and b - a >= MIN_PROBE_DOC_LEN:
+            return a, b
+    return None
+
+
+def verify_isolation(model, batch_ids, batch_position_ids, batch_logits) -> None:
+    """Prove, on real data, that the packed forward isolated its documents.
+
+    Capture cannot see isolation in its own output. If it is lost -- a cache
+    reaching the forward, a transformers change, a future edit to
+    `teacher_logits` -- the teacher attends across document boundaries and capture
+    writes a sidecar whose stored distributions are badly wrong. Nothing
+    downstream notices: `validate_sidecar` checks the header and the tokenize
+    hash, not the values, so the bad sidecar is accepted and reused until
+    something forces a recapture.
+
+    So this checks the property rather than any one of its causes: take a document
+    that is not first in its row, re-run its opening tokens on their own, and
+    compare top-k ids against the packed forward's rows for the same positions.
+
+    Every row of the batch is searched for a usable probe, because a shard whose
+    first row happens to hold one long document would otherwise be captured
+    entirely unverified.
+
+    Costs one forward over at most `PROBE_SCORE_POSITIONS` tokens. The flash-attn
+    path this replaced failed loudly when it could not isolate; this keeps that.
+    """
+    import torch
+
+    seq_len = int(batch_ids.shape[1])
+    found = None
+    for row in range(int(batch_ids.shape[0])):
+        probe = _find_probe(batch_position_ids[row], seq_len)
+        if probe is not None:
+            found = (row, *probe)
+            break
+    if found is None:
+        # No row in this batch packs a scorable document behind another, so there
+        # is no cross-document conditioning here that could go wrong.
+        return
+    row, a, b = found
+
+    # Score only the document's opening tokens. Logits at those positions depend
+    # solely on tokens [a, end), so the standalone forward needs no more than
+    # that -- which also bounds the comparison below.
+    end = min(b, a + PROBE_SCORE_POSITIONS)
+    with torch.inference_mode():
+        alone = model(input_ids=batch_ids[row, a:end].unsqueeze(0), use_cache=False).logits[0]
+    packed = batch_logits[row, a:end]
+
+    k = min(PROBE_TOP_K, int(alone.shape[-1]))
+    ids_alone = alone.topk(k, dim=-1).indices
+    ids_packed = packed.topk(k, dim=-1).indices
+    # [L, k, k] booleans, bounded by the caps above (<= 32 x 64 x 64) rather than
+    # by the user's top_k, which may be 1024 over a whole window.
+    agreement = float(
+        (ids_alone.unsqueeze(-1) == ids_packed.unsqueeze(-2)).any(-1).to(torch.float32).mean()
+    )
+
+    if agreement < MIN_TOPK_AGREEMENT:
+        raise RuntimeError(
+            f"Packed-document isolation check failed: the opening {end - a} tokens of a "
+            f"document captured inside a packed window agree with the same document "
+            f"captured alone on only {agreement:.1%} of their top-{k} tokens (expected "
+            f">= {MIN_TOPK_AGREEMENT:.0%}). The teacher is attending across document "
+            f"boundaries, so the captured logprobs would be conditioned on unrelated "
+            f"neighbouring text. Likely causes: the installed transformers no longer "
+            f"supports packed-sequence masking, or a cache reached the forward "
+            f"(`use_cache` must be False). Refusing to write a sidecar that looks valid "
+            f"but is not."
+        )

--- a/tests/distill/test_capture.py
+++ b/tests/distill/test_capture.py
@@ -4,10 +4,11 @@ Builds a tiny packed token shard (multiple docs with position-id resets), runs
 `capture_shard` with a cached small teacher, and compares each captured row
 against a reference computed by feeding EVERY DOCUMENT AS ITS OWN SEQUENCE.
 The per-doc reference makes this test sensitive to cross-document attention
-leaks: if the capture forward did not isolate packed documents (flash-attention
-varlen), rows after the first doc boundary diverge.
+leaks: if the capture forward did not isolate packed documents (transformers'
+packed-sequence support, driven by position_ids and `use_cache=False`), rows
+after the first doc boundary diverge.
 
-Requirements: 1 GPU, flash-attn installed, cached Qwen3 weights
+Requirements: 1 GPU, cached Qwen3 weights
 (QWEN3_MODEL_PATH or HF cache for Qwen/Qwen3-0.6B / Qwen/Qwen3-1.7B /
 Qwen/Qwen3.5-0.8B).
 """
@@ -22,9 +23,13 @@ import pytest
 
 torch = pytest.importorskip("torch")
 transformers = pytest.importorskip("transformers")
-pytest.importorskip("flash_attn", reason="capture's document isolation requires flash-attention-2")
 
-from surogate.distill.capture import capture_shard, _load_teacher
+capture = pytest.importorskip(
+    "surogate.distill.capture", reason="requires the built _surogate native module"
+)
+capture_shard = capture.capture_shard
+_load_teacher = capture._load_teacher
+
 from surogate.distill.sidecar import read_sidecar, read_token_shard_header
 
 pytestmark = [pytest.mark.gpu, pytest.mark.slow]
@@ -73,7 +78,7 @@ def teacher():
     snapshot = resolve_model_path()
     if snapshot is None:
         pytest.skip(f"No cached teacher. Set {ENV_VAR} or cache one of {CANDIDATE_MODELS}")
-    model = _load_teacher(str(snapshot), "cuda", allow_cross_doc_attention=False)
+    model = _load_teacher(str(snapshot), "cuda")
     yield snapshot, model
     del model
     torch.cuda.empty_cache()

--- a/tests/distill/test_capture_packing.py
+++ b/tests/distill/test_capture_packing.py
@@ -1,0 +1,193 @@
+"""Packed-document isolation during teacher capture: CPU, no GPU, no downloads.
+
+`distill-capture` packs several documents into one `sequence_len` window. The
+teacher must not let a packed document attend to its neighbours, or the stored
+distribution is conditioned on text that will never be present at training time.
+
+Isolation is transformers' own packed-sequence support, driven by the shard's
+`position_ids` resets. These tests guard *our usage* of it, which has two sharp
+edges that are easy to lose in a refactor:
+
+1. `use_cache=False` is load-bearing. With a cache allocated,
+   `_preprocess_mask_arguments` skips packed detection and the teacher attends
+   straight across document boundaries.
+2. Passing a hand-rolled 4D `attention_mask` instead short-circuits *both* the
+   causal and the sliding-window mask builders, so a sliding-window teacher
+   silently loses its sliding layers.
+
+Gold is each document run alone, which is by definition what capture should
+store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from surogate.distill.packed import teacher_logits, verify_isolation
+
+# Shaped so document 2 is a usable isolation probe: preceded by >=
+# MIN_PRECEDING_TOKENS of other text (leakage is invisible without it) and at
+# least MIN_PROBE_DOC_LEN long.
+DOC_LENS = [12, 20, 16]
+SEQ_LEN = sum(DOC_LENS)
+OFFSETS = [sum(DOC_LENS[:i]) for i in range(len(DOC_LENS))]
+
+POS = torch.cat([torch.arange(n) for n in DOC_LENS]).unsqueeze(0)
+IDS = torch.arange(1, SEQ_LEN + 1).unsqueeze(0) % 200
+
+
+def _gold(model):
+    """Each document forwarded on its own."""
+    with torch.inference_mode():
+        return torch.cat(
+            [model(input_ids=IDS[:, s : s + n]).logits[0] for s, n in zip(OFFSETS, DOC_LENS)]
+        )
+
+
+def _packed(model):
+    """The production call. If `use_cache=False` is dropped from
+    `teacher_logits`, these tests go red."""
+    with torch.inference_mode():
+        return teacher_logits(model, IDS, POS)[0]
+
+
+@pytest.fixture(scope="module")
+def qwen3():
+    from transformers import Qwen3Config, Qwen3ForCausalLM
+
+    cfg = Qwen3Config(
+        vocab_size=256, hidden_size=64, intermediate_size=128, num_hidden_layers=2,
+        num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        max_position_embeddings=512, attn_implementation="sdpa",
+    )
+    torch.manual_seed(0)
+    return Qwen3ForCausalLM(cfg).eval()
+
+
+@pytest.fixture(scope="module")
+def gemma3_sliding():
+    """A teacher with sliding-window layers, where a 4D mask would break isolation."""
+    from transformers import Gemma3ForCausalLM, Gemma3TextConfig
+
+    cfg = Gemma3TextConfig(
+        vocab_size=256, hidden_size=64, intermediate_size=128, num_hidden_layers=2,
+        num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        max_position_embeddings=64, sliding_window=4,
+        layer_types=["sliding_attention", "full_attention"],
+        attn_implementation="sdpa",
+    )
+    torch.manual_seed(0)
+    return Gemma3ForCausalLM(cfg).eval()
+
+
+def test_packed_capture_matches_unpacked_gold(qwen3):
+    """The load-bearing assertion: packed capture reproduces each document alone."""
+    torch.testing.assert_close(_packed(qwen3), _gold(qwen3), atol=1e-4, rtol=1e-4)
+
+
+def test_use_cache_must_be_false(qwen3):
+    """Without use_cache=False the packed detection is skipped and isolation is
+    silently lost. Nothing else in the forward signals this, so it is pinned."""
+    with torch.inference_mode():
+        leaky = qwen3(input_ids=IDS, position_ids=POS, use_cache=True).logits[0]
+    assert not torch.allclose(leaky, _gold(qwen3), atol=1e-4, rtol=1e-4)
+
+
+def test_verify_isolation_passes_on_an_isolated_forward(qwen3):
+    verify_isolation(qwen3, IDS, POS, _packed(qwen3).unsqueeze(0))
+
+
+def test_verify_isolation_refuses_a_leaking_forward(qwen3):
+    """The check must catch the real failure, whatever caused it.
+
+    A cache reaching the forward is the cause we know about; the check looks at
+    the property instead, so it also catches causes we have not thought of.
+    """
+    with torch.inference_mode():
+        leaky = qwen3(input_ids=IDS, position_ids=POS, use_cache=True).logits
+    with pytest.raises(RuntimeError, match="isolation check failed"):
+        verify_isolation(qwen3, IDS, POS, leaky)
+
+
+def test_verify_isolation_catches_a_leak_hidden_by_an_unbalanced_pack(qwen3):
+    """A short document followed by a long one hides a total leak from a naive
+    average, which is why only the probe's opening tokens are scored.
+
+    Contamination concentrates at a document's start: deep inside a long document
+    the leaked neighbours are a vanishing fraction of the context. Averaging over
+    the whole document therefore reports ~0.89 for a forward with isolation
+    COMPLETELY lost, which would clear MIN_TOPK_AGREEMENT. This test pins both the
+    refusal and the reason for it.
+    """
+    from surogate.distill.packed import MIN_TOPK_AGREEMENT, PROBE_SCORE_POSITIONS
+
+    a, b = 12, 200
+    pos = torch.cat([torch.arange(a), torch.arange(b)]).unsqueeze(0)
+    ids = torch.arange(1, a + b + 1).unsqueeze(0) % 200
+
+    with torch.inference_mode():
+        leaky = qwen3(input_ids=ids, position_ids=pos, use_cache=True).logits
+        alone = qwen3(input_ids=ids[:, a:], use_cache=False).logits[0]
+
+    def agreement(window):
+        x = alone[window].topk(64, -1).indices
+        y = leaky[0, a:][window].topk(64, -1).indices
+        return float((x.unsqueeze(-1) == y.unsqueeze(-2)).any(-1).float().mean())
+
+    whole_doc = agreement(slice(None))
+    leading = agreement(slice(0, PROBE_SCORE_POSITIONS))
+    assert whole_doc > MIN_TOPK_AGREEMENT, (
+        f"premise of this test is gone: whole-document scoring no longer hides the "
+        f"leak ({whole_doc:.3f})"
+    )
+    assert leading < MIN_TOPK_AGREEMENT
+
+    with pytest.raises(RuntimeError, match="isolation check failed"):
+        verify_isolation(qwen3, ids, pos, leaky)
+
+
+def test_verify_isolation_searches_past_an_unprobeable_first_row(qwen3):
+    """A shard whose first row holds one long document must not go unverified.
+
+    The probe is taken from whichever row of the batch first yields one, not from
+    row 0 -- otherwise every remaining row of that shard is captured with no check
+    at all.
+    """
+    row0 = torch.arange(SEQ_LEN).unsqueeze(0)  # one document, no probe available
+    pos = torch.cat([row0, POS], dim=0)
+    ids = torch.cat([IDS, IDS], dim=0)
+    with torch.inference_mode():
+        leaky = qwen3(input_ids=ids, position_ids=pos, use_cache=True).logits
+    with pytest.raises(RuntimeError, match="isolation check failed"):
+        verify_isolation(qwen3, ids, pos, leaky)
+
+
+def test_verify_isolation_skips_rows_with_nothing_packed(qwen3):
+    """A plain-arange row is one document: no cross-document conditioning to
+    check, and no probe to take. Must not raise."""
+    plain = torch.arange(SEQ_LEN).unsqueeze(0)
+    with torch.inference_mode():
+        logits = teacher_logits(qwen3, IDS, plain)
+    verify_isolation(qwen3, IDS, plain, logits)
+
+
+def test_document_starts_matches_the_runtime_rule():
+    """Boundary is 'position did not advance by one', the rule the compiled
+    trainer uses on these same shards -- not merely 'position == 0'."""
+    from surogate.distill.packed import _document_starts
+
+    assert _document_starts(torch.tensor([0, 1, 2, 0, 1])) == [0, 3]
+    assert _document_starts(torch.tensor([3, 4, 5, 0, 1])) == [0, 3]  # row opens mid-doc
+    assert _document_starts(torch.tensor([0, 1, 2, 5, 6])) == [0, 3]  # jump, no reset
+    assert _document_starts(torch.tensor([0, 1, 2, 3, 4])) == [0]
+
+
+def test_sliding_window_teacher_is_isolated(gemma3_sliding):
+    """Guards against reintroducing a hand-rolled 4D attention_mask: it would
+    override the sliding-window mask builder and this test would fail."""
+    torch.testing.assert_close(
+        _packed(gemma3_sliding), _gold(gemma3_sliding), atol=1e-4, rtol=1e-4
+    )


### PR DESCRIPTION
## Problem

`surogate distill-capture` cannot run in any shipped image. Every DISTILL run dies
before a single training step:

```
RuntimeError: distill-capture requires flash-attention-2 for per-document attention
isolation (position_ids resets -> varlen).
```

Confirmed live on Modal: failed in 68 s, `surogate sft` never invoked, zero metric
rows. Knowledge distillation has never completed on the platform.

`_load_teacher` hard-requires flash-attention-2, but `flash-attn` is not a dependency
and is installed by none of `Dockerfile.cu128/129/130`. vLLM's vendored
`vllm_flash_attn` is a different distribution and does not satisfy
`is_flash_attn_2_available()`.

**Adding it is not a one-line fix.** Dao-AILab publishes prebuilt cp312 wheels for
torch 2.2 through 2.10; our images ship torch 2.11.0. The remaining routes are a
source compile on every image build, a torch downgrade affecting all four training
methods, or an indefinite wait upstream.

## What flash-attn was doing

Tokenized shards pack several documents into one `sequence_len` window and mark each
document start by resetting `position_ids`. The teacher must not attend across those
boundaries, or the stored distribution is conditioned on text that will never be
present at training time. flash-attn's varlen path enforced that, which is also why
capture flattened its batch to `[1, B*S]`.

## What this does

Nothing else was needed. `transformers >= 5.5` already builds this mask from
`position_ids` (`find_packed_sequence_indices` -> `packed_sequence_mask_function` ->
`sdpa_mask`). Capture now passes `position_ids` and `use_cache=False` and owns no mask
code, and the forward returns to a natural `[B, S]` batch.

Scored against **per-document gold** (each document run alone, which is by definition
what capture should reproduce), on the top-64 id set the sidecar stores:

| packing | top-64 vs gold | argmax |
|---|---|---|
| flash-attn varlen (what we cannot ship) | 98.32% | 98.72% |
| **this change** | **98.46%** | **98.72%** |
| no isolation | 42.67% | 42.95% |

The 1.5% gap is bf16 kernel noise: two kernels computing identical maths on a single
unpacked document already disagree by that much.

### `use_cache=False` is load-bearing, and easy to misread

The model's `forward` declares `use_cache: bool | None = None` and allocates a cache
only under `if use_cache and past_key_values is None`, which suggests omitting the
argument is safe. It is not. `@merge_with_config_defaults`
(`transformers/utils/generic.py:908`) substitutes `config.use_cache` (normally `True`)
before the body runs, a cache is allocated, packed detection is skipped, and the
teacher attends across documents. Measured divergence from gold: `use_cache=False`
1.8e-07, **omitted 0.535**, `use_cache=True` 0.535.

### Why not a hand-rolled mask

A 4D `attention_mask` is returned as-is by `_preprocess_mask_arguments` for **both**
`create_causal_mask` and `create_sliding_window_causal_mask`, so a sliding-window
teacher (Gemma3, gpt-oss class) silently loses its sliding layers. Measured on
Gemma3: hand-rolled mask 0.51 error vs gold, this change 2.76e-07. On Qwen3 the two
are bit-identical, so the hand-rolled version bought nothing and cost correctness
elsewhere.

## Also fixes: capture memory

Dropping the flattening restores `_topk_logprobs`' per-window loop, which had silently
collapsed to one iteration over the whole batch and converted every batch to fp32.
Capture peak on a real workload: **21,569 -> 11,287 MiB (-48%)**.

## New: an isolation self-check

Losing isolation is invisible in capture's output. `validate_sidecar` checks the
header and tokenize hash, not the values, so a bad sidecar is accepted and reused
until something forces a recapture. The flash-attn path at least failed loudly.

`verify_isolation` runs once per shard: it re-runs the opening tokens of a packed
document on their own and compares top-k against the packed forward, refusing to write
below 80% agreement. It checks the property, not any single cause, so it catches
reasons we have not thought of.

Two details that matter, both found in review:

- It scores only the document's **opening** tokens. Contamination concentrates at a
  document's start; averaging over a whole document hides a total leak. Measured: a
  482-token document preceded by 30 tokens scores 0.89 with isolation completely lost,
  which would have passed.
- It searches **every row** of the batch for a probe. Taking only row 0 would leave a
  shard whose first row holds one long document entirely unverified.

## Breaking change

`--allow-cross-doc-attention` is removed. It meant "produce supervision that is ~43%
correct", and with isolation no longer optional there is nothing to fall back from. No
callers in this repo, surogate-ops or surogates.

## Testing

- `tests/distill/test_capture_packing.py`, new: 9 CPU tests, no GPU and no model
  downloads, covering gold equivalence, the `use_cache` invariant, sliding-window
  teachers, the unbalanced-pack leak above, and the unprobeable-first-row case.
- `tests/distill/test_capture.py` is **un-gated**. It already implemented the gold
  comparison but had never run: a `pytest.importorskip("flash_attn")` kept it dark
  since it was written. Still `gpu` + `slow`.
- Live, against the published `latest-cu128` image with these files overlaid: capture
  rc 0, sidecar read back from disk scores **97.92%** vs per-document gold over 835
  rows of real data, training completes, `train/kd_loss` emitted.
- Controlled A/B, identical config and seed (CE identical at step 0 to 7 dp):
  `kd_loss` **0.6365 isolated vs 2.0145 leaking**; CE falls 1.77 -> 1.54 isolated,
  rises 1.77 -> 2.14 leaking. Contaminated supervision actively degrades the student.

## Not covered

No run has gone through ops/Studio. That needs this released in an image, not merely
merged — all verification above overlays these files onto the published image, which
exercises the engine and not the platform path.

Design notes: `docs/superpowers/specs/2026-09-03-distill-capture-attention-mask-design.md`
