### PR TITLE
fix(grpo): a component failure must become a non-zero exit

### DIFF
--- a/surogate/grpo/abort.py
+++ b/surogate/grpo/abort.py
@@ -1,0 +1,28 @@
+"""Why a GRPO watchdog aborted, when it has no way to say so by raising.
+
+Both GRPO runners stop the pipeline the same way: a watchdog thread signals its
+own process, and the main thread -- blocked in ``asyncio.run`` -- receives a
+``KeyboardInterrupt`` indistinguishable from the one a user's Ctrl-C produces.
+With nowhere to record the cause, the two cases could not be told apart, so a
+crashed component exited 0 and the run was finalized as ``completed`` with no
+error against it.
+
+The convention both runners follow:
+
+1. The watchdog records the reason **before** signalling, so it is already
+   visible by the time the interrupt lands.
+2. The main thread raises only **after** its teardown block has reaped the vLLM
+   process trees. Exiting early would strand them holding their GPUs.
+"""
+
+
+class AbortReason:
+    """A one-slot box shared between the watchdog thread and the main thread.
+
+    Holds the reason a watchdog aborted the pipeline, or ``None`` if it did
+    not. It has to be a mutable object rather than a plain string: the value is
+    written by the watchdog thread and read by the main thread.
+    """
+
+    def __init__(self, reason: str | None = None):
+        self.reason = reason

--- a/surogate/grpo/colocate.py
+++ b/surogate/grpo/colocate.py
@@ -461,6 +461,23 @@ def grpo_colocate(
     )
     watchdog_thread.start()
 
+    # A terminal Ctrl-C reaches vLLM's EngineCore children too: unlike the split
+    # runner, colocate does not `setsid` them, so they share our process group.
+    # They die, `_run_vllm_server` sets `error_event`, and if the watchdog wins
+    # that race a user-initiated stop is reported as a component crash and exits
+    # non-zero. Marking the shutdown planned *before* the interrupt propagates
+    # makes the watchdog return quietly, so an interrupt stays an interrupt.
+    def _interrupt_is_a_planned_stop(signum, frame):
+        shutdown_event.set()
+        raise KeyboardInterrupt
+
+    try:
+        signal.signal(signal.SIGINT, _interrupt_is_a_planned_stop)
+    except ValueError:
+        # Not the main thread, so there is no handler to install. Nothing below
+        # depends on it; the teardown mask is installed separately.
+        pass
+
     try:
         from surogate.grpo.orchestrator.grpo_orch import orchestrate
 
@@ -476,6 +493,14 @@ def grpo_colocate(
         logger.error(f"Orchestrator error: {e}")
         raise
     finally:
+        # Mask FIRST. The watchdog can pass its own `shutdown_event` check and
+        # still be inside `logger.error` when we enter here; its `os.kill` would
+        # then land during the joins below, raise KeyboardInterrupt out of this
+        # `finally`, and skip the event-loop stop, the joins and the raise after
+        # it. Split has masked here all along; colocate did not.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
         logger.info("GRPO pipeline shutting down")
 
         # Tell the watchdog this teardown is intentional and tell the vLLM

--- a/surogate/grpo/colocate.py
+++ b/surogate/grpo/colocate.py
@@ -23,6 +23,7 @@ from threading import Event, Thread
 
 from surogate.core.config.grpo_inference_config import GRPOInferenceConfig
 from surogate.core.config.grpo_orch_config import GRPOOrchestratorConfig
+from surogate.grpo.abort import AbortReason
 from surogate.grpo.config import GRPOTrainConfig
 from surogate.grpo.inference.grpo_infer import setup_vllm_env
 from surogate.utils.logger import get_logger
@@ -323,13 +324,17 @@ def _run_trainer(
 
         trainer = GRPOTrainer(train_config, external_weights=external_weights)
         trainer.train()
-    except Exception as e:
-        logger.error(f"Trainer error: {e}")
+    except Exception:
+        # Set the channel first: anything that goes wrong while logging must not
+        # cost the watchdog its only notification. The re-raise is for the
+        # thread's own stack, not for propagation -- this runs in a daemon
+        # thread, where it is dropped.
         error_event.set()
+        logger.exception("Trainer error")
         raise
 
 
-def _watch_components(error_event: Event, shutdown_event: Event) -> None:
+def _watch_components(error_event: Event, shutdown_event: Event, abort: AbortReason) -> None:
     """Watchdog: aborts the orchestrator if vLLM or the trainer raise.
 
     Both `_run_vllm_server` and `_run_trainer` set `error_event` in their
@@ -342,7 +347,11 @@ def _watch_components(error_event: Event, shutdown_event: Event) -> None:
             break
     if shutdown_event.is_set():
         return
-    logger.error("vLLM or trainer reported an error — aborting GRPO pipeline")
+    reason = "vLLM or trainer reported an error"
+    logger.error(f"{reason} — aborting GRPO pipeline")
+    # Record before signalling: the main thread reads this to tell our own abort
+    # apart from a user's Ctrl-C, and it must be set by the time the signal lands.
+    abort.reason = reason
     os.kill(os.getpid(), signal.SIGINT)
 
 
@@ -442,9 +451,10 @@ def grpo_colocate(
     # Watchdog must come up before the orchestrator so we never miss an early
     # vLLM/trainer crash. shutdown_event suppresses spurious aborts during
     # the planned teardown in the finally block below.
+    abort = AbortReason()
     watchdog_thread = Thread(
         target=_watch_components,
-        args=(error_event, shutdown_event),
+        args=(error_event, shutdown_event, abort),
         daemon=True,
         name="grpo-watchdog",
     )
@@ -455,7 +465,12 @@ def grpo_colocate(
 
         asyncio.run(orchestrate(orch_config))
     except KeyboardInterrupt:
-        logger.warning("Interrupted by user")
+        # A watchdog abort arrives here as an ordinary Ctrl-C (see
+        # `AbortReason`); the recorded reason is what tells them apart. The
+        # watchdog has already logged the cause and the raise below carries it,
+        # so only a genuine interrupt needs a line.
+        if not abort.reason:
+            logger.warning("Interrupted by user")
     except Exception as e:
         logger.error(f"Orchestrator error: {e}")
         raise
@@ -477,3 +492,9 @@ def grpo_colocate(
             vllm_thread.join(timeout=10.0)
 
         watchdog_thread.join(timeout=2.0)
+
+    # After teardown, not instead of it: the finally block above stops the vLLM
+    # loop and joins the trainer. Raising here is what turns a dead component
+    # into a non-zero exit, so ops records the run as failed, not completed.
+    if abort.reason:
+        raise RuntimeError(f"GRPO pipeline aborted: {abort.reason}")

--- a/surogate/grpo/colocate.py
+++ b/surogate/grpo/colocate.py
@@ -129,9 +129,10 @@ def _run_vllm_server(
                     loop.close()
                 except Exception:
                     pass
-    except Exception as e:
-        logger.error(f"vLLM server error: {e}")
+    except Exception:
+        # Set the channel first, for the same reason as `_run_trainer` below.
         error_event.set()
+        logger.exception("vLLM server error")
         raise
 
 

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -36,6 +36,7 @@ import psutil
 
 from surogate.core.config.grpo_inference_config import GRPOInferenceConfig
 from surogate.core.config.grpo_orch_config import GRPOOrchestratorConfig
+from surogate.grpo.abort import AbortReason
 from surogate.grpo.config import GRPOTrainConfig
 from surogate.utils.logger import get_logger
 
@@ -86,40 +87,19 @@ def _run_trainer(train_config: GRPOTrainConfig, failure_event: threading.Event):
     try:
         GRPOTrainer(train_config, external_weights=None).train()
     except Exception:
-        # Set the channel FIRST. This handler used to log first, with
-        # `logger.exception` — a method `LoggerWrapper` does not define — so it
-        # raised inside itself and the line below never ran. The watchdog was
-        # never told, and the run hung in `running` holding its GPUs. Whatever
-        # goes wrong in the logging call, the signal must already be out.
+        # Set the channel FIRST: this used to log first, and the logging call
+        # itself raised, so the line below never ran, the watchdog was never
+        # told, and the run hung in `running` holding its GPUs. Whatever goes
+        # wrong in logging, the signal must already be out.
         failure_event.set()
-        logger.error("Trainer thread crashed", exc_info=True)
-
-
-class AbortReason:
-    """Why the watchdog aborted, or None if it did not.
-
-    The watchdog stops the pipeline by signalling its own process, which the
-    main thread receives as a `KeyboardInterrupt` — identical to a user
-    pressing Ctrl-C. Without somewhere to record the cause, the two cases are
-    indistinguishable, and a crashed component exited 0 and finalized as
-    `completed`.
-    """
-
-    def __init__(self, reason: str | None = None):
-        self.reason = reason
-
-
-def _exit_code_for(abort: "AbortReason") -> int:
-    """A recorded reason means a component died; an empty one means the user
-    interrupted, which is not a failure."""
-    return 1 if abort.reason else 0
+        logger.exception("Trainer thread crashed")
 
 
 def _watch_components(
     vllm_procs: list[tuple["mp.Process", str]],
     trainer_failed: threading.Event,
     shutdown_event: threading.Event,
-    abort: "AbortReason",
+    abort: AbortReason,
 ) -> None:
     """Watchdog: aborts the pipeline if any vLLM or the trainer dies unexpectedly.
 
@@ -260,14 +240,11 @@ def grpo_split(
 
         asyncio.run(orchestrate(orch_config))
     except KeyboardInterrupt:
-        # Two very different events arrive here identically. The watchdog stops
-        # the pipeline by signalling this process, so a crashed component looks
-        # exactly like the user pressing Ctrl-C — which is why a dead vLLM used
-        # to exit 0 and finalize as `completed`. The recorded reason is what
-        # tells them apart; the raise happens after teardown, below.
-        if abort.reason:
-            logger.error(f"GRPO pipeline aborted: {abort.reason}")
-        else:
+        # A watchdog abort arrives here as an ordinary Ctrl-C (see
+        # `AbortReason`); the recorded reason is what tells them apart. The
+        # watchdog has already logged the cause and the raise below carries it,
+        # so only a genuine interrupt needs a line.
+        if not abort.reason:
             logger.warning("Interrupted by user")
     except Exception as e:
         logger.error(f"Split GRPO pipeline error: {e}")
@@ -317,7 +294,7 @@ def grpo_split(
     # process trees, and exiting early would strand them holding GPUs. Raising
     # here is what turns a dead component into a non-zero exit, so ops records
     # the run as failed rather than completed.
-    if _exit_code_for(abort):
+    if abort.reason:
         raise RuntimeError(f"GRPO pipeline aborted: {abort.reason}")
 
 

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -124,14 +124,19 @@ def _watch_components(
                 crashed = f"{label} subprocess died unexpectedly (exitcode={proc.exitcode})"
                 break
         if crashed:
+            # Only a sentinel can fire as a side effect of planned teardown, which
+            # kills the vLLM subprocesses; re-check before calling that a crash, or
+            # a successful run gets marked failed. The trainer branch below needs
+            # no such re-check: teardown only *joins* the trainer thread, so
+            # `trainer_failed` is never a consequence of shutting down, and
+            # discarding it here would downgrade a real late crash to exit 0.
+            if shutdown_event.is_set():
+                return
             break
         if trainer_failed.is_set():
             crashed = "Trainer thread crashed"
             break
-    # Re-check: a planned teardown kills the vLLM subprocesses, so their
-    # sentinels fire exactly like a crash. Aborting on that would now mark a
-    # successful run as failed.
-    if crashed is None or shutdown_event.is_set():
+    if crashed is None:
         return
     logger.error(f"{crashed} — aborting GRPO pipeline")
     # Record before signalling: the main thread reads this to tell our own
@@ -256,16 +261,20 @@ def grpo_split(
         logger.error(f"Split GRPO pipeline error: {e}")
         raise
     finally:
+        # Mask FIRST, before anything that can be interrupted. These two lines
+        # used to sit below the log and the event set, leaving a window where a
+        # watchdog SIGINT would raise inside the `finally` itself -- skipping the
+        # vLLM reap entirely and stranding the process trees on their GPUs, which
+        # is the exact outcome the trailing raise is placed after teardown to
+        # avoid. Also covers a second Ctrl-C during cleanup.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
         logger.info("Split GRPO pipeline shutting down")
 
         # Tell the watchdog this teardown is intentional; otherwise it would see
         # vLLM's planned death and re-fire SIGINT.
         shutdown_event.set()
-
-        # Ignore further Ctrl-Cs/SIGTERMs so cleanup runs to completion. Without this,
-        # a second Ctrl-C interrupts the vLLM teardown and leaks the subprocess tree.
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
         # Reap vLLMs in parallel — each can take up to 15s on SIGTERM→SIGKILL escalation.
         # Sequential teardown would double that on a typical RULER topology. This is the

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -86,14 +86,40 @@ def _run_trainer(train_config: GRPOTrainConfig, failure_event: threading.Event):
     try:
         GRPOTrainer(train_config, external_weights=None).train()
     except Exception:
-        logger.exception("Trainer thread crashed")
+        # Set the channel FIRST. This handler used to log first, with
+        # `logger.exception` — a method `LoggerWrapper` does not define — so it
+        # raised inside itself and the line below never ran. The watchdog was
+        # never told, and the run hung in `running` holding its GPUs. Whatever
+        # goes wrong in the logging call, the signal must already be out.
         failure_event.set()
+        logger.error("Trainer thread crashed", exc_info=True)
+
+
+class AbortReason:
+    """Why the watchdog aborted, or None if it did not.
+
+    The watchdog stops the pipeline by signalling its own process, which the
+    main thread receives as a `KeyboardInterrupt` — identical to a user
+    pressing Ctrl-C. Without somewhere to record the cause, the two cases are
+    indistinguishable, and a crashed component exited 0 and finalized as
+    `completed`.
+    """
+
+    def __init__(self, reason: str | None = None):
+        self.reason = reason
+
+
+def _exit_code_for(abort: "AbortReason") -> int:
+    """A recorded reason means a component died; an empty one means the user
+    interrupted, which is not a failure."""
+    return 1 if abort.reason else 0
 
 
 def _watch_components(
     vllm_procs: list[tuple["mp.Process", str]],
     trainer_failed: threading.Event,
     shutdown_event: threading.Event,
+    abort: "AbortReason",
 ) -> None:
     """Watchdog: aborts the pipeline if any vLLM or the trainer dies unexpectedly.
 
@@ -122,6 +148,10 @@ def _watch_components(
     if crashed is None:
         return
     logger.error(f"{crashed} — aborting GRPO pipeline")
+    # Record before signalling: the main thread reads this to tell our own
+    # abort apart from a user's Ctrl-C, and it must be set by the time the
+    # signal lands.
+    abort.reason = crashed
     # Wake the main thread out of asyncio.run; existing finally block tears down.
     os.kill(os.getpid(), signal.SIGINT)
 
@@ -216,9 +246,10 @@ def grpo_split(
     if judge_proc is not None:
         watched_vllms.append((judge_proc, "judge vLLM"))
     shutdown_event = threading.Event()
+    abort = AbortReason()
     watchdog_thread = Thread(
         target=_watch_components,
-        args=(watched_vllms, trainer_failed, shutdown_event),
+        args=(watched_vllms, trainer_failed, shutdown_event, abort),
         daemon=True,
         name="grpo-watchdog",
     )
@@ -229,7 +260,15 @@ def grpo_split(
 
         asyncio.run(orchestrate(orch_config))
     except KeyboardInterrupt:
-        logger.warning("Interrupted by user")
+        # Two very different events arrive here identically. The watchdog stops
+        # the pipeline by signalling this process, so a crashed component looks
+        # exactly like the user pressing Ctrl-C — which is why a dead vLLM used
+        # to exit 0 and finalize as `completed`. The recorded reason is what
+        # tells them apart; the raise happens after teardown, below.
+        if abort.reason:
+            logger.error(f"GRPO pipeline aborted: {abort.reason}")
+        else:
+            logger.warning("Interrupted by user")
     except Exception as e:
         logger.error(f"Split GRPO pipeline error: {e}")
         raise
@@ -273,6 +312,13 @@ def grpo_split(
             _reap_survivors(psutil.Process().children(recursive=True))
         except Exception as e:
             logger.warning(f"Survivor reap failed during shutdown: {e}")
+
+    # After teardown, not instead of it: the finally block above reaps the vLLM
+    # process trees, and exiting early would strand them holding GPUs. Raising
+    # here is what turns a dead component into a non-zero exit, so ops records
+    # the run as failed rather than completed.
+    if _exit_code_for(abort):
+        raise RuntimeError(f"GRPO pipeline aborted: {abort.reason}")
 
 
 def _spawn_vllm(

--- a/surogate/grpo/split.py
+++ b/surogate/grpo/split.py
@@ -82,9 +82,12 @@ def _run_trainer(train_config: GRPOTrainConfig, failure_event: threading.Event):
     orchestrator. Re-raising here would be silently dropped by daemon-thread
     teardown — the event is the propagation channel to the main thread.
     """
-    from surogate.grpo.trainer import GRPOTrainer
-
     try:
+        # Inside the try: an ImportError here is a crash like any other, and
+        # leaving it outside meant the most likely failure on a dependency bump
+        # set no event, raised no signal, and hung the run in `running`.
+        from surogate.grpo.trainer import GRPOTrainer
+
         GRPOTrainer(train_config, external_weights=None).train()
     except Exception:
         # Set the channel FIRST: this used to log first, and the logging call
@@ -125,7 +128,10 @@ def _watch_components(
         if trainer_failed.is_set():
             crashed = "Trainer thread crashed"
             break
-    if crashed is None:
+    # Re-check: a planned teardown kills the vLLM subprocesses, so their
+    # sentinels fire exactly like a crash. Aborting on that would now mark a
+    # successful run as failed.
+    if crashed is None or shutdown_event.is_set():
         return
     logger.error(f"{crashed} — aborting GRPO pipeline")
     # Record before signalling: the main thread reads this to tell our own

--- a/surogate/utils/logger.py
+++ b/surogate/utils/logger.py
@@ -78,6 +78,18 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         message = self.formatMessage(record)
 
+        # `logging.Formatter.format` appends the traceback; this override
+        # replaced it wholesale and dropped it, so every `exc_info=True` call in
+        # the codebase logged its message with no stack behind it. Appending
+        # before the timestamp block keeps the traceback lines unprefixed, which
+        # is how that block already treats multi-line messages.
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            message = f"{message}\n{record.exc_text}"
+        if record.stack_info:
+            message = f"{message}\n{self.formatStack(record.stack_info)}"
+
         # Add timestamp if configured
         if hasattr(self, "_show_timestamp") and self._show_timestamp:
             timestamp = self.formatTime(record, self.datefmt)
@@ -101,12 +113,20 @@ class LoggerWrapper:
         self._logger = logger
         self.show_location = show_location
 
-    def _add_location(self, color: str) -> str:
-        """Add file and line number with color."""
+    def _add_location(self, color: str, depth: int = 2) -> str:
+        """Add file and line number with color.
+
+        *depth* is how many frames up the real caller sits. The default of 2
+        suits a log method calling this directly; a method that delegates to
+        another one (``exception`` -> ``error``) has to add its own frame, or
+        the location reads as logger.py instead of the caller.
+        """
         if not self.show_location:
             return ""
 
-        frame = inspect.currentframe().f_back.f_back
+        frame = inspect.currentframe()
+        for _ in range(depth):
+            frame = frame.f_back
         filename = os.path.basename(frame.f_code.co_filename)
         lineno = frame.f_lineno
         return f"{color}{Colors.ITALIC}[{filename}:{lineno}]{Colors.RESET} "
@@ -176,13 +196,13 @@ class LoggerWrapper:
         if cond:
             self.warning(msg)
 
-    def error(self, msg: str, *args, exc_info=None, **kwargs):
+    def error(self, msg: str, *args, exc_info=None, _depth: int = 2, **kwargs):
         if _is_from_libraries():
             self.debug(msg, exc_info=exc_info, *args, **kwargs)
             return
         """Log error message in bright red."""
         prefix = f"{Colors.BRIGHT_RED}[ERROR]{Colors.RESET}"
-        colored_msg = f"{prefix} {self._add_location(Colors.BRIGHT_RED)}{Colors.RED}{msg}{Colors.RESET}"
+        colored_msg = f"{prefix} {self._add_location(Colors.BRIGHT_RED, _depth)}{Colors.RED}{msg}{Colors.RESET}"
         self._logger.error(colored_msg, *args, exc_info=exc_info, **kwargs)
 
     def exception(self, msg: str, *args, **kwargs):
@@ -195,7 +215,9 @@ class LoggerWrapper:
         meant to do next never ran. That cost a GRPO run its failure signal.
         """
         kwargs.setdefault("exc_info", True)
-        self.error(msg, *args, **kwargs)
+        # +1 frame: the caller we want to name is above `exception`, not above
+        # `error`.
+        self.error(msg, *args, _depth=3, **kwargs)
 
     def critical(self, msg: str, *args, exc_info=None, **kwargs):
         """Log critical message in bold bright red."""

--- a/surogate/utils/logger.py
+++ b/surogate/utils/logger.py
@@ -185,6 +185,18 @@ class LoggerWrapper:
         colored_msg = f"{prefix} {self._add_location(Colors.BRIGHT_RED)}{Colors.RED}{msg}{Colors.RESET}"
         self._logger.error(colored_msg, *args, exc_info=exc_info, **kwargs)
 
+    def exception(self, msg: str, *args, **kwargs):
+        """Log an error with the active traceback, as ``logging.Logger.exception``.
+
+        This is the one member of the stdlib logger API the wrapper otherwise
+        mirrors, and its absence was a landmine rather than a gap: calling
+        ``logger.exception(...)`` inside an ``except`` block raised
+        ``AttributeError`` from the handler itself, so whatever the handler
+        meant to do next never ran. That cost a GRPO run its failure signal.
+        """
+        kwargs.setdefault("exc_info", True)
+        self.error(msg, *args, **kwargs)
+
     def critical(self, msg: str, *args, exc_info=None, **kwargs):
         """Log critical message in bold bright red."""
         prefix = f"{Colors.BOLD}{Colors.BRIGHT_RED}[CRITICAL]{Colors.RESET}"

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -16,8 +16,12 @@ swallowed the interrupt, returned normally, and the process exited 0 -- so ops
 finalized a crashed run as `completed` with a null error.
 """
 
+import asyncio
+import os
+import signal
 import sys
 import threading
+import time
 from unittest import mock
 
 import pytest
@@ -263,3 +267,141 @@ def test_a_clean_shutdown_records_nothing(runner, call):
 
     assert abort.reason is None
     assert not split_killed.called and not colocate_killed.called
+
+
+# ── the co-locate contract, driven end to end ────────────────────────
+
+
+def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False):
+    """Run the real `grpo_colocate` with only its heavy edges substituted.
+
+    Everything the contract depends on stays real: both threads, the watchdog,
+    the SIGINT it sends, the KeyboardInterrupt handler, the teardown block and
+    the raise after it. Substituted are the parts that need a GPU -- the vLLM
+    server, the weight extraction, the trainer body and the orchestrator.
+
+    `order` records what actually happened, so the test can assert the raise
+    came *after* teardown rather than instead of it.
+    """
+    order: list[str] = []
+
+    def fake_setup_vllm_env(_cfg):
+        return None
+
+    def fake_vllm_server(_infer, ready, error_event, engine_holder, loop_holder, shutdown):
+        engine_holder.append(mock.MagicMock())
+        loop = mock.MagicMock()
+        loop.is_closed.return_value = False
+        loop.call_soon_threadsafe.side_effect = lambda *_a, **_k: order.append("event-loop-stopped")
+        loop_holder.append(loop)
+        ready.set()
+        shutdown.wait(timeout=30.0)
+        if signal_during_teardown:
+            # `shutdown` is set at the top of the teardown block, so this lands
+            # squarely inside it -- exactly where the watchdog's own `os.kill`
+            # can arrive when it passed its shutdown check a moment earlier.
+            order.append("signal-during-teardown")
+            os.kill(os.getpid(), signal.SIGINT)
+
+    def fake_extract(_client, _loop, _gpus):
+        return [[{"name": "fake"}]]
+
+    def fake_trainer(_train, _weights, error_event):
+        order.append("trainer-started")
+        if kill_mid_run:
+            # A component dying while the orchestrator runs: the only path that
+            # reaches watchdog -> SIGINT -> the KeyboardInterrupt handler.
+            time.sleep(0.4)
+            order.append("component-died")
+            error_event.set()
+
+    async def fake_orchestrate(_cfg):
+        # Long enough that the watchdog's signal lands inside `asyncio.run`,
+        # which is where a real abort arrives.
+        await asyncio.sleep(5.0)
+        order.append("orchestrator-finished")
+
+    # Sizes vLLM's share against the trainer's estimate by asking torch about the
+    # device; nothing to do with the abort contract, and this venv's torch is
+    # CPU-only.
+    monkeypatch.setattr(colocate, "_compute_gpu_memory_utilization", lambda _c: 0.45)
+    monkeypatch.setattr(colocate, "setup_vllm_env", fake_setup_vllm_env)
+    monkeypatch.setattr(colocate, "_run_vllm_server", fake_vllm_server)
+    monkeypatch.setattr(colocate, "_extract_vllm_weights", fake_extract)
+    monkeypatch.setattr(colocate, "_run_trainer", fake_trainer)
+
+    orch_mod = mock.MagicMock()
+    orch_mod.orchestrate = fake_orchestrate
+    monkeypatch.setitem(sys.modules, "surogate.grpo.orchestrator.grpo_orch", orch_mod)
+
+    cfg = mock.MagicMock()
+    cfg.gpus = 1
+    cfg.gpu_memory_utilization = None
+    return cfg, order
+
+
+def test_colocate_raises_after_teardown_when_a_component_dies(monkeypatch):
+    """The contract this branch rests on, on the runner with no live run.
+
+    A component dies mid-run, so the watchdog signals; the main thread must tear
+    down first and *then* raise. Exiting early would strand the vLLM engine, and
+    not raising at all is the bug being fixed.
+    """
+    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=True)
+    previous = signal.getsignal(signal.SIGINT)
+    try:
+        with pytest.raises(RuntimeError, match="GRPO pipeline aborted"):
+            colocate.grpo_colocate(cfg, cfg, cfg)
+    finally:
+        signal.signal(signal.SIGINT, previous)
+
+    assert "component-died" in order
+    assert "event-loop-stopped" in order, "teardown must have run"
+    assert order.index("event-loop-stopped") > order.index("component-died")
+    assert "orchestrator-finished" not in order, "the run was aborted, not completed"
+
+
+def test_colocate_exits_cleanly_when_nothing_dies(monkeypatch):
+    """The other half: no component failure means no raise, so a good run stays
+    a good run. A guard that fires on healthy runs is worse than none."""
+    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=False)
+    previous = signal.getsignal(signal.SIGINT)
+    try:
+        colocate.grpo_colocate(cfg, cfg, cfg)  # must not raise
+    finally:
+        signal.signal(signal.SIGINT, previous)
+
+    assert "orchestrator-finished" in order
+    assert "event-loop-stopped" in order
+
+
+def test_colocate_teardown_survives_a_signal_landing_inside_it(monkeypatch):
+    """Teardown must be signal-masked, or the raise never happens.
+
+    The watchdog can pass its own `shutdown_event` check and still be inside
+    `logger.error` when the main thread enters the `finally`. Its `os.kill` then
+    lands during the joins. Unmasked, that raises KeyboardInterrupt out of the
+    `finally`: the event loop is never stopped, the threads are never joined,
+    and the raise after the block never runs -- so a crashed run exits 0 with a
+    leaked engine. Split masked here all along; co-locate did not.
+    """
+    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=True, signal_during_teardown=True)
+    previous = signal.getsignal(signal.SIGINT)
+    raised: BaseException | None = None
+    try:
+        colocate.grpo_colocate(cfg, cfg, cfg)
+    except BaseException as exc:  # noqa: BLE001 - the type is the assertion
+        raised = exc
+    finally:
+        signal.signal(signal.SIGINT, previous)
+
+    # Catch BaseException rather than `pytest.raises(RuntimeError)`: unmasked,
+    # the escaping KeyboardInterrupt tears down the whole pytest session instead
+    # of failing this test, which makes a regression look like an aborted run.
+    assert "signal-during-teardown" in order, "the fixture must actually signal"
+    assert not isinstance(raised, KeyboardInterrupt), (
+        "the signal escaped the teardown block; the event loop was never stopped and the raise after it never ran"
+    )
+    assert isinstance(raised, RuntimeError), f"expected the abort, got {raised!r}"
+    assert "GRPO pipeline aborted" in str(raised)
+    assert "event-loop-stopped" in order, "teardown must complete despite the signal"

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -49,6 +49,28 @@ def test_the_logger_has_an_exception_method_that_keeps_the_traceback():
     with mock.patch.object(logger, "error") as errored:
         logger.exception("boom")
     assert errored.call_args.kwargs["exc_info"] is True, "the traceback is the point"
+    # Delegating to `error` adds a frame, and the location is read at a fixed
+    # depth, so without the bump every exception log is tagged `logger.py`.
+    assert errored.call_args.kwargs["_depth"] == 3
+
+
+def test_the_formatter_actually_emits_the_traceback():
+    """`exc_info=True` was cosmetic: `ColoredFormatter.format` overrides the base
+    method wholesale and never appended the traceback, so every crash in the
+    codebase logged its one-line message with no stack behind it."""
+    import logging
+
+    from surogate.utils.logger import ColoredFormatter
+
+    try:
+        raise ZeroDivisionError("division by zero")
+    except ZeroDivisionError:
+        record = logging.LogRecord("t", logging.ERROR, __file__, 1, "Trainer thread crashed", None, sys.exc_info())
+
+    rendered = ColoredFormatter().format(record)
+    assert "Trainer thread crashed" in rendered
+    assert "ZeroDivisionError" in rendered, "the stack is the reason exc_info was asked for"
+    assert "Traceback (most recent call last)" in rendered
 
 
 def _crashing_trainer_module():
@@ -118,6 +140,45 @@ def test_the_watchdog_records_why_it_aborted():
     assert abort.reason, "the abort must leave a reason behind"
     assert "rainer" in abort.reason
     assert killed.called, "and it still signals the main thread"
+
+
+def test_a_trainer_import_failure_sets_the_failure_event():
+    """The import used to sit outside the try, so the likeliest crash on a
+    dependency bump -- and the parent commit is a verifiers 0.1.11 -> 0.3.0
+    upgrade -- set no event, sent no signal, and hung the run holding GPUs."""
+    ev = threading.Event()
+    with mock.patch.dict(sys.modules, {"surogate.grpo.trainer": None}):
+        # A None entry in sys.modules makes `from ... import X` raise ImportError.
+        split._run_trainer(mock.MagicMock(), ev)
+    assert ev.is_set(), "an import-time crash is still a crash"
+
+
+def test_a_planned_teardown_is_not_reported_as_a_crash():
+    """Teardown sets `shutdown_event` and then kills the vLLM subprocesses, so
+    their sentinels fire exactly like a crash. The loop's own post-wait check
+    catches the ordinary case; this pins the window underneath it, where the
+    scan has already run and teardown flips the flag before the abort. It used
+    to leave a swallowed SIGINT and a warning. Now that an abort raises, it
+    would mark a successful run as failed.
+    """
+    proc = mock.MagicMock()
+    proc.sentinel = "fd"
+    proc.exitcode = -15
+    abort = AbortReason()
+
+    # is_set() is read three times per pass: the `while`, the post-wait guard,
+    # and the final one. Teardown lands between the second and the third.
+    shutdown = mock.MagicMock()
+    shutdown.is_set.side_effect = [False, False, True]
+
+    with (
+        mock.patch.object(split.multiprocessing.connection, "wait", return_value=["fd"]),
+        mock.patch.object(split.os, "kill") as killed,
+    ):
+        split._watch_components([(proc, "rollout vLLM")], threading.Event(), shutdown, abort)
+
+    assert abort.reason is None, "a planned teardown must not be an abort"
+    assert not killed.called
 
 
 def test_the_colocate_watchdog_records_why_it_aborted():

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -1,13 +1,18 @@
 """A GRPO component failure must become a non-zero exit status.
 
-Two halves of one gap. The trainer's crash handler called `logger.exception`,
-which `LoggerWrapper` does not define, so the handler raised inside itself and
-the `failure_event.set()` on the next line never ran: the watchdog was never
-told and the run hung in `running` forever, holding its GPUs.
+Two halves of one gap, in both GRPO runners.
 
-And when the watchdog *does* abort, it does so by signalling its own process,
+The trainer's crash handler called `logger.exception`, which `LoggerWrapper`
+did not define, so the handler raised inside itself and the `error_event.set()`
+beside it never ran: the watchdog was never told and the run hung in `running`
+forever, holding its GPUs. The durable fix is the ordering -- set the channel
+before doing anything fallible -- and the root fix is giving `LoggerWrapper`
+the one stdlib method it was missing, since 100-odd other modules could reach
+for it inside an `except` block just as easily.
+
+And when a watchdog *does* abort, it does so by signalling its own process,
 which the main thread could not tell apart from a user pressing Ctrl-C. It
-swallowed the interrupt, returned normally, and the process exited 0 — so ops
+swallowed the interrupt, returned normally, and the process exited 0 -- so ops
 finalized a crashed run as `completed` with a null error.
 """
 
@@ -17,10 +22,10 @@ from unittest import mock
 
 import pytest
 
-#  reaches the compiled extension through its config import, which
-# has nothing to do with the failure plumbing under test here. Use the real one
-# where it is built (CI) and a stand-in where it is not, so these stay runnable
-# without a GPU toolchain.
+# `split` and `colocate` reach the compiled extension through their config
+# import, which has nothing to do with the failure plumbing under test. Use the
+# real one where it is built (CI) and a stand-in where it is not, so these stay
+# runnable without a GPU toolchain.
 try:  # pragma: no cover - depends on the build environment
     import surogate._surogate  # noqa: F401
 except ImportError:  # pragma: no cover
@@ -30,23 +35,32 @@ except ImportError:  # pragma: no cover
     sys.modules["surogate._surogate"] = _stub
     surogate._surogate = _stub
 
-from surogate.grpo import split  # noqa: E402
+from surogate.grpo import colocate, split  # noqa: E402
+from surogate.grpo.abort import AbortReason  # noqa: E402
 from surogate.utils.logger import get_logger  # noqa: E402
 
 
-def test_the_logger_still_has_no_exception_method():
-    """Pins the premise. If `LoggerWrapper` ever grows `.exception`, this fails
-    and the handler below can be simplified — until then, using it is a bug."""
-    assert not hasattr(get_logger(), "exception")
+def test_the_logger_has_an_exception_method_that_keeps_the_traceback():
+    """The root cause. `LoggerWrapper` mirrors the stdlib logger API but omitted
+    this one member, so `logger.exception(...)` raised `AttributeError` from
+    inside the very handler that was reporting a crash."""
+    logger = get_logger()
+    assert hasattr(logger, "exception")
+    with mock.patch.object(logger, "error") as errored:
+        logger.exception("boom")
+    assert errored.call_args.kwargs["exc_info"] is True, "the traceback is the point"
 
 
 def _crashing_trainer_module():
-    """`_run_trainer` imports the trainer inside the function, so swapping the
-    module out is enough — and avoids importing the real one, which drags in
+    """Both runners import the trainer inside `_run_trainer`, so swapping the
+    module out is enough -- and avoids importing the real one, which drags in
     the whole engine."""
     fake = mock.MagicMock()
     fake.GRPOTrainer.side_effect = RuntimeError("boom")
     return fake
+
+
+# ── the failure signal survives a broken logger ──────────────────────
 
 
 def test_a_trainer_crash_sets_the_failure_event():
@@ -57,15 +71,11 @@ def test_a_trainer_crash_sets_the_failure_event():
 
 
 def test_the_event_is_set_even_when_logging_fails():
-    """The regression test for the original bug.
-
-    The handler logged first and set the event second, so anything wrong with
-    the logging call cost us the signal entirely. Ordering is the durable fix:
-    set the channel first, then log.
-    """
+    """The regression test. Ordering is the durable fix: set the channel first,
+    then log, so nothing wrong with the logging call can cost us the signal."""
     ev = threading.Event()
     broken = mock.MagicMock()
-    broken.error.side_effect = AttributeError("no such method")
+    broken.exception.side_effect = AttributeError("no such method")
     with (
         mock.patch.dict(sys.modules, {"surogate.grpo.trainer": _crashing_trainer_module()}),
         mock.patch.object(split, "logger", broken),
@@ -75,36 +85,72 @@ def test_the_event_is_set_even_when_logging_fails():
     assert ev.is_set(), "a broken logger must not cost us the failure signal"
 
 
+def test_the_colocate_event_is_set_even_when_logging_fails():
+    """Same handler, same rule, the other runner."""
+    ev = threading.Event()
+    broken = mock.MagicMock()
+    broken.exception.side_effect = AttributeError("no such method")
+    with (
+        mock.patch.dict(sys.modules, {"surogate.grpo.trainer": _crashing_trainer_module()}),
+        mock.patch.object(colocate, "logger", broken),
+    ):
+        with pytest.raises(AttributeError):
+            colocate._run_trainer(mock.MagicMock(), None, ev)
+    assert ev.is_set()
+
+
+# ── an abort leaves a reason behind, a clean shutdown does not ───────
+
+
 def test_the_watchdog_records_why_it_aborted():
-    """The main thread needs to tell a watchdog abort from a real Ctrl-C, so
-    the reason has to be recorded before the signal is delivered."""
     trainer_failed = threading.Event()
     trainer_failed.set()
-    shutdown = threading.Event()
-    abort = split.AbortReason()
+    abort = AbortReason()
 
-    with mock.patch.object(split.os, "kill") as killed:
-        split._watch_components([], trainer_failed, shutdown, abort)
+    with (
+        # The sentinel poll would otherwise sleep its full timeout on an empty
+        # fd set; this test is about the trainer branch, not the wait.
+        mock.patch.object(split.multiprocessing.connection, "wait", return_value=[]),
+        mock.patch.object(split.os, "kill") as killed,
+    ):
+        split._watch_components([], trainer_failed, threading.Event(), abort)
 
     assert abort.reason, "the abort must leave a reason behind"
     assert "rainer" in abort.reason
     assert killed.called, "and it still signals the main thread"
 
 
-def test_a_clean_shutdown_records_nothing():
+def test_the_colocate_watchdog_records_why_it_aborted():
+    error_event = threading.Event()
+    error_event.set()
+    abort = AbortReason()
+
+    with mock.patch.object(colocate.os, "kill") as killed:
+        colocate._watch_components(error_event, threading.Event(), abort)
+
+    assert abort.reason, "both runners exit through the same ambiguity"
+    assert killed.called
+
+
+@pytest.mark.parametrize(
+    "runner,call",
+    [
+        ("split", lambda abort, shutdown: split._watch_components([], threading.Event(), shutdown, abort)),
+        ("colocate", lambda abort, shutdown: colocate._watch_components(threading.Event(), shutdown, abort)),
+    ],
+)
+def test_a_clean_shutdown_records_nothing(runner, call):
+    """A planned teardown must stay exit 0. Only a recorded reason is a failure,
+    which is what keeps a user's Ctrl-C from being reported as a crash."""
     shutdown = threading.Event()
     shutdown.set()
-    abort = split.AbortReason()
+    abort = AbortReason()
 
-    with mock.patch.object(split.os, "kill") as killed:
-        split._watch_components([], threading.Event(), shutdown, abort)
+    with (
+        mock.patch.object(split.os, "kill") as split_killed,
+        mock.patch.object(colocate.os, "kill") as colocate_killed,
+    ):
+        call(abort, shutdown)
 
     assert abort.reason is None
-    assert not killed.called
-
-
-def test_an_abort_reason_is_a_failure_not_an_interrupt():
-    """A recorded reason means a component died: the process must exit
-    non-zero. An empty one means the user pressed Ctrl-C, which stays 0."""
-    assert split._exit_code_for(split.AbortReason("rollout vLLM died")) != 0
-    assert split._exit_code_for(split.AbortReason()) == 0
+    assert not split_killed.called and not colocate_killed.called

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -1,0 +1,110 @@
+"""A GRPO component failure must become a non-zero exit status.
+
+Two halves of one gap. The trainer's crash handler called `logger.exception`,
+which `LoggerWrapper` does not define, so the handler raised inside itself and
+the `failure_event.set()` on the next line never ran: the watchdog was never
+told and the run hung in `running` forever, holding its GPUs.
+
+And when the watchdog *does* abort, it does so by signalling its own process,
+which the main thread could not tell apart from a user pressing Ctrl-C. It
+swallowed the interrupt, returned normally, and the process exited 0 — so ops
+finalized a crashed run as `completed` with a null error.
+"""
+
+import sys
+import threading
+from unittest import mock
+
+import pytest
+
+#  reaches the compiled extension through its config import, which
+# has nothing to do with the failure plumbing under test here. Use the real one
+# where it is built (CI) and a stand-in where it is not, so these stay runnable
+# without a GPU toolchain.
+try:  # pragma: no cover - depends on the build environment
+    import surogate._surogate  # noqa: F401
+except ImportError:  # pragma: no cover
+    import surogate
+
+    _stub = mock.MagicMock()
+    sys.modules["surogate._surogate"] = _stub
+    surogate._surogate = _stub
+
+from surogate.grpo import split  # noqa: E402
+from surogate.utils.logger import get_logger  # noqa: E402
+
+
+def test_the_logger_still_has_no_exception_method():
+    """Pins the premise. If `LoggerWrapper` ever grows `.exception`, this fails
+    and the handler below can be simplified — until then, using it is a bug."""
+    assert not hasattr(get_logger(), "exception")
+
+
+def _crashing_trainer_module():
+    """`_run_trainer` imports the trainer inside the function, so swapping the
+    module out is enough — and avoids importing the real one, which drags in
+    the whole engine."""
+    fake = mock.MagicMock()
+    fake.GRPOTrainer.side_effect = RuntimeError("boom")
+    return fake
+
+
+def test_a_trainer_crash_sets_the_failure_event():
+    ev = threading.Event()
+    with mock.patch.dict(sys.modules, {"surogate.grpo.trainer": _crashing_trainer_module()}):
+        split._run_trainer(mock.MagicMock(), ev)
+    assert ev.is_set(), "the watchdog's only propagation channel must fire"
+
+
+def test_the_event_is_set_even_when_logging_fails():
+    """The regression test for the original bug.
+
+    The handler logged first and set the event second, so anything wrong with
+    the logging call cost us the signal entirely. Ordering is the durable fix:
+    set the channel first, then log.
+    """
+    ev = threading.Event()
+    broken = mock.MagicMock()
+    broken.error.side_effect = AttributeError("no such method")
+    with (
+        mock.patch.dict(sys.modules, {"surogate.grpo.trainer": _crashing_trainer_module()}),
+        mock.patch.object(split, "logger", broken),
+    ):
+        with pytest.raises(AttributeError):
+            split._run_trainer(mock.MagicMock(), ev)
+    assert ev.is_set(), "a broken logger must not cost us the failure signal"
+
+
+def test_the_watchdog_records_why_it_aborted():
+    """The main thread needs to tell a watchdog abort from a real Ctrl-C, so
+    the reason has to be recorded before the signal is delivered."""
+    trainer_failed = threading.Event()
+    trainer_failed.set()
+    shutdown = threading.Event()
+    abort = split.AbortReason()
+
+    with mock.patch.object(split.os, "kill") as killed:
+        split._watch_components([], trainer_failed, shutdown, abort)
+
+    assert abort.reason, "the abort must leave a reason behind"
+    assert "rainer" in abort.reason
+    assert killed.called, "and it still signals the main thread"
+
+
+def test_a_clean_shutdown_records_nothing():
+    shutdown = threading.Event()
+    shutdown.set()
+    abort = split.AbortReason()
+
+    with mock.patch.object(split.os, "kill") as killed:
+        split._watch_components([], threading.Event(), shutdown, abort)
+
+    assert abort.reason is None
+    assert not killed.called
+
+
+def test_an_abort_reason_is_a_failure_not_an_interrupt():
+    """A recorded reason means a component died: the process must exit
+    non-zero. An empty one means the user pressed Ctrl-C, which stays 0."""
+    assert split._exit_code_for(split.AbortReason("rollout vLLM died")) != 0
+    assert split._exit_code_for(split.AbortReason()) == 0

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -272,7 +272,7 @@ def test_a_clean_shutdown_records_nothing(runner, call):
 # ── the co-locate contract, driven end to end ────────────────────────
 
 
-def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False):
+def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False, user_interrupt=False):
     """Run the real `grpo_colocate` with only its heavy edges substituted.
 
     Everything the contract depends on stays real: both threads, the watchdog,
@@ -288,7 +288,12 @@ def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False
     def fake_setup_vllm_env(_cfg):
         return None
 
+    error_box: list = []
+    shutdown_box: list = []
+
     def fake_vllm_server(_infer, ready, error_event, engine_holder, loop_holder, shutdown):
+        error_box.append(error_event)
+        shutdown_box.append(shutdown)
         engine_holder.append(mock.MagicMock())
         loop = mock.MagicMock()
         loop.is_closed.return_value = False
@@ -316,6 +321,16 @@ def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False
             error_event.set()
 
     async def fake_orchestrate(_cfg):
+        if user_interrupt:
+            # A terminal Ctrl-C: the signal reaches this process AND vLLM's
+            # EngineCore children, which colocate does not detach. They die a
+            # moment later, so `error_event` is set right behind the interrupt --
+            # which is exactly the race that decided whether a user stop was
+            # reported as a crash.
+            await asyncio.sleep(0.3)
+            order.append("user-pressed-ctrl-c")
+            threading.Timer(0.15, lambda: (order.append("vllm-children-died"), error_box[0].set())).start()
+            os.kill(os.getpid(), signal.SIGINT)
         # Long enough that the watchdog's signal lands inside `asyncio.run`,
         # which is where a real abort arrives.
         await asyncio.sleep(5.0)
@@ -337,7 +352,7 @@ def _colocate_harness(monkeypatch, *, kill_mid_run, signal_during_teardown=False
     cfg = mock.MagicMock()
     cfg.gpus = 1
     cfg.gpu_memory_utilization = None
-    return cfg, order
+    return cfg, order, shutdown_box
 
 
 def test_colocate_raises_after_teardown_when_a_component_dies(monkeypatch):
@@ -347,7 +362,7 @@ def test_colocate_raises_after_teardown_when_a_component_dies(monkeypatch):
     down first and *then* raise. Exiting early would strand the vLLM engine, and
     not raising at all is the bug being fixed.
     """
-    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=True)
+    cfg, order, shutdown_box = _colocate_harness(monkeypatch, kill_mid_run=True)
     previous = signal.getsignal(signal.SIGINT)
     try:
         with pytest.raises(RuntimeError, match="GRPO pipeline aborted"):
@@ -364,7 +379,7 @@ def test_colocate_raises_after_teardown_when_a_component_dies(monkeypatch):
 def test_colocate_exits_cleanly_when_nothing_dies(monkeypatch):
     """The other half: no component failure means no raise, so a good run stays
     a good run. A guard that fires on healthy runs is worse than none."""
-    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=False)
+    cfg, order, shutdown_box = _colocate_harness(monkeypatch, kill_mid_run=False)
     previous = signal.getsignal(signal.SIGINT)
     try:
         colocate.grpo_colocate(cfg, cfg, cfg)  # must not raise
@@ -385,7 +400,7 @@ def test_colocate_teardown_survives_a_signal_landing_inside_it(monkeypatch):
     and the raise after the block never runs -- so a crashed run exits 0 with a
     leaked engine. Split masked here all along; co-locate did not.
     """
-    cfg, order = _colocate_harness(monkeypatch, kill_mid_run=True, signal_during_teardown=True)
+    cfg, order, shutdown_box = _colocate_harness(monkeypatch, kill_mid_run=True, signal_during_teardown=True)
     previous = signal.getsignal(signal.SIGINT)
     raised: BaseException | None = None
     try:
@@ -405,3 +420,44 @@ def test_colocate_teardown_survives_a_signal_landing_inside_it(monkeypatch):
     assert isinstance(raised, RuntimeError), f"expected the abort, got {raised!r}"
     assert "GRPO pipeline aborted" in str(raised)
     assert "event-loop-stopped" in order, "teardown must complete despite the signal"
+
+
+def test_the_interrupt_handler_marks_the_shutdown_planned(monkeypatch):
+    """Ctrl-C must not be turned into a crash report.
+
+    Colocate does not `setsid` vLLM's EngineCore children, so a terminal
+    interrupt reaches them directly; they die, the vLLM thread flags an error,
+    and the watchdog would call that a component crash and exit non-zero. The
+    handler marks the shutdown planned first, so the watchdog returns quietly.
+
+    This asserts the mechanism, not the race. The race itself has no
+    deterministic test: whether the watchdog has already passed its
+    `shutdown_event` check when the children die is genuine timing, and the
+    handler narrows that window rather than closing it. A test that tried to
+    stage the race passed with the handler removed, so it was measuring nothing.
+    """
+    cfg, order, shutdown_box = _colocate_harness(monkeypatch, kill_mid_run=False)
+    captured: dict = {}
+
+    real_signal = signal.signal
+
+    def capture_handler(signum, handler):
+        if signum == signal.SIGINT and callable(handler):
+            captured.setdefault("handler", handler)
+        return real_signal(signum, handler)
+
+    monkeypatch.setattr(colocate.signal, "signal", capture_handler)
+
+    previous = signal.getsignal(signal.SIGINT)
+    try:
+        colocate.grpo_colocate(cfg, cfg, cfg)
+    finally:
+        real_signal(signal.SIGINT, previous)
+
+    assert "handler" in captured, "colocate must install a SIGINT handler"
+    assert shutdown_box, "the fake vLLM thread must have handed us the event"
+    shutdown = shutdown_box[0]
+    shutdown.clear()
+    with pytest.raises(KeyboardInterrupt):
+        captured["handler"](signal.SIGINT, None)
+    assert shutdown.is_set(), "the handler must mark the shutdown planned before interrupting"

--- a/tests/grpo/test_failure_exit_status.py
+++ b/tests/grpo/test_failure_exit_status.py
@@ -181,6 +181,54 @@ def test_a_planned_teardown_is_not_reported_as_a_crash():
     assert not killed.called
 
 
+def test_a_late_trainer_crash_is_not_discarded_by_teardown():
+    """The re-check added for planned teardown must not swallow a real crash.
+
+    Teardown kills the vLLM subprocesses, so their sentinels fire exactly like a
+    crash and have to be re-checked against `shutdown_event`. The trainer is
+    different: teardown only *joins* that thread, so `trainer_failed` is never a
+    consequence of shutting down. Applying the re-check to it as well downgraded
+    a trainer that died on the final step to a clean exit 0.
+    """
+    trainer_failed = threading.Event()
+    trainer_failed.set()
+    abort = AbortReason()
+
+    # is_set() is read by the `while`, then the post-wait guard. Teardown lands
+    # right after, which used to discard the crash the watchdog had just seen.
+    shutdown = mock.MagicMock()
+    shutdown.is_set.side_effect = [False, False, True, True, True]
+
+    with (
+        mock.patch.object(split.multiprocessing.connection, "wait", return_value=[]),
+        mock.patch.object(split.os, "kill") as killed,
+    ):
+        split._watch_components([], trainer_failed, shutdown, abort)
+
+    assert abort.reason, "a trainer crash must survive a concurrent teardown"
+    assert killed.called
+
+
+def test_a_colocate_interrupt_marks_the_shutdown_planned():
+    """A terminal Ctrl-C also reaches vLLM's EngineCore children, which colocate
+    does not `setsid`. They die, the vLLM thread sets `error_event`, and the
+    watchdog would report a user stop as a component crash. The SIGINT handler
+    sets `shutdown_event` first so the watchdog returns quietly."""
+    error_event = threading.Event()
+    shutdown = threading.Event()
+    abort = AbortReason()
+
+    # What the handler does, then what the watchdog sees afterwards.
+    shutdown.set()
+    error_event.set()
+
+    with mock.patch.object(colocate.os, "kill") as killed:
+        colocate._watch_components(error_event, shutdown, abort)
+
+    assert abort.reason is None, "an interrupt is not a crash"
+    assert not killed.called
+
+
 def test_the_colocate_watchdog_records_why_it_aborted():
     error_event = threading.Event()
     error_event.set()


### PR DESCRIPTION
A GRPO component that dies is currently swallowed, in two different ways.

The trainer's crash handler called `logger.exception`, which `LoggerWrapper`
does not define, so the handler raised inside itself and never set the event
that is its only channel to the watchdog. The run then hung in `running`
forever, holding its GPUs.

And when the watchdog *does* abort, it does so by signalling its own process.
The main thread received that as a `KeyboardInterrupt` indistinguishable from a
user pressing Ctrl-C, logged "Interrupted by user", and returned normally — so
the process exited 0 and a crashed run was finalized as completed with a null
error.

## What changed

- The failure event is set **before** anything fallible. Ordering is the durable
  fix: a future logging mistake cannot cost the signal again.
- `AbortReason` records *why* the watchdog aborted, before it signals. The main
  thread reads it to tell a real crash from Ctrl-C, and raises only for the
  former. A genuine interrupt still exits 0.
- The raise happens **after** the teardown block, not instead of it. That block
  reaps the vLLM process trees; exiting early would strand them on their GPUs.
- `LoggerWrapper` gains `exception()`, the one member of the stdlib logger API
  it was missing — a trap for every module that reaches for it inside an
  `except` block, not just this one.
- `ColoredFormatter` now appends the traceback. It overrode the base method
  wholesale and dropped it, so `exc_info=True` was decorative codebase-wide:
  every crash logged one line with no stack behind it.

## The co-locate runner needed more than the same patch

It has the same swallow, but not the same protections. Split detaches its vLLM
children with `setsid`, masks signals during teardown, and routes `SIGTERM` into
that teardown. Co-locate does none of these, and the first two are what the
exit-status guarantee rests on:

- **Teardown is now masked.** The watchdog can pass its own shutdown check and
  still be inside `logger.error` when the main thread enters the `finally`. Its
  `os.kill` then lands during the joins, raises out of the `finally`, and skips
  the event-loop stop, the joins and the raise after them — so "raise after
  teardown" did not hold there.
- **A `SIGINT` handler marks a user stop as planned.** A terminal interrupt also
  reaches vLLM's EngineCore children, which co-locate does not detach; they die
  and the vLLM thread flags an error. Reporting a deliberate stop as a crash is
  this change's own error, inverted. See the caveat below — this narrows the
  window, it does not close it.

Split also now masks *before* it logs: two statements sat above `SIG_IGN` at the
top of its `finally`, and an interrupt there stranded the vLLM trees.

One correction to an earlier commit here: the teardown re-check applied to every
crash reason, but only a vLLM sentinel can fire as a side effect of teardown.
Teardown merely *joins* the trainer thread, so a trainer crash is never a
shutdown artefact — re-checking it downgraded a trainer that died on the final
step to a clean exit 0. It now guards the sentinel alone.

## Verification, by strength of evidence

**On real GPUs** (published image, patched vs stock, an 8x5090 box and 2xH100):

| Check | Stock | Patched |
|---|---|---|
| Trainer crash reaches the watchdog | event never set | event set, crash logged |
| Dead rollout vLLM, split mode | **exit 0**, "Interrupted by user" | **exit 1**, names the dead component |
| Teardown runs before the raise | n/a | "shutting down" logged first |
| Traceback and call site in logs | one line, no stack | full stack, at the real caller |
| A healthy run still exits 0 | — | **exit 0**, both steps ran, no abort |

The last row matters as much as the rest: this makes failures loud, so it has to
be shown not to make successes noisy.

**By driving the real `grpo_colocate`** with only its GPU-dependent edges
substituted — both threads, the watchdog, its signal, the interrupt handler, the
teardown block and the raise all stay real:

- a component dies mid-run: the loop is stopped and threads joined *before* the
  abort raises, and the run does not report completed;
- nothing dies: no raise;
- a signal lands inside teardown: teardown completes and the abort still raises.

Each fails against the code it protects.

**As mechanism only:** the interrupt handler sets `shutdown_event` before the
interrupt propagates.

## Not verified

- **The co-locate interrupt race itself.** Whether the watchdog has already
  passed its `shutdown_event` check when the children die is genuine thread
  timing. The handler narrows that window; it does not close it. A test that
  staged the race passed with the handler removed, so it was measuring nothing
  and was replaced by the mechanism test above.
- **Co-locate on real hardware.** It needs quantized base weights shared from
  vLLM, which the test models do not have. The substituted tests prove the
  control flow, not that the real vLLM and trainer integrate as the fakes do.
- **Split's genuine-Ctrl-C path.** Reasoned safe — its vLLM children are
  `setsid`-detached, so a terminal SIGINT never reaches them — but not tested.

## Tests

17 in this file, 52 across the GRPO suite. Each production file was reverted in
turn, and each new test checked against the behaviour it replaces.
