### PR TITLE
fix(train): refuse a run that cannot complete one optimizer step

### DIFF
--- a/surogate/train/distributed.py
+++ b/surogate/train/distributed.py
@@ -1158,6 +1158,7 @@ class RayDistributedTrainer:
         from surogate.train.gradient_tracker import GradientTracker
         from surogate.train.loss_guard import LossGuard
         from surogate.train.lr_schedule import LRSchedule
+        from surogate.train.step_budget import check_step_budget
         from surogate.train.metrics import MoEMetrics, StepMetrics
         from surogate.train.moe_monitor import MoEMonitor
         from surogate.train.phase_detector import PhaseDetector
@@ -1216,6 +1217,18 @@ class RayDistributedTrainer:
         else:
             max_steps = steps_per_epoch * config.num_epochs
             logger.info(f"Calculated {steps_per_epoch} steps per epoch from {num_tokens} tokens")
+
+        # Same guard as the single-node path: 0 steps must fail loudly
+        # rather than complete with an untrained model.
+        check_step_budget(
+            max_steps,
+            dataset_tokens=num_tokens,
+            tokens_per_step=total_tokens_per_step,
+            batch_size=config.per_device_train_batch_size,
+            sequence_len=config.sequence_len,
+            gpus=config.gpus,
+            gradient_accumulation_steps=config.gradient_accumulation_steps,
+        )
 
         # Apply warmup_ratio if warmup_steps is 0
         warmup_steps = config.warmup_steps

--- a/surogate/train/distributed.py
+++ b/surogate/train/distributed.py
@@ -1158,12 +1158,12 @@ class RayDistributedTrainer:
         from surogate.train.gradient_tracker import GradientTracker
         from surogate.train.loss_guard import LossGuard
         from surogate.train.lr_schedule import LRSchedule
-        from surogate.train.step_budget import check_step_budget
         from surogate.train.metrics import MoEMetrics, StepMetrics
         from surogate.train.moe_monitor import MoEMonitor
         from surogate.train.phase_detector import PhaseDetector
         from surogate.train.plateau_detector import PlateauDetector
         from surogate.train.reporter import training_logger_context
+        from surogate.train.step_budget import check_step_budget
         from surogate.train.training_advisor import TrainingAdvisor
         from surogate.train.training_plot import generate_training_plot
         from surogate.utils.logger import get_logger
@@ -1220,14 +1220,16 @@ class RayDistributedTrainer:
 
         # Same guard as the single-node path: 0 steps must fail loudly
         # rather than complete with an untrained model.
+        # Tokens rather than chunks here: the loader lives on the node actors
+        # and is reached over RPC, which exposes no chunk count today. Tokens
+        # miss the case of many files each shorter than sequence_len, where the
+        # per-file floor yields no chunks at all. The single-node path uses the
+        # exact count.
         check_step_budget(
             max_steps,
+            config=config,
             dataset_tokens=num_tokens,
             tokens_per_step=total_tokens_per_step,
-            batch_size=config.per_device_train_batch_size,
-            sequence_len=config.sequence_len,
-            gpus=config.gpus,
-            gradient_accumulation_steps=config.gradient_accumulation_steps,
         )
 
         # Apply warmup_ratio if warmup_steps is 0

--- a/surogate/train/step_budget.py
+++ b/surogate/train/step_budget.py
@@ -1,0 +1,70 @@
+"""Guard against a run that cannot take a single optimizer step.
+
+The step budget is computed in *tokens*, not rows::
+
+    tokens_per_step = per_device_train_batch_size * sequence_len * gpus
+                      * gradient_accumulation_steps
+    steps_per_epoch = dataset_tokens // tokens_per_step
+
+so a dataset smaller than one step's worth of tokens yields ``0`` and the
+training loop runs zero times. Left unchecked the run then logs
+"Training loop completed successfully after step -1", writes out an
+adapter that never saw a gradient, and reports success — indistinguishable
+from a real run to anyone reading the UI.
+"""
+
+from __future__ import annotations
+
+
+class ZeroStepBudgetError(ValueError):
+    """The configured budget yields no optimizer steps."""
+
+
+def check_step_budget(
+    max_steps: int,
+    *,
+    dataset_tokens: int | None = None,
+    tokens_per_step: int | None = None,
+    batch_size: int | None = None,
+    sequence_len: int | None = None,
+    gpus: int | None = None,
+    gradient_accumulation_steps: int | None = None,
+) -> None:
+    """Raise if *max_steps* is not positive.
+
+    Everything after ``max_steps`` is optional and only shapes the message:
+    the point of the error is to say which knob to turn, since "0 steps" on
+    its own sends people looking at their data when the batch settings are
+    usually what's wrong.
+    """
+    if max_steps > 0:
+        return
+
+    detail = ""
+    if dataset_tokens is not None and tokens_per_step:
+        shortfall = tokens_per_step - dataset_tokens
+        detail = (
+            f" The dataset holds {dataset_tokens:,} tokens but one step "
+            f"consumes {tokens_per_step:,}"
+        )
+        parts = [
+            f"per_device_train_batch_size={batch_size}" if batch_size else "",
+            f"sequence_len={sequence_len}" if sequence_len else "",
+            f"gpus={gpus}" if gpus else "",
+            (
+                f"gradient_accumulation_steps={gradient_accumulation_steps}"
+                if gradient_accumulation_steps else ""
+            ),
+        ]
+        parts = [p for p in parts if p]
+        if parts:
+            detail += " (" + " x ".join(parts) + ")"
+        detail += f", short by {shortfall:,}."
+
+    raise ZeroStepBudgetError(
+        "This configuration trains for 0 optimizer steps, so the run would "
+        "produce an untrained model." + detail +
+        " Use a larger dataset, a shorter sequence_len, or a smaller "
+        "effective batch (batch size x gradient accumulation). Set "
+        "max_steps explicitly to override."
+    )

--- a/surogate/train/step_budget.py
+++ b/surogate/train/step_budget.py
@@ -17,15 +17,23 @@ def _starved(num_chunks, chunks_per_step, dataset_tokens, tokens_per_step) -> bo
     """Whether the data cannot fill a single optimizer step.
 
     Chunks are what the loader actually serves, so prefer them: they are
-    counted **per file** with a floor (``NumTokens / seq_len``), which means a
-    dataset of many files each shorter than ``sequence_len`` yields zero chunks
-    while its token total looks healthy. Token count is the fallback for the
-    Ray path, which reaches its loader over RPC and does not expose the chunk
-    count today; it is an approximation that misses exactly that case.
+    counted **per file** with a floor, which means a dataset of many files each
+    shorter than the loader's chunk size yields zero chunks while its token
+    total looks healthy. Token count is the fallback for the Ray path, which
+    reaches its loader over RPC and exposes no chunk count today; it is an
+    approximation that misses exactly that case.
+
+    *chunks_per_step* must be supplied by the caller, not derived here: the
+    loader is constructed with ``chunk_size`` as its unit, not ``sequence_len``
+    (``trainer.py`` passes ``self.chunk_size``), and dispatch-pp redefines the
+    relationship again. Only the caller knows the ratio it actually built.
+
+    A non-positive *dataset_tokens* means "unknown", not "empty": the
+    multimodal path reports ``-1`` when it cannot measure the dataset.
     """
     if num_chunks is not None and chunks_per_step:
         return num_chunks < chunks_per_step
-    if dataset_tokens is not None and tokens_per_step:
+    if dataset_tokens is not None and dataset_tokens > 0 and tokens_per_step:
         return dataset_tokens < tokens_per_step
     return False
 
@@ -35,6 +43,7 @@ def check_step_budget(
     *,
     config=None,
     num_chunks: int | None = None,
+    chunks_per_step: int | None = None,
     dataset_tokens: int | None = None,
     tokens_per_step: int | None = None,
 ) -> None:
@@ -49,11 +58,9 @@ def check_step_budget(
     one epoch holds is normal, the loader wraps between steps. Only a dataset
     too small for a single step is a defect.
 
-    *config* is used only to shape the message and to convert tokens-per-step
-    into chunks-per-step; the two counts come from the loader.
+    *config* is used only to shape the message; every count comes from the
+    caller, which is the only place that knows what the loader was built with.
     """
-    seq_len = getattr(config, "sequence_len", None)
-    chunks_per_step = tokens_per_step // seq_len if (tokens_per_step and seq_len) else None
     starved = _starved(num_chunks, chunks_per_step, dataset_tokens, tokens_per_step)
 
     if max_steps > 0 and not starved:
@@ -62,9 +69,32 @@ def check_step_budget(
     # Covers both causes without claiming a step count the user did not ask
     # for: someone who set max_steps=5 should not be told they asked for 0.
     detail = ""
-    if starved and dataset_tokens is not None and tokens_per_step:
+    chunk_starved = num_chunks is not None and chunks_per_step and num_chunks < chunks_per_step
+    if chunk_starved:
+        # Report the unit that actually ran out. Token totals can look ample
+        # here, because chunks are floored per file.
+        detail = f" The dataset yields {num_chunks:,} loadable chunk(s) but one step needs {chunks_per_step:,}"
+        if dataset_tokens is not None and dataset_tokens > 0:
+            detail += (
+                f"; its {dataset_tokens:,} tokens did not fill them, which usually "
+                f"means individual files are shorter than one chunk"
+            )
+        detail += "."
+    elif starved and dataset_tokens is not None and tokens_per_step:
         detail = f" The dataset holds {dataset_tokens:,} tokens but one step consumes {tokens_per_step:,}"
-        if config is not None:
+        # Only print the factorisation when it actually multiplies out: the Ray
+        # path scales by num_nodes and dispatch-pp redefines the product, so a
+        # blindly printed factor list would contradict the total beside it.
+        if (
+            config is not None
+            and (
+                config.per_device_train_batch_size
+                * config.sequence_len
+                * config.gpus
+                * config.gradient_accumulation_steps
+            )
+            == tokens_per_step
+        ):
             detail += (
                 f" (per_device_train_batch_size={config.per_device_train_batch_size}"
                 f" x sequence_len={config.sequence_len}"

--- a/surogate/train/step_budget.py
+++ b/surogate/train/step_budget.py
@@ -30,14 +30,33 @@ def check_step_budget(
     gpus: int | None = None,
     gradient_accumulation_steps: int | None = None,
 ) -> None:
-    """Raise if *max_steps* is not positive.
+    """Raise if the run cannot take a full optimizer step.
+
+    Two ways that happens, and both must be caught here:
+
+    * the budget resolved to zero, which is what an epochs-based run yields
+      when ``dataset_tokens // tokens_per_step`` floors to 0; and
+    * the dataset cannot fill a single step even though ``max_steps`` was
+      given explicitly. A typed-in number is not evidence the data exists,
+      and left unchecked the run dies later in the dataloader with
+      ``No more files to load``, which names neither the dataset nor the
+      batch settings.
+
+    Note this is deliberately *not* "fewer steps than requested". Asking for
+    more steps than one epoch holds is normal, the loader wraps. Only a
+    dataset too small for one step is a defect.
 
     Everything after ``max_steps`` is optional and only shapes the message:
     the point of the error is to say which knob to turn, since "0 steps" on
     its own sends people looking at their data when the batch settings are
     usually what's wrong.
     """
-    if max_steps > 0:
+    starved = (
+        dataset_tokens is not None
+        and tokens_per_step
+        and dataset_tokens < tokens_per_step
+    )
+    if max_steps > 0 and not starved:
         return
 
     detail = ""
@@ -61,10 +80,25 @@ def check_step_budget(
             detail += " (" + " x ".join(parts) + ")"
         detail += f", short by {shortfall:,}."
 
+    # Two different situations, and telling them apart matters: one is a
+    # budget that resolved to nothing, the other is a budget that was asked
+    # for and cannot be met.
+    if starved and max_steps > 0:
+        headline = (
+            f"The dataset cannot fill a single optimizer step, so the "
+            f"requested {max_steps} step(s) cannot run."
+        )
+    else:
+        headline = (
+            "This configuration trains for 0 optimizer steps, so the run "
+            "would produce an untrained model."
+        )
+
+    # Deliberately no longer suggests setting max_steps. That never let
+    # anyone train: it only swapped this message for the dataloader's
+    # `No more files to load`, since the data is still absent either way.
     raise ZeroStepBudgetError(
-        "This configuration trains for 0 optimizer steps, so the run would "
-        "produce an untrained model." + detail +
+        headline + detail +
         " Use a larger dataset, a shorter sequence_len, or a smaller "
-        "effective batch (batch size x gradient accumulation). Set "
-        "max_steps explicitly to override."
+        "effective batch (batch size x gradient accumulation)."
     )

--- a/surogate/train/step_budget.py
+++ b/surogate/train/step_budget.py
@@ -1,104 +1,80 @@
 """Guard against a run that cannot take a single optimizer step.
 
-The step budget is computed in *tokens*, not rows::
-
-    tokens_per_step = per_device_train_batch_size * sequence_len * gpus
-                      * gradient_accumulation_steps
-    steps_per_epoch = dataset_tokens // tokens_per_step
-
-so a dataset smaller than one step's worth of tokens yields ``0`` and the
-training loop runs zero times. Left unchecked the run then logs
-"Training loop completed successfully after step -1", writes out an
-adapter that never saw a gradient, and reports success — indistinguishable
-from a real run to anyone reading the UI.
+Left unchecked, such a run loops zero times, writes out an adapter that never
+saw a gradient, and reports success, or else dies inside the native dataloader
+with ``No more files to load`` (``csrc/.../dataloader.cpp``) naming neither the
+dataset nor the batch settings. Both are the same config defect: the data is
+smaller than one step. Only the Python side knows the knobs, which is why the
+check lives here rather than in the loader.
 """
-
-from __future__ import annotations
 
 
 class ZeroStepBudgetError(ValueError):
-    """The configured budget yields no optimizer steps."""
+    """The configured budget cannot complete one optimizer step."""
+
+
+def _starved(num_chunks, chunks_per_step, dataset_tokens, tokens_per_step) -> bool:
+    """Whether the data cannot fill a single optimizer step.
+
+    Chunks are what the loader actually serves, so prefer them: they are
+    counted **per file** with a floor (``NumTokens / seq_len``), which means a
+    dataset of many files each shorter than ``sequence_len`` yields zero chunks
+    while its token total looks healthy. Token count is the fallback for the
+    Ray path, which reaches its loader over RPC and does not expose the chunk
+    count today; it is an approximation that misses exactly that case.
+    """
+    if num_chunks is not None and chunks_per_step:
+        return num_chunks < chunks_per_step
+    if dataset_tokens is not None and tokens_per_step:
+        return dataset_tokens < tokens_per_step
+    return False
 
 
 def check_step_budget(
     max_steps: int,
     *,
+    config=None,
+    num_chunks: int | None = None,
     dataset_tokens: int | None = None,
     tokens_per_step: int | None = None,
-    batch_size: int | None = None,
-    sequence_len: int | None = None,
-    gpus: int | None = None,
-    gradient_accumulation_steps: int | None = None,
 ) -> None:
-    """Raise if the run cannot take a full optimizer step.
+    """Raise if the run cannot complete a full optimizer step.
 
-    Two ways that happens, and both must be caught here:
+    Two ways that happens and both must be caught here: the budget resolved to
+    zero, which is what an epochs-based run yields when the floor divide gives
+    0; or the dataset cannot fill one step even though ``max_steps`` was given
+    explicitly. A typed-in number is not evidence the data exists.
 
-    * the budget resolved to zero, which is what an epochs-based run yields
-      when ``dataset_tokens // tokens_per_step`` floors to 0; and
-    * the dataset cannot fill a single step even though ``max_steps`` was
-      given explicitly. A typed-in number is not evidence the data exists,
-      and left unchecked the run dies later in the dataloader with
-      ``No more files to load``, which names neither the dataset nor the
-      batch settings.
+    Deliberately *not* "fewer steps than requested": asking for more steps than
+    one epoch holds is normal, the loader wraps between steps. Only a dataset
+    too small for a single step is a defect.
 
-    Note this is deliberately *not* "fewer steps than requested". Asking for
-    more steps than one epoch holds is normal, the loader wraps. Only a
-    dataset too small for one step is a defect.
-
-    Everything after ``max_steps`` is optional and only shapes the message:
-    the point of the error is to say which knob to turn, since "0 steps" on
-    its own sends people looking at their data when the batch settings are
-    usually what's wrong.
+    *config* is used only to shape the message and to convert tokens-per-step
+    into chunks-per-step; the two counts come from the loader.
     """
-    starved = (
-        dataset_tokens is not None
-        and tokens_per_step
-        and dataset_tokens < tokens_per_step
-    )
+    seq_len = getattr(config, "sequence_len", None)
+    chunks_per_step = tokens_per_step // seq_len if (tokens_per_step and seq_len) else None
+    starved = _starved(num_chunks, chunks_per_step, dataset_tokens, tokens_per_step)
+
     if max_steps > 0 and not starved:
         return
 
+    # Covers both causes without claiming a step count the user did not ask
+    # for: someone who set max_steps=5 should not be told they asked for 0.
     detail = ""
-    if dataset_tokens is not None and tokens_per_step:
-        shortfall = tokens_per_step - dataset_tokens
-        detail = (
-            f" The dataset holds {dataset_tokens:,} tokens but one step "
-            f"consumes {tokens_per_step:,}"
-        )
-        parts = [
-            f"per_device_train_batch_size={batch_size}" if batch_size else "",
-            f"sequence_len={sequence_len}" if sequence_len else "",
-            f"gpus={gpus}" if gpus else "",
-            (
-                f"gradient_accumulation_steps={gradient_accumulation_steps}"
-                if gradient_accumulation_steps else ""
-            ),
-        ]
-        parts = [p for p in parts if p]
-        if parts:
-            detail += " (" + " x ".join(parts) + ")"
-        detail += f", short by {shortfall:,}."
+    if starved and dataset_tokens is not None and tokens_per_step:
+        detail = f" The dataset holds {dataset_tokens:,} tokens but one step consumes {tokens_per_step:,}"
+        if config is not None:
+            detail += (
+                f" (per_device_train_batch_size={config.per_device_train_batch_size}"
+                f" x sequence_len={config.sequence_len}"
+                f" x gpus={config.gpus}"
+                f" x gradient_accumulation_steps={config.gradient_accumulation_steps})"
+            )
+        detail += f", short by {tokens_per_step - dataset_tokens:,}."
 
-    # Two different situations, and telling them apart matters: one is a
-    # budget that resolved to nothing, the other is a budget that was asked
-    # for and cannot be met.
-    if starved and max_steps > 0:
-        headline = (
-            f"The dataset cannot fill a single optimizer step, so the "
-            f"requested {max_steps} step(s) cannot run."
-        )
-    else:
-        headline = (
-            "This configuration trains for 0 optimizer steps, so the run "
-            "would produce an untrained model."
-        )
-
-    # Deliberately no longer suggests setting max_steps. That never let
-    # anyone train: it only swapped this message for the dataloader's
-    # `No more files to load`, since the data is still absent either way.
     raise ZeroStepBudgetError(
-        headline + detail +
-        " Use a larger dataset, a shorter sequence_len, or a smaller "
-        "effective batch (batch size x gradient accumulation)."
+        "This run cannot complete a single optimizer step, so it would produce "
+        "an untrained model." + detail + " Use a larger dataset, a shorter sequence_len, or a smaller effective "
+        "batch (batch size x gradient accumulation)."
     )

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -17,6 +17,7 @@ from surogate.train.adapter_init import (
 from surogate.train.early_stopping import EarlyStopping
 from surogate.train.gradient_tracker import GradientTracker
 from surogate.train.loss_guard import LossGuard
+from surogate.train.step_budget import check_step_budget
 from surogate.train.lr_schedule import LRSchedule
 from surogate.train.metrics import MoEMetrics, StepMetrics
 from surogate.train.moe_monitor import MoEMonitor
@@ -560,6 +561,18 @@ class SurogateTrainerWrapper:
         else:
             self.max_steps = self.steps_per_epoch * self.config.num_epochs
             logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s)")
+
+        # A budget of 0 steps must fail here, not sail through the loop and
+        # save an untrained adapter as a "successful" run.
+        check_step_budget(
+            self.max_steps,
+            dataset_tokens=getattr(self.train_loader, "num_tokens", None),
+            tokens_per_step=self.total_batch_size,
+            batch_size=config.per_device_train_batch_size,
+            sequence_len=config.sequence_len,
+            gpus=config.gpus,
+            gradient_accumulation_steps=config.gradient_accumulation_steps,
+        )
 
         # Apply warmup_ratio if warmup_steps is 0
         self.warmup_steps = config.warmup_steps

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -17,8 +17,8 @@ from surogate.train.adapter_init import (
 from surogate.train.early_stopping import EarlyStopping
 from surogate.train.gradient_tracker import GradientTracker
 from surogate.train.loss_guard import LossGuard
-from surogate.train.step_budget import check_step_budget
 from surogate.train.lr_schedule import LRSchedule
+from surogate.train.step_budget import check_step_budget
 from surogate.train.metrics import MoEMetrics, StepMetrics
 from surogate.train.moe_monitor import MoEMonitor
 from surogate.train.phase_detector import PhaseDetector
@@ -429,6 +429,42 @@ class SurogateTrainerWrapper:
                 prefetch,
             )
 
+        # Determine max_steps
+        if config.max_steps > 0:
+            self.max_steps = config.max_steps
+        elif self._train_vision:
+            if self.steps_per_epoch == 0:
+                raise ValueError("train_vision requires max_steps when dataset length is unknown.")
+            self.max_steps = self.steps_per_epoch * self.config.num_epochs
+            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s)")
+        elif config.epoch_adjustment and self.config.from_scratch:
+            # Adjust epochs to reach Chinchilla-optimal token budget
+            chinchilla_epochs = max(1, int(np.ceil(self.chinchilla_tokens / max(self.train_loader.num_tokens, 1))))
+            if chinchilla_epochs != self.config.num_epochs:
+                logger.info(
+                    f"Epoch adjustment: {self.config.num_epochs} -> {chinchilla_epochs} epochs "
+                    f"(Chinchilla budget {self.chinchilla_tokens / 1e9:.1f}B tokens, "
+                    f"dataset {self.train_loader.num_tokens / 1e9:.1f}B tokens)"
+                )
+                self.config.num_epochs = chinchilla_epochs
+            self.max_steps = self.steps_per_epoch * self.config.num_epochs
+            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s) (epoch_adjustment)")
+        else:
+            self.max_steps = self.steps_per_epoch * self.config.num_epochs
+            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s)")
+
+        # Refuse before the expensive setup below rather than after it: this
+        # used to sit past trainer construction, so a config already known to
+        # be unrunnable still paid for the CUDA context, NCCL bring-up and a
+        # full weight import first.
+        check_step_budget(
+            self.max_steps,
+            config=config,
+            num_chunks=self.train_loader.num_chunks if self.train_loader else None,
+            dataset_tokens=self.train_loader.num_tokens if self.train_loader else None,
+            tokens_per_step=self.total_batch_size,
+        )
+
         # Create trainer
         self.start_step = 0
         if config.resume_from_checkpoint:
@@ -538,41 +574,6 @@ class SurogateTrainerWrapper:
             self.chinchilla_tokens = 20 * self.num_params
             self.tokens_per_step = self.total_batch_size
 
-        # Determine max_steps
-        if config.max_steps > 0:
-            self.max_steps = config.max_steps
-        elif self._train_vision:
-            if self.steps_per_epoch == 0:
-                raise ValueError("train_vision requires max_steps when dataset length is unknown.")
-            self.max_steps = self.steps_per_epoch * self.config.num_epochs
-            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s)")
-        elif config.epoch_adjustment and self.config.from_scratch:
-            # Adjust epochs to reach Chinchilla-optimal token budget
-            chinchilla_epochs = max(1, int(np.ceil(self.chinchilla_tokens / max(self.train_loader.num_tokens, 1))))
-            if chinchilla_epochs != self.config.num_epochs:
-                logger.info(
-                    f"Epoch adjustment: {self.config.num_epochs} -> {chinchilla_epochs} epochs "
-                    f"(Chinchilla budget {self.chinchilla_tokens / 1e9:.1f}B tokens, "
-                    f"dataset {self.train_loader.num_tokens / 1e9:.1f}B tokens)"
-                )
-                self.config.num_epochs = chinchilla_epochs
-            self.max_steps = self.steps_per_epoch * self.config.num_epochs
-            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s) (epoch_adjustment)")
-        else:
-            self.max_steps = self.steps_per_epoch * self.config.num_epochs
-            logger.info(f"Derived {self.max_steps} steps from {self.config.num_epochs} epoch(s)")
-
-        # A budget of 0 steps must fail here, not sail through the loop and
-        # save an untrained adapter as a "successful" run.
-        check_step_budget(
-            self.max_steps,
-            dataset_tokens=getattr(self.train_loader, "num_tokens", None),
-            tokens_per_step=self.total_batch_size,
-            batch_size=config.per_device_train_batch_size,
-            sequence_len=config.sequence_len,
-            gpus=config.gpus,
-            gradient_accumulation_steps=config.gradient_accumulation_steps,
-        )
 
         # Apply warmup_ratio if warmup_steps is 0
         self.warmup_steps = config.warmup_steps

--- a/surogate/train/trainer.py
+++ b/surogate/train/trainer.py
@@ -429,6 +429,12 @@ class SurogateTrainerWrapper:
                 prefetch,
             )
 
+        if self.config.from_scratch:
+            # Chinchilla token budget (optimal tokens ≈ 20 × params)
+            self.num_params = estimate_model_parameters(config.model_info.config)
+            self.chinchilla_tokens = 20 * self.num_params
+            self.tokens_per_step = self.total_batch_size
+
         # Determine max_steps
         if config.max_steps > 0:
             self.max_steps = config.max_steps
@@ -461,6 +467,10 @@ class SurogateTrainerWrapper:
             self.max_steps,
             config=config,
             num_chunks=self.train_loader.num_chunks if self.train_loader else None,
+            # The loader was built with chunk_size as its unit, so a step is
+            # this many of them. dispatch-pp redefines total_batch_size, and
+            # this ratio follows it.
+            chunks_per_step=self.total_batch_size // self.chunk_size if self.chunk_size else None,
             dataset_tokens=self.train_loader.num_tokens if self.train_loader else None,
             tokens_per_step=self.total_batch_size,
         )
@@ -567,13 +577,6 @@ class SurogateTrainerWrapper:
                     memcpy_all_gather=config.memcpy_all_gather,
                     memcpy_send_recv=config.memcpy_send_recv,
                 )
-
-        if self.config.from_scratch:
-            # Chinchilla token budget (optimal tokens ≈ 20 × params)
-            self.num_params = estimate_model_parameters(config.model_info.config)
-            self.chinchilla_tokens = 20 * self.num_params
-            self.tokens_per_step = self.total_batch_size
-
 
         # Apply warmup_ratio if warmup_steps is 0
         self.warmup_steps = config.warmup_steps

--- a/tests/train/test_step_budget.py
+++ b/tests/train/test_step_budget.py
@@ -11,6 +11,16 @@ import pytest
 from surogate.train.step_budget import ZeroStepBudgetError, check_step_budget
 
 
+class Cfg:
+    """Only the four fields the message reads."""
+
+    def __init__(self, batch=2, seq=2048, gpus=1, ga=4):
+        self.per_device_train_batch_size = batch
+        self.sequence_len = seq
+        self.gpus = gpus
+        self.gradient_accumulation_steps = ga
+
+
 def test_a_positive_budget_passes():
     check_step_budget(50)
 
@@ -24,28 +34,24 @@ def test_a_nonpositive_budget_raises(budget):
 def test_the_message_names_the_arithmetic_and_the_knobs():
     with pytest.raises(ZeroStepBudgetError) as exc:
         check_step_budget(
-            0, dataset_tokens=2048, tokens_per_step=16384,
-            batch_size=2, sequence_len=2048, gpus=1,
-            gradient_accumulation_steps=4,
+            0,
+            dataset_tokens=2048,
+            tokens_per_step=16384,
+            config=Cfg(),
         )
     msg = str(exc.value)
-    assert "2,048 tokens" in msg          # what you have
-    assert "16,384" in msg                # what one step costs
-    assert "short by 14,336" in msg       # the gap
+    assert "2,048 tokens" in msg  # what you have
+    assert "16,384" in msg  # what one step costs
+    assert "short by 14,336" in msg  # the gap
     assert "per_device_train_batch_size=2" in msg
     assert "gradient_accumulation_steps=4" in msg
-    # The message used to end "Set max_steps explicitly to override". That
-    # advice was removed: an explicit max_steps never let anyone train on a
-    # starved dataset, it only swapped this message for the dataloader's
-    # `No more files to load`. Covered by
-    # test_the_message_no_longer_advises_setting_max_steps.
 
 
 def test_the_message_degrades_without_the_numbers():
     # Callers that cannot supply the arithmetic still get the headline.
     with pytest.raises(ZeroStepBudgetError) as exc:
         check_step_budget(0)
-    assert "0 optimizer steps" in str(exc.value)
+    assert "cannot complete a single optimizer step" in str(exc.value)
     assert "tokens but one step" not in str(exc.value)
 
 
@@ -66,18 +72,8 @@ def test_explicit_max_steps_does_not_excuse_a_starved_dataset():
             5,
             dataset_tokens=2048,
             tokens_per_step=16384,
-            batch_size=2,
-            sequence_len=2048,
-            gpus=1,
-            gradient_accumulation_steps=4,
+            config=Cfg(),
         )
-
-
-def test_the_message_names_both_numbers():
-    with pytest.raises(ZeroStepBudgetError) as exc:
-        check_step_budget(5, dataset_tokens=2048, tokens_per_step=16384)
-    msg = str(exc.value)
-    assert "2,048" in msg and "16,384" in msg
 
 
 def test_the_message_no_longer_advises_setting_max_steps():
@@ -102,3 +98,33 @@ def test_asking_for_more_steps_than_one_epoch_is_fine():
 def test_unknown_dataset_size_does_not_raise():
     """A loader that cannot report its token count must not be guessed at."""
     check_step_budget(5, dataset_tokens=None, tokens_per_step=16384)
+
+
+def test_chunks_beat_tokens_when_the_two_disagree():
+    """The token count is a proxy and it misses a real case.
+
+    Chunks are counted per file with a floor, so a dataset of many files each
+    shorter than `sequence_len` yields zero chunks while its token total looks
+    healthy. Before the chunk predicate this passed the guard and then died in
+    the loader with `No more files to load`.
+    """
+    with pytest.raises(ZeroStepBudgetError):
+        check_step_budget(
+            5,
+            config=Cfg(),
+            num_chunks=0,  # 100 files x 2048 tokens, seq_len 2048
+            dataset_tokens=204_800,  # ... looks like ample data
+            tokens_per_step=16_384,
+        )
+
+
+def test_enough_chunks_passes_even_with_a_modest_token_count():
+    check_step_budget(5, config=Cfg(), num_chunks=8, tokens_per_step=16_384)
+
+
+def test_no_negative_shortfall_in_the_message():
+    """max_steps can resolve to 0 with ample data (num_epochs: 0). The detail
+    block used to run anyway and print `short by -3,616`."""
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(0, config=Cfg(), dataset_tokens=20_000, tokens_per_step=16_384)
+    assert "short by -" not in str(exc.value)

--- a/tests/train/test_step_budget.py
+++ b/tests/train/test_step_budget.py
@@ -34,7 +34,11 @@ def test_the_message_names_the_arithmetic_and_the_knobs():
     assert "short by 14,336" in msg       # the gap
     assert "per_device_train_batch_size=2" in msg
     assert "gradient_accumulation_steps=4" in msg
-    assert "max_steps" in msg             # the override
+    # The message used to end "Set max_steps explicitly to override". That
+    # advice was removed: an explicit max_steps never let anyone train on a
+    # starved dataset, it only swapped this message for the dataloader's
+    # `No more files to load`. Covered by
+    # test_the_message_no_longer_advises_setting_max_steps.
 
 
 def test_the_message_degrades_without_the_numbers():
@@ -43,3 +47,58 @@ def test_the_message_degrades_without_the_numbers():
         check_step_budget(0)
     assert "0 optimizer steps" in str(exc.value)
     assert "tokens but one step" not in str(exc.value)
+
+
+# ── a starved dataset must fail even when max_steps was typed in ────
+
+
+def test_explicit_max_steps_does_not_excuse_a_starved_dataset():
+    """The guard used to ask only "is the step count positive?".
+
+    A typed-in max_steps sailed past it while the data was still absent, and
+    training then died in the dataloader with `No more files to load`, naming
+    neither the dataset nor the batch settings. These are bug 36's numbers: 8
+    examples packed into one 2048-token sequence, against a default step of
+    2 x 2048 x 1 x 4.
+    """
+    with pytest.raises(ZeroStepBudgetError):
+        check_step_budget(
+            5,
+            dataset_tokens=2048,
+            tokens_per_step=16384,
+            batch_size=2,
+            sequence_len=2048,
+            gpus=1,
+            gradient_accumulation_steps=4,
+        )
+
+
+def test_the_message_names_both_numbers():
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(5, dataset_tokens=2048, tokens_per_step=16384)
+    msg = str(exc.value)
+    assert "2,048" in msg and "16,384" in msg
+
+
+def test_the_message_no_longer_advises_setting_max_steps():
+    """It used to end "Set max_steps explicitly to override", which never let
+    anyone train: it swapped a clear error for `No more files to load`."""
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(0, dataset_tokens=500, tokens_per_step=16384)
+    assert "explicitly to override" not in str(exc.value)
+
+
+def test_exactly_one_step_of_data_is_allowed():
+    """The boundary: enough for one step is enough. The loader wraps for more."""
+    check_step_budget(5, dataset_tokens=16384, tokens_per_step=16384)
+
+
+def test_asking_for_more_steps_than_one_epoch_is_fine():
+    """Not "fewer steps than requested" — epochs wrap. Only a dataset that
+    cannot fill a single step is a defect."""
+    check_step_budget(1000, dataset_tokens=163840, tokens_per_step=16384)
+
+
+def test_unknown_dataset_size_does_not_raise():
+    """A loader that cannot report its token count must not be guessed at."""
+    check_step_budget(5, dataset_tokens=None, tokens_per_step=16384)

--- a/tests/train/test_step_budget.py
+++ b/tests/train/test_step_budget.py
@@ -100,11 +100,59 @@ def test_unknown_dataset_size_does_not_raise():
     check_step_budget(5, dataset_tokens=None, tokens_per_step=16384)
 
 
+def test_a_healthy_chunk_count_is_not_rejected():
+    """The ratio must come from the caller, not be derived from sequence_len.
+
+    The loader is built with `chunk_size` (= bsz x seq x gpus) as its unit, so
+    a step needs `total_batch_size // chunk_size` chunks, which is grad_accum.
+    Deriving it as `tokens_per_step // sequence_len` overstates it by
+    `bsz x gpus` and rejects runs that train fine.
+    """
+    check_step_budget(
+        5,
+        config=Cfg(),
+        num_chunks=6,
+        chunks_per_step=4,
+        dataset_tokens=24_577,
+        tokens_per_step=16_384,
+    )
+
+
+def test_unknown_dataset_size_is_not_treated_as_empty():
+    """The multimodal path reports -1 when it cannot measure the dataset."""
+    check_step_budget(5, config=Cfg(), dataset_tokens=-1, tokens_per_step=16_384)
+
+
+def test_chunk_starvation_reports_chunks_not_a_negative_shortfall():
+    """Tokens can look ample when chunks are the thing that ran out, because
+    chunks are floored per file."""
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(
+            5,
+            config=Cfg(),
+            num_chunks=1,
+            chunks_per_step=4,
+            dataset_tokens=24_577,
+            tokens_per_step=16_384,
+        )
+    msg = str(exc.value)
+    assert "chunk" in msg
+    assert "short by -" not in msg
+
+
+def test_the_factor_list_is_omitted_when_it_would_not_multiply_out():
+    """The Ray path scales by num_nodes, so a blindly printed factorisation
+    would contradict the total beside it."""
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(0, config=Cfg(), dataset_tokens=500, tokens_per_step=32_768)
+    assert "per_device_train_batch_size=" not in str(exc.value)
+
+
 def test_chunks_beat_tokens_when_the_two_disagree():
     """The token count is a proxy and it misses a real case.
 
     Chunks are counted per file with a floor, so a dataset of many files each
-    shorter than `sequence_len` yields zero chunks while its token total looks
+    shorter than one chunk yields zero chunks while its token total looks
     healthy. Before the chunk predicate this passed the guard and then died in
     the loader with `No more files to load`.
     """
@@ -112,14 +160,15 @@ def test_chunks_beat_tokens_when_the_two_disagree():
         check_step_budget(
             5,
             config=Cfg(),
-            num_chunks=0,  # 100 files x 2048 tokens, seq_len 2048
-            dataset_tokens=204_800,  # ... looks like ample data
+            num_chunks=0,  # 100 files, each shorter than one chunk
+            chunks_per_step=4,
+            dataset_tokens=204_800,  # ... while the token total looks ample
             tokens_per_step=16_384,
         )
 
 
 def test_enough_chunks_passes_even_with_a_modest_token_count():
-    check_step_budget(5, config=Cfg(), num_chunks=8, tokens_per_step=16_384)
+    check_step_budget(5, config=Cfg(), num_chunks=8, chunks_per_step=4, tokens_per_step=16_384)
 
 
 def test_no_negative_shortfall_in_the_message():

--- a/tests/train/test_step_budget.py
+++ b/tests/train/test_step_budget.py
@@ -1,0 +1,45 @@
+"""A run that cannot take a single optimizer step must fail, not 'succeed'.
+
+The budget is counted in tokens, so a dataset smaller than one step's worth
+yields 0 steps. Unguarded, the loop ran zero times, saved an adapter that
+never saw a gradient, and reported "Training completed successfully" —
+observed live on a 10-row dataset against the default 2 x 2048 x 4.
+"""
+
+import pytest
+
+from surogate.train.step_budget import ZeroStepBudgetError, check_step_budget
+
+
+def test_a_positive_budget_passes():
+    check_step_budget(50)
+
+
+@pytest.mark.parametrize("budget", [0, -1])
+def test_a_nonpositive_budget_raises(budget):
+    with pytest.raises(ZeroStepBudgetError):
+        check_step_budget(budget)
+
+
+def test_the_message_names_the_arithmetic_and_the_knobs():
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(
+            0, dataset_tokens=2048, tokens_per_step=16384,
+            batch_size=2, sequence_len=2048, gpus=1,
+            gradient_accumulation_steps=4,
+        )
+    msg = str(exc.value)
+    assert "2,048 tokens" in msg          # what you have
+    assert "16,384" in msg                # what one step costs
+    assert "short by 14,336" in msg       # the gap
+    assert "per_device_train_batch_size=2" in msg
+    assert "gradient_accumulation_steps=4" in msg
+    assert "max_steps" in msg             # the override
+
+
+def test_the_message_degrades_without_the_numbers():
+    # Callers that cannot supply the arithmetic still get the headline.
+    with pytest.raises(ZeroStepBudgetError) as exc:
+        check_step_budget(0)
+    assert "0 optimizer steps" in str(exc.value)
+    assert "tokens but one step" not in str(exc.value)


### PR DESCRIPTION
A dataset smaller than a single optimizer step fails in one of two ways, and
neither tells you what went wrong.

If the budget resolves to zero, the loop runs zero times, saves an adapter
that never saw a gradient, and reports "Training completed successfully".
If `max_steps` was typed in explicitly, it sails past that and dies inside
the native dataloader with `No more files to load`, naming neither the
dataset nor the batch settings.

Both are the same config defect: the data is smaller than one step. Only the
Python side knows the knobs, so the check lives there.

## What changed

`check_step_budget` refuses such a run before the expensive setup, with a
message naming the numbers and the ways out:

> This run cannot complete a single optimizer step, so it would produce an
> untrained model. The dataset yields 0 loadable chunk(s) but one step needs
> 4; its 2,048 tokens did not fill them, which usually means individual files
> are shorter than one chunk. Use a larger dataset, a shorter sequence_len,
> or a smaller effective batch (batch size x gradient accumulation).

It counts **chunks**, not tokens, because chunks are what the loader actually
serves and they are floored **per file** — a dataset of many short files
yields zero chunks while its token total looks healthy. Token count stays as
a fallback for the Ray path, which reaches its loader over RPC and exposes no
chunk count. `chunks_per_step` comes from the caller: the loader is built with
`chunk_size` as its unit, not `sequence_len`, and deriving it here overstated
it by `bsz x gpus` and rejected runs that train fine.

Deliberately *not* "fewer steps than requested" — asking for more steps than
one epoch holds is normal, the loader wraps. Only a dataset too small for a
single step is a defect.

## Verified

On an 8x5090 box against the published image:

- **Control** reproduces the opaque failure: `Steps per epoch: 0` ->
  `Starting training loop: steps 0 to 4` -> `RuntimeError: No more files to load`
- **Fixed** raises `ZeroStepBudgetError` with the message above
- **A healthy run is unaffected**: exit 0, 5 steps, loss 4.6142 -> 3.3873,
  adapter written

18 unit tests cover the boundaries: exactly one step of data is allowed, an
unknown dataset size (`-1` from the multimodal path) is not treated as empty,
and the factorisation is omitted when it would not multiply out.
