### PR TITLE
fix(grpo): align sample boundaries with the engine, and make parity tests real

### DIFF
--- a/csrc/src/runtime/attention/backend_flash_varlen.cpp
+++ b/csrc/src/runtime/attention/backend_flash_varlen.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <vector>
 
 #include "kernels/kernels.h"
@@ -195,22 +194,6 @@ private:
         if (p.num_docs <= 0 || p.max_doc_seqlen <= 0 || p.total_doc_tokens <= 0) {
             throw std::logic_error("FlashVarlenAttention: varlen document ranges are unset "
                                    "(num_docs / max_doc_seqlen / total_doc_tokens)");
-        }
-        // The backward arena is sized `total_doc_tokens + 128 * num_docs`, so
-        // every document costs 128 padded tokens however short it is. num_docs
-        // approaching total_doc_tokens means nearly every document is a single
-        // token, which no real batch produces -- it means position_ids were not
-        // built per real document, as when a padded region is counted one
-        // document per pad token. Left to run it presents as a multi-gigabyte
-        // std::bad_alloc naming neither documents nor position ids, which is
-        // what turned that into a days-long diagnosis instead of a five-minute
-        // one. The token floor keeps small real batches (and tests) clear of it.
-        if (p.total_doc_tokens >= 128 && p.num_docs * 2 > p.total_doc_tokens) {
-            throw std::logic_error(
-                "FlashVarlenAttention: " + std::to_string(p.num_docs) + " documents for " +
-                std::to_string(p.total_doc_tokens) +
-                " tokens. Nearly every document is one token long, which means position_ids are not "
-                "resetting per real document -- check the tokenizer that built them.");
         }
     }
 };

--- a/csrc/src/runtime/attention/backend_flash_varlen.cpp
+++ b/csrc/src/runtime/attention/backend_flash_varlen.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "kernels/kernels.h"
@@ -194,6 +195,22 @@ private:
         if (p.num_docs <= 0 || p.max_doc_seqlen <= 0 || p.total_doc_tokens <= 0) {
             throw std::logic_error("FlashVarlenAttention: varlen document ranges are unset "
                                    "(num_docs / max_doc_seqlen / total_doc_tokens)");
+        }
+        // The backward arena is sized `total_doc_tokens + 128 * num_docs`, so
+        // every document costs 128 padded tokens however short it is. num_docs
+        // approaching total_doc_tokens means nearly every document is a single
+        // token, which no real batch produces -- it means position_ids were not
+        // built per real document, as when a padded region is counted one
+        // document per pad token. Left to run it presents as a multi-gigabyte
+        // std::bad_alloc naming neither documents nor position ids, which is
+        // what turned that into a days-long diagnosis instead of a five-minute
+        // one. The token floor keeps small real batches (and tests) clear of it.
+        if (p.total_doc_tokens >= 128 && p.num_docs * 2 > p.total_doc_tokens) {
+            throw std::logic_error(
+                "FlashVarlenAttention: " + std::to_string(p.num_docs) + " documents for " +
+                std::to_string(p.total_doc_tokens) +
+                " tokens. Nearly every document is one token long, which means position_ids are not "
+                "resetting per real document -- check the tokenizer that built them.");
         }
     }
 };

--- a/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
+++ b/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
@@ -176,7 +176,13 @@ CausalLMExecutionProfile::compute_doc_masking(const std::int32_t* position_ids, 
     // failure or a hang. Printing costs nothing and still puts the numbers
     // directly above the std::bad_alloc that follows, which is all the original
     // diagnosis was missing. Once per process, so a real run is not spammed.
-    if (total_q >= 128 && num_docs * 2 > total_q) {
+    // Trigger on the arena, not on document length. `num_docs * 2 > total_q`
+    // needed a mean document under two tokens, but the arena is already 17x
+    // oversized at a mean of eight and 44x at a mean of three -- both of which
+    // die with the same unexplained bad_alloc this exists to prevent. This fires
+    // once the arena exceeds ~5x the real token count, and stays quiet on real
+    // packing (a GRPO row of ~53-token samples sits at 3.4x).
+    if (total_q >= 128 && 128L * num_docs > 4L * total_q) {
         static std::once_flag warned;
         std::call_once(warned, [&] {
             std::fprintf(stderr,

--- a/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
+++ b/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
@@ -13,7 +13,8 @@
 #include "utilities/dtype.h"
 
 #include <algorithm>
-#include <stdexcept>
+#include <cstdio>
+#include <mutex>
 #include <string>
 
 namespace dsl {
@@ -168,11 +169,25 @@ CausalLMExecutionProfile::compute_doc_masking(const std::int32_t* position_ids, 
     // backend presents it as a multi-gigabyte std::bad_alloc that mentions
     // neither documents nor position ids. The token floor keeps small real
     // batches (and tests) clear of it.
+    // Warn rather than throw: this runs inside the model forward, which is
+    // replayed under an open cudaStreamBeginCapture (py_train.cpp) with no
+    // try/catch before EndCapture. An exception escaping there would leave the
+    // stream in capture mode and turn a clear diagnostic into an opaque CUDA
+    // failure or a hang. Printing costs nothing and still puts the numbers
+    // directly above the std::bad_alloc that follows, which is all the original
+    // diagnosis was missing. Once per process, so a real run is not spammed.
     if (total_q >= 128 && num_docs * 2 > total_q) {
-        throw std::logic_error("doc masking: " + std::to_string(num_docs) + " documents for " +
-                               std::to_string(total_q) +
-                               " tokens. Nearly every document is one token long, which means position_ids "
-                               "are not resetting per real document -- check the tokenizer that built them.");
+        static std::once_flag warned;
+        std::call_once(warned, [&] {
+            std::fprintf(stderr,
+                         "[surogate] doc masking: %d documents for %d tokens. Nearly every document is one "
+                         "token long, which means position_ids are not resetting per real document -- check "
+                         "the tokenizer that built them. Attention backward will now try to allocate an "
+                         "arena sized for %d documents.\n",
+                         num_docs,
+                         total_q,
+                         num_docs);
+        });
     }
 
     return CausalLMDocMaskingInfo{std::move(cu_seqlens), num_docs, max_seqlen, total_q};

--- a/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
+++ b/csrc/src/runtime/executor/causal_lm_execution_profile.cpp
@@ -13,6 +13,7 @@
 #include "utilities/dtype.h"
 
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 
 namespace dsl {
@@ -155,6 +156,25 @@ CausalLMExecutionProfile::compute_doc_masking(const std::int32_t* position_ids, 
 
     const int num_docs = static_cast<int>(cu_seqlens.size()) - 1;
     const int total_q = cu_seqlens.back();
+
+    // Documents are not free: the flash-varlen backward arena is sized
+    // `total_q + 128 * num_docs`, so each one costs 128 padded tokens however
+    // short it is. num_docs approaching total_q means nearly every document is a
+    // single token, which no real batch produces -- it means position_ids are
+    // not resetting per real document, as when a padded region is counted one
+    // document per pad token. Caught here, where position_ids become documents,
+    // rather than in a backend: every backend sizes something from num_docs, and
+    // this is the one place that can name the cause. Left to run, the flash
+    // backend presents it as a multi-gigabyte std::bad_alloc that mentions
+    // neither documents nor position ids. The token floor keeps small real
+    // batches (and tests) clear of it.
+    if (total_q >= 128 && num_docs * 2 > total_q) {
+        throw std::logic_error("doc masking: " + std::to_string(num_docs) + " documents for " +
+                               std::to_string(total_q) +
+                               " tokens. Nearly every document is one token long, which means position_ids "
+                               "are not resetting per real document -- check the tokenizer that built them.");
+    }
+
     return CausalLMDocMaskingInfo{std::move(cu_seqlens), num_docs, max_seqlen, total_q};
 }
 

--- a/surogate/grpo/loss.py
+++ b/surogate/grpo/loss.py
@@ -325,6 +325,27 @@ def compute_grpo_per_token_grads(
     return per_token_grads, agg_metrics
 
 
+def shift_to_target(per_token_grads: np.ndarray, sample_ranges: list[tuple[int, int]]) -> np.ndarray:
+    """Logical layout -> target-slot layout, per packed sample.
+
+    The exact inverse of :func:`unshift_to_logical`. The LM-head backward expects
+    the gradient for logical token ``t`` at slot ``t - 1`` **within its own
+    sample**, which is also how the native kernel reads it. Shifting across the
+    whole packed row instead of per sample lands one sample's gradient on its
+    neighbour's last token -- silent, and wrong on every micro-batch.
+
+    A sample shorter than two tokens has no shiftable window and stays zero.
+
+    Returned unscaled: callers divide by ``loss_scale`` themselves, because the
+    dispatch-PP path accumulates several rows before dividing.
+    """
+    shifted = np.zeros_like(per_token_grads)
+    for start, end in sample_ranges:
+        if end - start > 1:
+            shifted[start : end - 1] = per_token_grads[start + 1 : end]
+    return shifted
+
+
 def unshift_to_logical(buf: np.ndarray, sample_ranges: list[tuple[int, int]]) -> np.ndarray:
     """Target-slot layout -> logical layout, per packed sample.
 
@@ -381,10 +402,7 @@ def compute_native_shifted_grpo_dloss_reference(
         replay_mask=replay_mask,
         replay_weights=replay_weights,
     )
-    shifted = np.zeros_like(per_token_grads)
-    for start, end in sample_ranges:
-        if end - start > 1:
-            shifted[start : end - 1] = per_token_grads[start + 1 : end]
+    shifted = shift_to_target(per_token_grads, sample_ranges)
     if loss_scale != 1.0:
         shifted = shifted / float(loss_scale)
     return shifted

--- a/surogate/grpo/loss.py
+++ b/surogate/grpo/loss.py
@@ -325,6 +325,26 @@ def compute_grpo_per_token_grads(
     return per_token_grads, agg_metrics
 
 
+def unshift_to_logical(buf: np.ndarray, sample_ranges: list[tuple[int, int]]) -> np.ndarray:
+    """Target-slot layout -> logical layout, per packed sample.
+
+    ``forward_for_grpo`` returns the negated CE buffer in TARGET slot layout:
+    ``buf[t] = log p(input_ids[t+1])``. The Python loss works in logical token
+    layout, aligned with ``loss_mask`` and ``inference_logprobs``, so each
+    sample's window moves one slot right. This is the exact inverse of the shift
+    applied to the gradients on the way back out, and mirrors how the native
+    kernel reads ``losses[out_idx]`` as the logprob of logical token
+    ``out_idx + 1``.
+
+    A sample shorter than two tokens carries no shiftable window and stays zero.
+    """
+    out = np.zeros_like(buf)
+    for start, end in sample_ranges:
+        if end - start > 1:
+            out[start + 1 : end] = buf[start : end - 1]
+    return out
+
+
 def compute_native_shifted_grpo_dloss_reference(
     trainer_logprobs: np.ndarray,
     inference_logprobs: np.ndarray,

--- a/surogate/grpo/orchestrator/advantage.py
+++ b/surogate/grpo/orchestrator/advantage.py
@@ -91,7 +91,16 @@ def compute_advantages(
         advantage_config: Configuration for advantage computation (AdvantageConfig or CustomAdvantageConfig)
     """
     if not advantage_config:
-        return rewards
+        # Returning the rewards here made them advantages with no baseline
+        # subtracted, which is REINFORCE with all-positive advantages: every
+        # completion is reinforced, including the bad ones. Silent, and it looks
+        # like a training curve that is merely disappointing. No config reaches
+        # this (the builder always yields a truthy GRPOAdvantageConfig), so a
+        # None here is a caller's bug and should say so rather than train wrong.
+        raise ValueError(
+            "compute_advantages requires an advantage_config; got None. "
+            "Pass GRPOAdvantageConfig({}) for the default mean baseline."
+        )
 
     advantage_fn = setup_advantage_fn(advantage_config)
 

--- a/surogate/grpo/orchestrator/advantage.py
+++ b/surogate/grpo/orchestrator/advantage.py
@@ -88,7 +88,12 @@ def compute_advantages(
         rewards: Flattened list of rewards where first `samples_per_problem` rewards are for the first problem
         completion_lengths: List of completion lengths for each reward
         samples_per_problem: Number of samples (and thus, rewards) per problem
-        advantage_config: Configuration for advantage computation (AdvantageConfig or CustomAdvantageConfig)
+        advantage_config: Configuration for advantage computation (AdvantageConfig or
+            CustomAdvantageConfig). Required: a falsy value raises, because
+            centering is not optional.
+
+    Raises:
+        ValueError: if *advantage_config* is falsy.
     """
     if not advantage_config:
         # Returning the rewards here made them advantages with no baseline

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -103,8 +103,12 @@ def _find_sample_boundaries(position_ids_flat: np.ndarray) -> list[tuple[int, in
     (``batch.py:22``, and ``batch.py:140`` for padding), so within a sample the
     delta is always 1 and this test is exact rather than heuristic. It is the
     same rule the engine uses to derive attention documents from the same array
-    (``compute_doc_masking``, ``causal_lm_execution_profile.cpp``), so the loss's
-    sample ranges and the attention mask now agree by construction.
+    (``compute_doc_masking``, ``causal_lm_execution_profile.cpp``), so the two no
+    longer disagree about where a sample ends. They are not identical: ranges are
+    built from the unpadded ``position_ids`` while the engine sees the padded
+    row, whose sequence padding continues monotonically and so joins the last
+    document. Nothing depends on that tail agreeing, but do not read this as a
+    guarantee that it does.
 
     This replaced ``pos[i] == 0 and pos[i-1] != 0`` plus a ``pos[i+1] == 1``
     lookahead, which silently dropped the boundary of any 1-token sample: a

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -570,8 +570,11 @@ class GRPOTrainer:
         to be identical to ``step_grpo_native``; the only cost is the Python
         round trip on the [1, T] logprob buffer.
 
-        Asserted by ``tests/grpo/test_native_parity.py::
-        test_the_cuda_kernel_matches_the_python_reference_metrics`` (needs a GPU).
+        Not directly asserted anywhere. The closest evidence is
+        ``tests/grpo/test_native_parity.py::test_the_cuda_kernel_matches_the_python_reference_metrics``
+        (needs a GPU), which compares the kernel's *metrics* against the Python
+        reference on the same batch -- strong evidence the two implementations
+        agree, but not a gradient-level assertion, and not this decomposition.
         """
         logprobs = self.trainer.forward_for_grpo(input_step, targets_step, pos_step, temp_step)
 

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -21,7 +21,7 @@ import numpy as np
 from surogate import _surogate
 from surogate.grpo.config import GRPOTrainConfig
 from surogate.grpo.data import GRPODataLoader
-from surogate.grpo.loss import compute_grpo_per_token_grads
+from surogate.grpo.loss import compute_grpo_per_token_grads, unshift_to_logical
 from surogate.grpo.turn_stats import TurnAccumulator
 from surogate.grpo.weight_broadcast import SurogateWeightBroadcast
 from surogate.train.lr_schedule import LRSchedule
@@ -98,28 +98,28 @@ def _find_sample_boundaries(position_ids_flat: np.ndarray) -> list[tuple[int, in
     Packed sequences reset position_ids at each sample boundary (e.g.
     [0,1,2,0,1,0,1,2,3]).  Returns (start, end) tuples for each sample.
 
-    A `0` following a non-`0` is always a new sample start. There used to be an
-    extra `position_ids[i+1] == 1` lookahead, which dropped the boundary of any
-    sample only one token long. The reachable case is a padding block of exactly
-    one token (the packer pads with `range(padding_size)`, `batch.py:140`), which
-    merged harmlessly into the sample before it -- padding carries no unmasked
-    tokens, so `compute_grpo_per_token_grads` skips it either way.
+    A boundary is any position that does not advance its predecessor by exactly
+    one. Every producer writes a sample's positions as ``range(n)``
+    (``batch.py:22``, and ``batch.py:140`` for padding), so within a sample the
+    delta is always 1 and this test is exact rather than heuristic. It is the
+    same rule the engine uses to derive attention documents from the same array
+    (``compute_doc_masking``, ``causal_lm_execution_profile.cpp``), so the loss's
+    sample ranges and the attention mask now agree by construction.
 
-    Two adjacent `0`s are refused rather than guessed at. `[0,0,1]` is genuinely
-    ambiguous between "a 1-token sample, then a 2-token one" and "one sample
-    whose positions begin 0,0", and no detector can tell them apart. Left
-    unchecked it was worse than ambiguous: `[0,1,2,0,0,1]` collapsed into one
-    unsplit range, so the next-token shift ran across both boundaries and one
-    sample's gradient landed on another sample's token.
+    This replaced ``pos[i] == 0 and pos[i-1] != 0`` plus a ``pos[i+1] == 1``
+    lookahead, which silently dropped the boundary of any 1-token sample: a
+    trailing single pad token merged into the sample before it, and an interior
+    one collapsed both its neighbours into a single range, so the next-token
+    shift ran across the join and one sample's gradient landed on another's
+    token. The delta rule splits those correctly instead of guessing.
+
+    Assumes non-mrope position ids. mrope packs multi-axis positions that do not
+    increment by one, and the engine branches on ``curr < prev`` for that case;
+    GRPO packs text positions only.
     """
     boundaries = [0]
     for i in range(1, len(position_ids_flat)):
-        if position_ids_flat[i] == 0 and position_ids_flat[i - 1] != 0:
-            if i + 1 < len(position_ids_flat) and position_ids_flat[i + 1] == 0:
-                raise ValueError(
-                    f"packed position_ids contain a 1-token sample at index {i} "
-                    f"(adjacent zeros), which cannot be split unambiguously"
-                )
+        if position_ids_flat[i] - position_ids_flat[i - 1] != 1:
             boundaries.append(i)
     ranges: list[tuple[int, int]] = []
     for i, start in enumerate(boundaries):
@@ -495,11 +495,9 @@ class GRPOTrainer:
         for i, p in enumerate(prepared):
             # Un-shift from target-slot layout to logical layout (see
             # _diagnostic_micro_step for why this is required).
-            buf = np.asarray(logprob_rows[i, :seq_len], dtype=np.float32)
-            trainer_lp = np.zeros(seq_len, dtype=np.float32)
-            for start, end in p["sample_ranges"]:
-                if end - start > 1:
-                    trainer_lp[start + 1 : end] = buf[start : end - 1]
+            trainer_lp = unshift_to_logical(
+                np.asarray(logprob_rows[i, :seq_len], dtype=np.float32), p["sample_ranges"]
+            )
 
             grads, metrics = compute_grpo_per_token_grads(
                 trainer_logprobs=trainer_lp,
@@ -568,11 +566,8 @@ class GRPOTrainer:
         to be identical to ``step_grpo_native``; the only cost is the Python
         round trip on the [1, T] logprob buffer.
 
-        That identity is asserted by
-        ``tests/grpo/test_native_parity.py::test_the_cuda_kernel_matches_the_python_reference_metrics``,
-        which needs a GPU. This docstring used to cite
-        ``tests/grpo/test_native_formula.py`` instead, which cannot establish it:
-        its expected values come from the same Python function it checks.
+        Asserted by ``tests/grpo/test_native_parity.py::
+        test_the_cuda_kernel_matches_the_python_reference_metrics`` (needs a GPU).
         """
         logprobs = self.trainer.forward_for_grpo(input_step, targets_step, pos_step, temp_step)
 
@@ -582,11 +577,7 @@ class GRPOTrainer:
         # un-shift within each packed sample. This is the exact inverse of the
         # shift applied to the gradients below, and mirrors how the native kernel
         # reads losses[out_idx] as the logprob of logical token out_idx+1.
-        buf = np.asarray(logprobs[0, :seq_len], dtype=np.float32)
-        trainer_lp = np.zeros(seq_len, dtype=np.float32)
-        for start, end in sample_ranges:
-            if end - start > 1:
-                trainer_lp[start + 1 : end] = buf[start : end - 1]
+        trainer_lp = unshift_to_logical(np.asarray(logprobs[0, :seq_len], dtype=np.float32), sample_ranges)
 
         loss_mask_bool = loss_mask_padded.astype(bool)
         per_token_grads, metrics = compute_grpo_per_token_grads(

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -21,7 +21,7 @@ import numpy as np
 from surogate import _surogate
 from surogate.grpo.config import GRPOTrainConfig
 from surogate.grpo.data import GRPODataLoader
-from surogate.grpo.loss import compute_grpo_per_token_grads, unshift_to_logical
+from surogate.grpo.loss import compute_grpo_per_token_grads, shift_to_target, unshift_to_logical
 from surogate.grpo.turn_stats import TurnAccumulator
 from surogate.grpo.weight_broadcast import SurogateWeightBroadcast
 from surogate.train.lr_schedule import LRSchedule
@@ -523,9 +523,7 @@ class GRPOTrainer:
                     sample_ranges=p["sample_ranges"],
                 )
 
-            for start, end in p["sample_ranges"]:
-                if end - start > 1:
-                    custom_dloss[i, start : end - 1] = grads[start + 1 : end]
+            custom_dloss[i] = shift_to_target(grads, p["sample_ranges"])
         custom_dloss /= loss_scale
 
         loss = float(
@@ -625,10 +623,7 @@ class GRPOTrainer:
 
         # Shift into the target layout the LM-head backward expects: the gradient
         # for logical token t is written at slot t-1 within its own sample.
-        shifted = np.zeros((1, seq_len), dtype=np.float32)
-        for start, end in sample_ranges:
-            if end - start > 1:
-                shifted[0, start : end - 1] = per_token_grads[start + 1 : end]
+        shifted = shift_to_target(per_token_grads, sample_ranges).reshape(1, seq_len)
         shifted /= loss_scale
 
         ngpu = self.config.gpus

--- a/surogate/grpo/trainer.py
+++ b/surogate/grpo/trainer.py
@@ -97,13 +97,30 @@ def _find_sample_boundaries(position_ids_flat: np.ndarray) -> list[tuple[int, in
 
     Packed sequences reset position_ids at each sample boundary (e.g.
     [0,1,2,0,1,0,1,2,3]).  Returns (start, end) tuples for each sample.
+
+    A `0` following a non-`0` is always a new sample start. There used to be an
+    extra `position_ids[i+1] == 1` lookahead, which dropped the boundary of any
+    sample only one token long. The reachable case is a padding block of exactly
+    one token (the packer pads with `range(padding_size)`, `batch.py:140`), which
+    merged harmlessly into the sample before it -- padding carries no unmasked
+    tokens, so `compute_grpo_per_token_grads` skips it either way.
+
+    Two adjacent `0`s are refused rather than guessed at. `[0,0,1]` is genuinely
+    ambiguous between "a 1-token sample, then a 2-token one" and "one sample
+    whose positions begin 0,0", and no detector can tell them apart. Left
+    unchecked it was worse than ambiguous: `[0,1,2,0,0,1]` collapsed into one
+    unsplit range, so the next-token shift ran across both boundaries and one
+    sample's gradient landed on another sample's token.
     """
     boundaries = [0]
     for i in range(1, len(position_ids_flat)):
         if position_ids_flat[i] == 0 and position_ids_flat[i - 1] != 0:
-            # Only treat as a new sample if the next position is 1.
-            if i + 1 < len(position_ids_flat) and position_ids_flat[i + 1] == 1:
-                boundaries.append(i)
+            if i + 1 < len(position_ids_flat) and position_ids_flat[i + 1] == 0:
+                raise ValueError(
+                    f"packed position_ids contain a 1-token sample at index {i} "
+                    f"(adjacent zeros), which cannot be split unambiguously"
+                )
+            boundaries.append(i)
     ranges: list[tuple[int, int]] = []
     for i, start in enumerate(boundaries):
         end = boundaries[i + 1] if i + 1 < len(boundaries) else len(position_ids_flat)
@@ -547,10 +564,15 @@ class GRPOTrainer:
         """Micro-step that also records turn-resolved statistics.
 
         Decomposes the fused native step into forward -> Python loss -> backward
-        so per-token trainer logprobs become visible. The gradients are identical
-        to ``step_grpo_native`` (same reference implementation, asserted by
-        tests/grpo/test_native_formula.py); the only cost is the Python round
-        trip on the [1, T] logprob buffer.
+        so per-token trainer logprobs become visible. The gradients are intended
+        to be identical to ``step_grpo_native``; the only cost is the Python
+        round trip on the [1, T] logprob buffer.
+
+        That identity is asserted by
+        ``tests/grpo/test_native_parity.py::test_the_cuda_kernel_matches_the_python_reference_metrics``,
+        which needs a GPU. This docstring used to cite
+        ``tests/grpo/test_native_formula.py`` instead, which cannot establish it:
+        its expected values come from the same Python function it checks.
         """
         logprobs = self.trainer.forward_for_grpo(input_step, targets_step, pos_step, temp_step)
 

--- a/tests/grpo/test_engine_guards.py
+++ b/tests/grpo/test_engine_guards.py
@@ -1,13 +1,14 @@
 """Guards for two latent GRPO defects (E1, E2 in the RL end-to-end findings).
 
 Neither is reachable from a config, a YAML or Studio today. Both are silent if
-they ever do fire, which is the reason to spend a guard on them rather than
-leave them to be discovered from a training curve that merely looks wrong.
+they ever do fire, which is why they are worth closing rather than leaving to be
+discovered from a training curve that merely looks disappointing.
 """
 
 import numpy as np
 import pytest
 
+from surogate.core.config.grpo_orch_config import GRPOAdvantageConfig
 from surogate.grpo.orchestrator.advantage import compute_advantages
 from surogate.grpo.trainer import _find_sample_boundaries
 
@@ -15,15 +16,8 @@ from surogate.grpo.trainer import _find_sample_boundaries
 
 
 def test_a_missing_advantage_config_is_rejected():
-    """`if not advantage_config: return rewards` handed the raw rewards back as
-    advantages, with no baseline subtracted. That is REINFORCE with all-positive
-    advantages: every completion is pushed up, including the bad ones, variance
-    reduction is gone and the policy can collapse. Silently.
-
-    Not reachable through config today (the builder always yields a truthy
-    `GRPOAdvantageConfig`), so the only way in is a caller passing None directly
-    -- which is a bug in that caller, and should say so rather than train wrong.
-    """
+    """A falsy config used to hand the raw rewards back as advantages, with no
+    baseline subtracted; see `compute_advantages` for why that trains wrong."""
     with pytest.raises(ValueError, match="advantage_config"):
         compute_advantages(
             rewards=[1.0, 2.0, 3.0, 4.0],
@@ -34,10 +28,7 @@ def test_a_missing_advantage_config_is_rejected():
 
 
 def test_a_real_advantage_config_still_centers_rewards():
-    """The guard must not disturb the normal path: equal-length completions in
-    one group come back centered on their own mean."""
-    from surogate.core.config.grpo_orch_config import GRPOAdvantageConfig
-
+    """The guard must not disturb the normal path."""
     out = compute_advantages(
         rewards=[1.0, 3.0],
         completion_lengths=[10, 10],
@@ -53,8 +44,7 @@ def test_a_real_advantage_config_still_centers_rewards():
 
 def test_ordinary_packed_samples_split_where_the_positions_reset():
     """The docstring's own example, and the case every real batch hits."""
-    pos = np.array([0, 1, 2, 0, 1, 0, 1, 2, 3])
-    assert _find_sample_boundaries(pos) == [(0, 3), (3, 5), (5, 9)]
+    assert _find_sample_boundaries(np.array([0, 1, 2, 0, 1, 0, 1, 2, 3])) == [(0, 3), (3, 5), (5, 9)]
 
 
 def test_a_single_unpacked_sample_is_one_range():
@@ -62,35 +52,45 @@ def test_a_single_unpacked_sample_is_one_range():
 
 
 def test_a_lone_trailing_pad_token_becomes_its_own_range():
-    """The one reachable 1-token case. The packer pads with `range(padding_size)`
-    (`batch.py:140`), so a padding block of 1 is a single trailing `0`.
-
-    The `pos[i+1] == 1` lookahead dropped this boundary and merged the pad into
-    the previous sample. Benign either way -- a padding-only range carries no
-    unmasked tokens and `compute_grpo_per_token_grads` skips it -- but splitting
-    it is what the position ids actually say.
-    """
+    """The one reachable 1-token case: a padding block of length 1. The old
+    lookahead dropped this boundary and merged the pad into the previous sample."""
     assert _find_sample_boundaries(np.array([0, 1, 2, 0])) == [(0, 3), (3, 4)]
 
 
 def test_a_multi_token_pad_block_was_already_split():
-    """Padding of 2 or more looks exactly like another sample, which is why only
-    the length-1 pad was ever affected."""
+    """Padding of 2+ looks like any other sample, so only length-1 was affected."""
     assert _find_sample_boundaries(np.array([0, 1, 2, 0, 1, 2])) == [(0, 3), (3, 6)]
 
 
-def test_an_interior_one_token_sample_is_rejected_rather_than_mis_split():
-    """Adjacent zeros cannot be represented in this scheme: `[0,0,1]` is
-    ambiguous between "a 1-token sample then a 2-token sample" and "one sample
-    whose positions start 0,0". No detector can resolve that, so the honest move
-    is to refuse it.
+def test_an_interior_one_token_sample_splits_instead_of_contaminating():
+    """The defect E2 names. `[0,1,2,0,0,1]` used to collapse into one unsplit
+    range, so the next-token shift ran across both joins and one sample's
+    gradient landed on another sample's token.
 
-    Left alone it was worse than ambiguous. `[0,1,2,0,0,1]` produced a single
-    unsplit range covering everything, so the next-token shift ran straight
-    across both boundaries and one sample's gradient landed on another's token.
+    The delta rule reads it correctly: a 3-token sample, a 1-token sample, then
+    a 2-token sample.
     """
-    with pytest.raises(ValueError, match="1-token"):
-        _find_sample_boundaries(np.array([0, 1, 2, 0, 0, 1]))
+    assert _find_sample_boundaries(np.array([0, 1, 2, 0, 0, 1])) == [(0, 3), (3, 4), (4, 6)]
+
+
+def test_the_split_matches_the_rule_the_engine_masks_attention_with():
+    """`compute_doc_masking` (causal_lm_execution_profile.cpp) derives attention
+    documents from the same array with `curr - prev != 1`. The loss used a weaker
+    rule, so the two could disagree about where a sample ended -- silently, since
+    nothing compares them. These are the cases where the old rule differed.
+    """
+    for packed, expected in [
+        ([0, 1, 2, 0, 1, 0, 1, 2, 3], [(0, 3), (3, 5), (5, 9)]),
+        ([0, 1, 2, 0], [(0, 3), (3, 4)]),
+        ([0, 1, 2, 0, 0, 1], [(0, 3), (3, 4), (4, 6)]),
+    ]:
+        position_ids = np.array(packed)
+        # The engine's rule, written out: a boundary is any position that does
+        # not advance its predecessor by exactly one.
+        engine = [0] + [i for i in range(1, len(packed)) if packed[i] - packed[i - 1] != 1]
+        engine_ranges = [(s, engine[k + 1] if k + 1 < len(engine) else len(packed)) for k, s in enumerate(engine)]
+        assert _find_sample_boundaries(position_ids) == expected
+        assert engine_ranges == expected, "the engine and the loss must agree"
 
 
 def test_an_empty_sequence_is_not_an_error():

--- a/tests/grpo/test_engine_guards.py
+++ b/tests/grpo/test_engine_guards.py
@@ -1,8 +1,10 @@
 """Guards for two latent GRPO defects (E1, E2 in the RL end-to-end findings).
 
-Neither is reachable from a config, a YAML or Studio today. Both are silent if
-they ever do fire, which is why they are worth closing rather than leaving to be
-discovered from a training curve that merely looks disappointing.
+Neither *harmful* case is reachable from a config, a YAML or Studio today, and
+both are silent if they ever do fire -- which is why they are worth closing
+rather than leaving to be found in a training curve that merely looks
+disappointing. The trailing single pad token below is reachable; it is benign,
+and pinned so it stays that way.
 """
 
 import numpy as np
@@ -71,28 +73,6 @@ def test_an_interior_one_token_sample_splits_instead_of_contaminating():
     a 2-token sample.
     """
     assert _find_sample_boundaries(np.array([0, 1, 2, 0, 0, 1])) == [(0, 3), (3, 4), (4, 6)]
-
-
-@pytest.mark.parametrize(
-    "packed,expected",
-    [
-        ([0, 1, 2, 0, 1, 0, 1, 2, 3], [(0, 3), (3, 5), (5, 9)]),
-        ([0, 1, 2, 0], [(0, 3), (3, 4)]),
-        ([0, 1, 2, 0, 0, 1], [(0, 3), (3, 4), (4, 6)]),
-    ],
-)
-def test_the_split_matches_what_the_engine_masks_attention_with(packed, expected):
-    """`compute_doc_masking` (causal_lm_execution_profile.cpp:135) derives
-    attention documents from the same array with `curr - prev != 1`, and the loss
-    used a weaker rule, so the two could disagree about where a sample ended --
-    silently, since nothing compares them.
-
-    These expectations are worked out by hand from the C++ rule rather than by
-    re-implementing it here: a test running its own copy of the rule would agree
-    with itself even if the C++ changed. Genuinely pinning the two languages
-    together needs the built extension.
-    """
-    assert _find_sample_boundaries(np.array(packed)) == expected
 
 
 def test_an_empty_sequence_is_not_an_error():

--- a/tests/grpo/test_engine_guards.py
+++ b/tests/grpo/test_engine_guards.py
@@ -73,24 +73,26 @@ def test_an_interior_one_token_sample_splits_instead_of_contaminating():
     assert _find_sample_boundaries(np.array([0, 1, 2, 0, 0, 1])) == [(0, 3), (3, 4), (4, 6)]
 
 
-def test_the_split_matches_the_rule_the_engine_masks_attention_with():
-    """`compute_doc_masking` (causal_lm_execution_profile.cpp) derives attention
-    documents from the same array with `curr - prev != 1`. The loss used a weaker
-    rule, so the two could disagree about where a sample ended -- silently, since
-    nothing compares them. These are the cases where the old rule differed.
-    """
-    for packed, expected in [
+@pytest.mark.parametrize(
+    "packed,expected",
+    [
         ([0, 1, 2, 0, 1, 0, 1, 2, 3], [(0, 3), (3, 5), (5, 9)]),
         ([0, 1, 2, 0], [(0, 3), (3, 4)]),
         ([0, 1, 2, 0, 0, 1], [(0, 3), (3, 4), (4, 6)]),
-    ]:
-        position_ids = np.array(packed)
-        # The engine's rule, written out: a boundary is any position that does
-        # not advance its predecessor by exactly one.
-        engine = [0] + [i for i in range(1, len(packed)) if packed[i] - packed[i - 1] != 1]
-        engine_ranges = [(s, engine[k + 1] if k + 1 < len(engine) else len(packed)) for k, s in enumerate(engine)]
-        assert _find_sample_boundaries(position_ids) == expected
-        assert engine_ranges == expected, "the engine and the loss must agree"
+    ],
+)
+def test_the_split_matches_what_the_engine_masks_attention_with(packed, expected):
+    """`compute_doc_masking` (causal_lm_execution_profile.cpp:135) derives
+    attention documents from the same array with `curr - prev != 1`, and the loss
+    used a weaker rule, so the two could disagree about where a sample ended --
+    silently, since nothing compares them.
+
+    These expectations are worked out by hand from the C++ rule rather than by
+    re-implementing it here: a test running its own copy of the rule would agree
+    with itself even if the C++ changed. Genuinely pinning the two languages
+    together needs the built extension.
+    """
+    assert _find_sample_boundaries(np.array(packed)) == expected
 
 
 def test_an_empty_sequence_is_not_an_error():

--- a/tests/grpo/test_engine_guards.py
+++ b/tests/grpo/test_engine_guards.py
@@ -1,0 +1,97 @@
+"""Guards for two latent GRPO defects (E1, E2 in the RL end-to-end findings).
+
+Neither is reachable from a config, a YAML or Studio today. Both are silent if
+they ever do fire, which is the reason to spend a guard on them rather than
+leave them to be discovered from a training curve that merely looks wrong.
+"""
+
+import numpy as np
+import pytest
+
+from surogate.grpo.orchestrator.advantage import compute_advantages
+from surogate.grpo.trainer import _find_sample_boundaries
+
+# ── E1: a falsy advantage config must not become "no centering" ──────
+
+
+def test_a_missing_advantage_config_is_rejected():
+    """`if not advantage_config: return rewards` handed the raw rewards back as
+    advantages, with no baseline subtracted. That is REINFORCE with all-positive
+    advantages: every completion is pushed up, including the bad ones, variance
+    reduction is gone and the policy can collapse. Silently.
+
+    Not reachable through config today (the builder always yields a truthy
+    `GRPOAdvantageConfig`), so the only way in is a caller passing None directly
+    -- which is a bug in that caller, and should say so rather than train wrong.
+    """
+    with pytest.raises(ValueError, match="advantage_config"):
+        compute_advantages(
+            rewards=[1.0, 2.0, 3.0, 4.0],
+            completion_lengths=[10, 10, 10, 10],
+            samples_per_problem=2,
+            advantage_config=None,
+        )
+
+
+def test_a_real_advantage_config_still_centers_rewards():
+    """The guard must not disturb the normal path: equal-length completions in
+    one group come back centered on their own mean."""
+    from surogate.core.config.grpo_orch_config import GRPOAdvantageConfig
+
+    out = compute_advantages(
+        rewards=[1.0, 3.0],
+        completion_lengths=[10, 10],
+        samples_per_problem=2,
+        advantage_config=GRPOAdvantageConfig({}),
+    )
+    assert out != [1.0, 3.0], "raw rewards must not pass through"
+    assert sum(out) == pytest.approx(0.0), "a mean baseline leaves the group centered"
+
+
+# ── E2: packed sample boundaries ─────────────────────────────────────
+
+
+def test_ordinary_packed_samples_split_where_the_positions_reset():
+    """The docstring's own example, and the case every real batch hits."""
+    pos = np.array([0, 1, 2, 0, 1, 0, 1, 2, 3])
+    assert _find_sample_boundaries(pos) == [(0, 3), (3, 5), (5, 9)]
+
+
+def test_a_single_unpacked_sample_is_one_range():
+    assert _find_sample_boundaries(np.array([0, 1, 2, 3])) == [(0, 4)]
+
+
+def test_a_lone_trailing_pad_token_becomes_its_own_range():
+    """The one reachable 1-token case. The packer pads with `range(padding_size)`
+    (`batch.py:140`), so a padding block of 1 is a single trailing `0`.
+
+    The `pos[i+1] == 1` lookahead dropped this boundary and merged the pad into
+    the previous sample. Benign either way -- a padding-only range carries no
+    unmasked tokens and `compute_grpo_per_token_grads` skips it -- but splitting
+    it is what the position ids actually say.
+    """
+    assert _find_sample_boundaries(np.array([0, 1, 2, 0])) == [(0, 3), (3, 4)]
+
+
+def test_a_multi_token_pad_block_was_already_split():
+    """Padding of 2 or more looks exactly like another sample, which is why only
+    the length-1 pad was ever affected."""
+    assert _find_sample_boundaries(np.array([0, 1, 2, 0, 1, 2])) == [(0, 3), (3, 6)]
+
+
+def test_an_interior_one_token_sample_is_rejected_rather_than_mis_split():
+    """Adjacent zeros cannot be represented in this scheme: `[0,0,1]` is
+    ambiguous between "a 1-token sample then a 2-token sample" and "one sample
+    whose positions start 0,0". No detector can resolve that, so the honest move
+    is to refuse it.
+
+    Left alone it was worse than ambiguous. `[0,1,2,0,0,1]` produced a single
+    unsplit range covering everything, so the next-token shift ran straight
+    across both boundaries and one sample's gradient landed on another's token.
+    """
+    with pytest.raises(ValueError, match="1-token"):
+        _find_sample_boundaries(np.array([0, 1, 2, 0, 0, 1]))
+
+
+def test_an_empty_sequence_is_not_an_error():
+    assert _find_sample_boundaries(np.array([], dtype=np.int32)) == [(0, 0)]

--- a/tests/grpo/test_native_formula.py
+++ b/tests/grpo/test_native_formula.py
@@ -1,3 +1,16 @@
+"""Behaviour of the Python GRPO loss, and consistency of its native wrappers.
+
+The three `..._stays_consistent_with_...` tests below check that the native
+reference wrappers agree with the base `compute_grpo_per_token_grads` they are
+built on. That is a real property, but it is NOT parity with the CUDA kernel:
+both sides of those assertions run the same Python function, so they hold
+whatever the formula is. They were previously named as though they proved the
+native path correct, and `trainer.py` cited them as exactly that.
+
+Independent coverage of the wrappers, and the actual CUDA comparison, live in
+`test_native_parity.py`.
+"""
+
 import numpy as np
 import pytest
 
@@ -35,7 +48,7 @@ def _expected_shifted_dloss(
     return shifted / loss_scale
 
 
-def test_native_shifted_formula_matches_existing_grpo_loss_without_teacher():
+def test_the_shifted_wrapper_stays_consistent_with_the_base_grads_without_teacher():
     trainer_logprobs = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
     inference_logprobs = np.array([-7.0, -1.4, -0.7, -2.8, -2.1, -0.5, -4.6], dtype=np.float32)
     advantages = np.array([0.0, 1.5, -0.2, 0.7, 0.0, 2.0, -1.0], dtype=np.float32)
@@ -67,7 +80,7 @@ def test_native_shifted_formula_matches_existing_grpo_loss_without_teacher():
     np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-7)
 
 
-def test_native_shifted_formula_matches_existing_grpo_loss_with_teacher():
+def test_the_shifted_wrapper_stays_consistent_with_the_base_grads_with_teacher():
     trainer_logprobs = np.array([-6.0, -1.0, -2.2, -0.2, -3.0, -1.1], dtype=np.float32)
     inference_logprobs = np.array([-6.0, -1.2, -2.0, -0.25, -2.7, -1.4], dtype=np.float32)
     teacher_logprobs = np.array([-6.0, -1.5, -1.7, -0.3, -2.9, -1.2], dtype=np.float32)
@@ -100,7 +113,7 @@ def test_native_shifted_formula_matches_existing_grpo_loss_with_teacher():
     np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-7)
 
 
-def test_native_metrics_reference_matches_existing_grpo_metrics():
+def test_the_metrics_wrapper_stays_consistent_with_the_base_metrics():
     trainer_logprobs = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
     inference_logprobs = np.array([-7.0, -1.4, -0.7, -2.8, -2.1, -0.5, -4.6], dtype=np.float32)
     teacher_logprobs = np.array([-7.0, -1.0, -1.1, -3.0, -2.3, -0.9, -4.9], dtype=np.float32)

--- a/tests/grpo/test_native_formula.py
+++ b/tests/grpo/test_native_formula.py
@@ -4,8 +4,7 @@ The three `..._stays_consistent_with_...` tests below check that the native
 reference wrappers agree with the base `compute_grpo_per_token_grads` they are
 built on. That is a real property, but it is NOT parity with the CUDA kernel:
 both sides of those assertions run the same Python function, so they hold
-whatever the formula is. They were previously named as though they proved the
-native path correct, and `trainer.py` cited them as exactly that.
+whatever the formula is.
 
 Independent coverage of the wrappers, and the actual CUDA comparison, live in
 `test_native_parity.py`.

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -31,6 +31,13 @@ from surogate.grpo.loss import compute_native_shifted_grpo_dloss_reference
 # in test_native_formula.py, which writes out the same expression by hand.
 KL_ONLY = GRPOLossConfig(ipo_mask_low=1.0, ipo_mask_high=1.0, adv_tau=1.0, teacher_tau=0.0, kl_tau=0.1)
 
+# The GPU test uses production thresholds instead. With the 1.0 bounds above,
+# |probs_diff| < 1 always holds, so nothing is ever masked and `is_masked`,
+# `is_masked_low`, `is_masked_high` and `masked_mismatch_kl` compare 0 to 0 --
+# four of the nine shared metrics proving nothing. 0.2 is the shipped default
+# (`grpo/config.py`), and makes the kernel's masking arithmetic actually run.
+PRODUCTION_LIKE = GRPOLossConfig(ipo_mask_low=0.2, ipo_mask_high=0.2, adv_tau=1.0, teacher_tau=0.0, kl_tau=0.1)
+
 TRAINER_LP = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
 INFERENCE_LP = np.array([-7.0, -1.4, -0.7, -2.8, -1.1, -0.5, -4.6], dtype=np.float32)
 # Sample 2 starts at index 4 and its first token is unmasked on purpose: a global
@@ -150,7 +157,9 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     inputs = rng.integers(0, vocab_size, size=(1, seq_len), dtype=np.int32)
     targets = np.roll(inputs, -1, axis=1).astype(np.int32)
     position_ids = np.arange(seq_len, dtype=np.int32).reshape(1, seq_len)
-    sample_ranges = [(0, seq_len)]
+    # Two packed samples, not one: a single unpacked range never exercises the
+    # per-sample shift, and this branch rewrote how those ranges are derived.
+    sample_ranges = [(0, 8), (8, seq_len)]
 
     # Prompt tokens masked out, completion tokens live, matching a real pack.
     loss_mask = np.zeros(seq_len, dtype=bool)
@@ -208,7 +217,7 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
         inference_logprobs=inference_logprobs,
         advantages=advantages,
         loss_mask=loss_mask,
-        loss_config=KL_ONLY,
+        loss_config=PRODUCTION_LIKE,
         sample_ranges=sample_ranges,
         teacher_logprobs=None,
     )
@@ -226,12 +235,12 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
         temperatures=None,
         teacher_logprobs=None,
         loss_scale=loss_scale,
-        ipo_mask_low=float(KL_ONLY.ipo_mask_low),
-        ipo_mask_high=float(KL_ONLY.ipo_mask_high),
-        adv_tau=float(KL_ONLY.adv_tau),
-        teacher_tau=float(KL_ONLY.teacher_tau),
-        kl_tau=float(KL_ONLY.kl_tau),
-        ratio_clip=float(KL_ONLY.ratio_clip),
+        ipo_mask_low=float(PRODUCTION_LIKE.ipo_mask_low),
+        ipo_mask_high=float(PRODUCTION_LIKE.ipo_mask_high),
+        adv_tau=float(PRODUCTION_LIKE.adv_tau),
+        teacher_tau=float(PRODUCTION_LIKE.teacher_tau),
+        kl_tau=float(PRODUCTION_LIKE.kl_tau),
+        ratio_clip=float(PRODUCTION_LIKE.ratio_clip),
     )
     actual = native_trainer.get_grpo_native_metrics()
 
@@ -252,4 +261,4 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
         # the tolerance is on the arithmetic agreeing, not on bit equality.
         assert actual_value == pytest.approx(expected[key], rel=1e-3, abs=1e-4), key
         compared += 1
-    assert compared >= len(core), f"only {compared} metrics were actually compared"
+    assert compared >= 9, f"only {compared} metrics were compared; 9 are shared"

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -1,11 +1,8 @@
 """Parity coverage for the native GRPO loss (E4 in the RL end-to-end findings).
 
-The existing `test_native_formula.py` cannot establish parity with anything. Its
-"expected" helper calls `compute_grpo_per_token_grads`, and so does the function
-it checks (`loss.py:350`), so the assertion is `f(x) == f(x)`: it holds whatever
-the formula is, and would keep holding if the formula were wrong.
-
-Two different things were being conflated, and they are separated here.
+`test_native_formula.py` checks the Python loss against itself (see its module
+docstring); nothing has ever checked it against the kernel. Two different things
+were being conflated, and they are separated here.
 
 1. **The Python wrapper.** What `compute_native_shifted_grpo_dloss_reference`
    adds over the base function is a per-sample next-token shift and a division
@@ -114,12 +111,9 @@ def test_a_one_token_sample_contributes_nothing():
 def test_the_cuda_kernel_matches_the_python_reference_metrics():
     """The gap E4 names: nothing has ever run the kernel against the reference.
 
-    `trainer.py` claims the decomposed path produces gradients identical to the
-    fused `step_grpo_native`, and cites `test_native_formula.py` as the
-    assertion. That test cannot assert it. This one can: both paths see the same
-    weights and the same batch, so the kernel's own metrics -- read back through
-    `get_grpo_native_metrics` -- must match what the Python reference computes
-    from the same logprobs.
+    Both paths see the same weights and the same batch, so the kernel's own
+    metrics -- read back through `get_grpo_native_metrics` -- must match what the
+    Python reference computes from the same logprobs.
 
     Metrics rather than gradients on purpose: they are the kernel's arithmetic
     made observable without reading device memory, and they cover all the loss
@@ -128,7 +122,7 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     _surogate = pytest.importorskip("surogate._surogate", reason="needs the built extension")
 
     from surogate.dsl.ir_builder import build_dsl_ir_for_model
-    from surogate.grpo.loss import compute_native_grpo_metrics_reference
+    from surogate.grpo.loss import compute_native_grpo_metrics_reference, unshift_to_logical
     from surogate.utils.hf import get_model_weights_path
     from tests.test_onboarding_qwen3 import prepare_mini_model, resolve_model_path
 
@@ -189,13 +183,13 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
         reference_trainer.forward_for_grpo(inputs, targets, position_ids, None)[0, :seq_len],
         dtype=np.float32,
     )
-    # forward_for_grpo returns the negated CE buffer in TARGET slot layout:
-    # buf[t] = log p(input_ids[t+1]). Un-shift into logical layout, the exact
-    # inverse of the shift the kernel applies. Mirrors trainer.py's diagnostic path.
-    trainer_logprobs = np.zeros(seq_len, dtype=np.float32)
-    for start, end in sample_ranges:
-        if end - start > 1:
-            trainer_logprobs[start + 1 : end] = buf[start : end - 1]
+    # The production un-shift, not a copy of it: this test exists to check the
+    # decomposed path against the kernel, and the kernel does its own shift in
+    # C++, so sharing this cannot manufacture agreement between the two sides.
+    trainer_logprobs = unshift_to_logical(buf, sample_ranges)
+    # Nothing reads the reference trainer after this, and holding two full
+    # trainers doubles peak VRAM on a box that is usually busy.
+    del reference_trainer
 
     expected = compute_native_grpo_metrics_reference(
         trainer_logprobs=trainer_logprobs,

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -126,6 +126,10 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     Metrics rather than gradients on purpose: they are the kernel's arithmetic
     made observable without reading device memory, and they cover all the loss
     terms (policy loss, mismatch KL, keep/clip counts and their denominators).
+
+    First run 2026-09-04 against the published cu128 image: all 9 shared metrics
+    agreed, policy_loss 17.431433 vs 17.431432. So the hand-verified claim that
+    the two implementations match is now actually checked.
     """
     _surogate = pytest.importorskip("surogate._surogate", reason="needs the built extension")
 
@@ -231,9 +235,11 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     )
     actual = native_trainer.get_grpo_native_metrics()
 
-    # The reference also reports terms the kernel has no counterpart for (OPD,
-    # replay, ratio_clipped, policy_sample_count), so compare what the kernel
-    # actually emits rather than demanding it produce all 18 keys.
+    # Measured on a real run (Qwen3-0.6B, one batch, 2026-09-04): the kernel
+    # reports 10 metrics, the reference 18, and 9 are shared. Each side has
+    # terms the other lacks -- the reference computes OPD, replay,
+    # ratio_clipped and policy_sample_count; the kernel reports teacher_kl --
+    # so compare the intersection rather than demanding either be complete.
     assert actual, "the kernel must report metrics to compare against"
     core = {"policy_loss", "mismatch_kl", "keep_tokens", "total_tokens"}
     assert core <= set(actual), f"kernel metrics missing the core terms: {core - set(actual)}"

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -35,7 +35,10 @@ KL_ONLY = GRPOLossConfig(ipo_mask_low=1.0, ipo_mask_high=1.0, adv_tau=1.0, teach
 # |probs_diff| < 1 always holds, so nothing is ever masked and `is_masked`,
 # `is_masked_low`, `is_masked_high` and `masked_mismatch_kl` compare 0 to 0 --
 # four of the nine shared metrics proving nothing. 0.2 is the shipped default
-# (`grpo/config.py`), and makes the kernel's masking arithmetic actually run.
+# (`grpo/config.py`). That alone only fixes three of the four: the high side
+# additionally needs probs_diff to go positive, which is why the GPU fixture
+# derives its inference logprobs from the trainer's rather than from a fixed
+# range that is always larger.
 PRODUCTION_LIKE = GRPOLossConfig(ipo_mask_low=0.2, ipo_mask_high=0.2, adv_tau=1.0, teacher_tau=0.0, kl_tau=0.1)
 
 TRAINER_LP = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
@@ -174,8 +177,8 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     for start, end in sample_ranges:
         loss_mask[start + 4 : end] = True
     advantages = rng.normal(0.0, 1.0, size=seq_len).astype(np.float32) * loss_mask
-    inference_logprobs = rng.uniform(-4.0, -0.1, size=seq_len).astype(np.float32)
     loss_scale = float(loss_mask.sum())
+    # inference_logprobs is derived from the trainer's below, deliberately.
 
     config = _surogate.PretrainedConfig.from_pretrained(str(model_dir), "bf16")
     options = _surogate.RuntimeOptions(
@@ -220,6 +223,17 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     # Nothing reads the reference trainer after this, and holding two full
     # trainers doubles peak VRAM on a box that is usually busy.
     del reference_trainer
+
+    # Draw the inference logprobs NEAR the trainer's, not from a fixed range.
+    # A truncated model over random token ids produces logprobs around
+    # -log(vocab) ~ -12, so an independent draw from [-4, -0.1] leaves
+    # importance_ratio = exp(trainer - inference) ~ 5e-5. The kernel's advantage
+    # branch then contributes ~5e-6 of policy_loss, far under the 1e-3 tolerance:
+    # the entire policy-gradient half could be deleted from the kernel and every
+    # assertion here would still pass. Keeping the ratio near 1 puts the policy
+    # term on the same order as the KL term, and makes probs_diff straddle zero
+    # so both sides of the IPO mask are exercised rather than only the low side.
+    inference_logprobs = (trainer_logprobs + rng.normal(0.0, 0.3, size=seq_len)).astype(np.float32)
 
     expected = compute_native_grpo_metrics_reference(
         trainer_logprobs=trainer_logprobs,

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -126,7 +126,8 @@ def test_a_trailing_one_token_range_leaves_the_sample_before_it_alone():
 
 @pytest.mark.gpu
 @pytest.mark.slow
-def test_the_cuda_kernel_matches_the_python_reference_metrics():
+@pytest.mark.parametrize("case", ["ratio", "mask"])
+def test_the_cuda_kernel_matches_the_python_reference_metrics(case):
     """The gap E4 names: nothing has ever run the kernel against the reference.
 
     Both paths see the same weights and the same batch, so the kernel's own
@@ -224,16 +225,24 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     # trainers doubles peak VRAM on a box that is usually busy.
     del reference_trainer
 
-    # Draw the inference logprobs NEAR the trainer's, not from a fixed range.
-    # A truncated model over random token ids produces logprobs around
-    # -log(vocab) ~ -12, so an independent draw from [-4, -0.1] leaves
-    # importance_ratio = exp(trainer - inference) ~ 5e-5. The kernel's advantage
-    # branch then contributes ~5e-6 of policy_loss, far under the 1e-3 tolerance:
-    # the entire policy-gradient half could be deleted from the kernel and every
-    # assertion here would still pass. Keeping the ratio near 1 puts the policy
-    # term on the same order as the KL term, and makes probs_diff straddle zero
-    # so both sides of the IPO mask are exercised rather than only the low side.
-    inference_logprobs = (trainer_logprobs + rng.normal(0.0, 0.3, size=seq_len)).astype(np.float32)
+    # Two cases, because with this fixture they are mutually exclusive and
+    # neither alone compares the whole kernel. A truncated model over random
+    # token ids gives per-token probabilities around 2e-6:
+    #
+    #   "ratio"  inference drawn NEAR the trainer's, so importance_ratio ~ 1 and
+    #            the advantage branch is the same order as KL. An independent
+    #            draw from [-4, -0.1] instead leaves ratio ~5e-5, so the whole
+    #            policy-gradient half contributes ~5e-6 of policy_loss -- under
+    #            the 1e-3 tolerance. It could be deleted from the kernel and
+    #            every assertion here would still pass.
+    #   "mask"   inference drawn FAR from the trainer's, so probs_diff clears the
+    #            0.2 threshold and the IPO mask actually fires. Unreachable in
+    #            the "ratio" case: both probabilities are ~2e-6 there, so their
+    #            difference cannot exceed 0.2.
+    if case == "ratio":
+        inference_logprobs = (trainer_logprobs + rng.normal(0.0, 0.3, size=seq_len)).astype(np.float32)
+    else:
+        inference_logprobs = rng.uniform(-4.0, -0.1, size=seq_len).astype(np.float32)
 
     expected = compute_native_grpo_metrics_reference(
         trainer_logprobs=trainer_logprobs,

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -156,14 +156,23 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
 
     inputs = rng.integers(0, vocab_size, size=(1, seq_len), dtype=np.int32)
     targets = np.roll(inputs, -1, axis=1).astype(np.int32)
-    position_ids = np.arange(seq_len, dtype=np.int32).reshape(1, seq_len)
     # Two packed samples, not one: a single unpacked range never exercises the
     # per-sample shift, and this branch rewrote how those ranges are derived.
+    # The positions must RESET per sample, as the packer emits them -- a
+    # continuous arange alongside two ranges is contradictory input, and the
+    # kernel faults on it with a misaligned address rather than rejecting it.
     sample_ranges = [(0, 8), (8, seq_len)]
+    position_ids = np.concatenate([np.arange(e - s, dtype=np.int32) for s, e in sample_ranges]).reshape(1, seq_len)
 
-    # Prompt tokens masked out, completion tokens live, matching a real pack.
+    # Prompt masked, completion live -- PER SAMPLE. The first token of every
+    # packed sample must be a masked prompt token: the kernel emits gradients
+    # only for logical [start+1, end-1], so a sample whose first token is live
+    # makes the kernel and the reference disagree by exactly that token. That is
+    # an unvalidated invariant of the packed layout, not a divergence, and a
+    # flat `loss_mask[4:] = True` across two samples silently breaks it.
     loss_mask = np.zeros(seq_len, dtype=bool)
-    loss_mask[4:] = True
+    for start, end in sample_ranges:
+        loss_mask[start + 4 : end] = True
     advantages = rng.normal(0.0, 1.0, size=seq_len).astype(np.float32) * loss_mask
     inference_logprobs = rng.uniform(-4.0, -0.1, size=seq_len).astype(np.float32)
     loss_scale = float(loss_mask.sum())

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -23,10 +23,12 @@ import pytest
 from surogate.grpo.config import GRPOLossConfig
 from surogate.grpo.loss import compute_native_shifted_grpo_dloss_reference
 
-# A config where only the KL term is live, so the per-token gradient has a closed
-# form: -2 * kl_tau * (trainer_logprob - inference_logprob) on unmasked tokens.
-# Established independently by `test_sparse_outcome_advantage_preserves_full_completion_kl`
-# in test_native_formula.py, which derives the same expression by hand.
+# `ipo_mask_low/high = 1.0` masks nothing (probs_diff is always within +/-1), so
+# the advantage term stays live; it contributes zero only because `_call` passes
+# zero advantages. That leaves the KL term alone, with the closed form
+# -2 * kl_tau * (trainer_logprob - inference_logprob) on unmasked tokens.
+# Derived independently by `test_sparse_outcome_advantage_preserves_full_completion_kl`
+# in test_native_formula.py, which writes out the same expression by hand.
 KL_ONLY = GRPOLossConfig(ipo_mask_low=1.0, ipo_mask_high=1.0, adv_tau=1.0, teacher_tau=0.0, kl_tau=0.1)
 
 TRAINER_LP = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
@@ -87,20 +89,26 @@ def test_the_result_is_divided_by_loss_scale():
     np.testing.assert_allclose(_call(loss_scale=4.0), _call(loss_scale=1.0) / 4.0, rtol=1e-6)
 
 
-def test_a_one_token_sample_contributes_nothing():
-    """`end - start > 1` guards the shift, so a length-1 range (a lone trailing
-    pad token) leaves zeros rather than reading out of its own range."""
-    actual = compute_native_shifted_grpo_dloss_reference(
-        trainer_logprobs=TRAINER_LP[:4],
-        inference_logprobs=INFERENCE_LP[:4],
-        advantages=np.zeros(4, dtype=np.float32),
-        loss_mask=np.array([False, True, True, True]),
+def test_a_trailing_one_token_range_leaves_the_sample_before_it_alone():
+    """A lone trailing pad token gets its own range now (see
+    `_find_sample_boundaries`). The sample before it must shift exactly as it
+    would have without that range -- the pad must neither absorb a gradient nor
+    displace one."""
+    grads = _expected_unshifted_grads()
+    split = compute_native_shifted_grpo_dloss_reference(
+        trainer_logprobs=TRAINER_LP,
+        inference_logprobs=INFERENCE_LP,
+        advantages=np.zeros(7, dtype=np.float32),
+        loss_mask=LOSS_MASK,
         loss_config=KL_ONLY,
-        sample_ranges=[(0, 3), (3, 4)],
+        sample_ranges=[(0, 4), (4, 6), (6, 7)],
         teacher_logprobs=None,
         loss_scale=1.0,
     )
-    assert actual[3] == 0.0
+    assert split[4] == pytest.approx(grads[5]), "the shortened sample still shifts"
+    assert split[5] == 0.0, "its last slot receives nothing"
+    assert split[6] == 0.0, "and the 1-token range contributes nothing"
+    np.testing.assert_allclose(split[0:3], grads[1:4], rtol=1e-6, atol=1e-7)
 
 
 # ── the actual CUDA parity, which needs hardware ─────────────────────
@@ -223,9 +231,19 @@ def test_the_cuda_kernel_matches_the_python_reference_metrics():
     )
     actual = native_trainer.get_grpo_native_metrics()
 
-    assert expected, "the reference must produce metrics to compare against"
-    for key, expected_value in expected.items():
-        assert key in actual, f"the kernel reports no {key}"
+    # The reference also reports terms the kernel has no counterpart for (OPD,
+    # replay, ratio_clipped, policy_sample_count), so compare what the kernel
+    # actually emits rather than demanding it produce all 18 keys.
+    assert actual, "the kernel must report metrics to compare against"
+    core = {"policy_loss", "mismatch_kl", "keep_tokens", "total_tokens"}
+    assert core <= set(actual), f"kernel metrics missing the core terms: {core - set(actual)}"
+
+    compared = 0
+    for key, actual_value in actual.items():
+        if key not in expected:
+            continue
         # bf16 forward, so the logprobs feeding both sides carry real error;
         # the tolerance is on the arithmetic agreeing, not on bit equality.
-        assert actual[key] == pytest.approx(expected_value, rel=1e-3, abs=1e-4), key
+        assert actual_value == pytest.approx(expected[key], rel=1e-3, abs=1e-4), key
+        compared += 1
+    assert compared >= len(core), f"only {compared} metrics were actually compared"

--- a/tests/grpo/test_native_parity.py
+++ b/tests/grpo/test_native_parity.py
@@ -1,0 +1,237 @@
+"""Parity coverage for the native GRPO loss (E4 in the RL end-to-end findings).
+
+The existing `test_native_formula.py` cannot establish parity with anything. Its
+"expected" helper calls `compute_grpo_per_token_grads`, and so does the function
+it checks (`loss.py:350`), so the assertion is `f(x) == f(x)`: it holds whatever
+the formula is, and would keep holding if the formula were wrong.
+
+Two different things were being conflated, and they are separated here.
+
+1. **The Python wrapper.** What `compute_native_shifted_grpo_dloss_reference`
+   adds over the base function is a per-sample next-token shift and a division
+   by `loss_scale`. Both are checked below against values derived from the loss
+   definition rather than from the code under test.
+
+2. **The CUDA kernel.** `grpo_custom_dloss_kernel` has only ever been compared
+   to the Python reference *by hand*. Nothing in the suite imports `_surogate`
+   or calls `step_grpo_native`, so any future edit to either side diverges with
+   a green suite. That test needs a GPU and lives at the bottom of this file.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from surogate.grpo.config import GRPOLossConfig
+from surogate.grpo.loss import compute_native_shifted_grpo_dloss_reference
+
+# A config where only the KL term is live, so the per-token gradient has a closed
+# form: -2 * kl_tau * (trainer_logprob - inference_logprob) on unmasked tokens.
+# Established independently by `test_sparse_outcome_advantage_preserves_full_completion_kl`
+# in test_native_formula.py, which derives the same expression by hand.
+KL_ONLY = GRPOLossConfig(ipo_mask_low=1.0, ipo_mask_high=1.0, adv_tau=1.0, teacher_tau=0.0, kl_tau=0.1)
+
+TRAINER_LP = np.array([-7.0, -1.2, -0.8, -3.1, -2.0, -0.4, -5.0], dtype=np.float32)
+INFERENCE_LP = np.array([-7.0, -1.4, -0.7, -2.8, -1.1, -0.5, -4.6], dtype=np.float32)
+# Sample 2 starts at index 4 and its first token is unmasked on purpose: a global
+# (rather than per-sample) shift would leak that gradient back into index 3.
+LOSS_MASK = np.array([False, True, True, True, True, True, True])
+SAMPLE_RANGES = [(0, 4), (4, 7)]
+
+
+def _expected_unshifted_grads() -> np.ndarray:
+    """The KL gradient, written from the loss definition, not from the code."""
+    grads = -2.0 * KL_ONLY.kl_tau * (TRAINER_LP - INFERENCE_LP)
+    return np.where(LOSS_MASK, grads, 0.0).astype(np.float32)
+
+
+def _call(loss_scale: float) -> np.ndarray:
+    return compute_native_shifted_grpo_dloss_reference(
+        trainer_logprobs=TRAINER_LP,
+        inference_logprobs=INFERENCE_LP,
+        advantages=np.zeros(7, dtype=np.float32),
+        loss_mask=LOSS_MASK,
+        loss_config=KL_ONLY,
+        sample_ranges=SAMPLE_RANGES,
+        teacher_logprobs=None,
+        loss_scale=loss_scale,
+    )
+
+
+def test_the_shift_moves_each_gradient_one_token_left_within_its_sample():
+    """The kernel reads `losses[out_idx]` as the logprob of logical token
+    `out_idx + 1`, so the reference has to hand back gradients in that layout."""
+    grads = _expected_unshifted_grads()
+    actual = _call(loss_scale=1.0)
+
+    expected = np.zeros(7, dtype=np.float32)
+    expected[0:3] = grads[1:4]  # sample (0, 4)
+    expected[4:6] = grads[5:7]  # sample (4, 7)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-7)
+
+
+def test_the_shift_does_not_cross_a_sample_boundary():
+    """The last slot of each sample receives nothing. If the shift were applied
+    across the whole packed row instead of per sample, index 3 would pick up
+    sample 2's first gradient, which is non-zero precisely so this can fail."""
+    grads = _expected_unshifted_grads()
+    assert grads[4] != 0.0, "the fixture must make the leak detectable"
+
+    actual = _call(loss_scale=1.0)
+    assert actual[3] == 0.0, "sample 1's last slot must not receive sample 2's gradient"
+    assert actual[6] == 0.0, "nor may the final slot of the row"
+
+
+def test_the_result_is_divided_by_loss_scale():
+    """`loss = total / loss_scale`, and the reference owes the caller the divided
+    form: the engine does not divide again."""
+    np.testing.assert_allclose(_call(loss_scale=4.0), _call(loss_scale=1.0) / 4.0, rtol=1e-6)
+
+
+def test_a_one_token_sample_contributes_nothing():
+    """`end - start > 1` guards the shift, so a length-1 range (a lone trailing
+    pad token) leaves zeros rather than reading out of its own range."""
+    actual = compute_native_shifted_grpo_dloss_reference(
+        trainer_logprobs=TRAINER_LP[:4],
+        inference_logprobs=INFERENCE_LP[:4],
+        advantages=np.zeros(4, dtype=np.float32),
+        loss_mask=np.array([False, True, True, True]),
+        loss_config=KL_ONLY,
+        sample_ranges=[(0, 3), (3, 4)],
+        teacher_logprobs=None,
+        loss_scale=1.0,
+    )
+    assert actual[3] == 0.0
+
+
+# ── the actual CUDA parity, which needs hardware ─────────────────────
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_the_cuda_kernel_matches_the_python_reference_metrics():
+    """The gap E4 names: nothing has ever run the kernel against the reference.
+
+    `trainer.py` claims the decomposed path produces gradients identical to the
+    fused `step_grpo_native`, and cites `test_native_formula.py` as the
+    assertion. That test cannot assert it. This one can: both paths see the same
+    weights and the same batch, so the kernel's own metrics -- read back through
+    `get_grpo_native_metrics` -- must match what the Python reference computes
+    from the same logprobs.
+
+    Metrics rather than gradients on purpose: they are the kernel's arithmetic
+    made observable without reading device memory, and they cover all the loss
+    terms (policy loss, mismatch KL, keep/clip counts and their denominators).
+    """
+    _surogate = pytest.importorskip("surogate._surogate", reason="needs the built extension")
+
+    from surogate.dsl.ir_builder import build_dsl_ir_for_model
+    from surogate.grpo.loss import compute_native_grpo_metrics_reference
+    from surogate.utils.hf import get_model_weights_path
+    from tests.test_onboarding_qwen3 import prepare_mini_model, resolve_model_path
+
+    snapshot = resolve_model_path()
+    if snapshot is None:
+        pytest.skip("Qwen3 weights not found; set QWEN3_MODEL_PATH or cache Qwen/Qwen3-0.6B")
+    model_dir = prepare_mini_model(snapshot)
+
+    seq_len = 16
+    vocab_size = int(json.loads((model_dir / "config.json").read_text())["vocab_size"])
+    rng = np.random.default_rng(0)
+
+    inputs = rng.integers(0, vocab_size, size=(1, seq_len), dtype=np.int32)
+    targets = np.roll(inputs, -1, axis=1).astype(np.int32)
+    position_ids = np.arange(seq_len, dtype=np.int32).reshape(1, seq_len)
+    sample_ranges = [(0, seq_len)]
+
+    # Prompt tokens masked out, completion tokens live, matching a real pack.
+    loss_mask = np.zeros(seq_len, dtype=bool)
+    loss_mask[4:] = True
+    advantages = rng.normal(0.0, 1.0, size=seq_len).astype(np.float32) * loss_mask
+    inference_logprobs = rng.uniform(-4.0, -0.1, size=seq_len).astype(np.float32)
+    loss_scale = float(loss_mask.sum())
+
+    config = _surogate.PretrainedConfig.from_pretrained(str(model_dir), "bf16")
+    options = _surogate.RuntimeOptions(
+        offload_residual=False,
+        use_cuda_graphs=False,
+        offload_master=False,
+        offload_grads=False,
+        offload_optimizer=False,
+        shard_gradients=True,
+        use_zero_copy=False,
+    )
+    options.dsl_ir_json = build_dsl_ir_for_model(str(model_dir))
+
+    def _new_trainer():
+        t = _surogate.SurogateTrainer(
+            ngpu=1,
+            config=config,
+            options=options,
+            batch_size=1,
+            seq_len=seq_len,
+            grad_accum=1,
+            memcpy_all_gather=True,
+            memcpy_send_recv=True,
+            lora_config=None,
+            qlora_config=None,
+        )
+        t.import_weights(get_model_weights_path(str(model_dir)))
+        return t
+
+    # A separate trainer per path: `forward_for_grpo` saves activations that
+    # `step_grpo_native` would otherwise inherit. Same weights either way, so the
+    # logprobs are the same.
+    reference_trainer = _new_trainer()
+    buf = np.asarray(
+        reference_trainer.forward_for_grpo(inputs, targets, position_ids, None)[0, :seq_len],
+        dtype=np.float32,
+    )
+    # forward_for_grpo returns the negated CE buffer in TARGET slot layout:
+    # buf[t] = log p(input_ids[t+1]). Un-shift into logical layout, the exact
+    # inverse of the shift the kernel applies. Mirrors trainer.py's diagnostic path.
+    trainer_logprobs = np.zeros(seq_len, dtype=np.float32)
+    for start, end in sample_ranges:
+        if end - start > 1:
+            trainer_logprobs[start + 1 : end] = buf[start : end - 1]
+
+    expected = compute_native_grpo_metrics_reference(
+        trainer_logprobs=trainer_logprobs,
+        inference_logprobs=inference_logprobs,
+        advantages=advantages,
+        loss_mask=loss_mask,
+        loss_config=KL_ONLY,
+        sample_ranges=sample_ranges,
+        teacher_logprobs=None,
+    )
+
+    native_trainer = _new_trainer()
+    native_trainer.step_grpo_native(
+        inputs,
+        targets,
+        inference_logprobs,
+        advantages,
+        loss_mask.astype(np.uint8),
+        np.array([s for s, _ in sample_ranges], dtype=np.int32),
+        np.array([e for _, e in sample_ranges], dtype=np.int32),
+        position_ids=position_ids,
+        temperatures=None,
+        teacher_logprobs=None,
+        loss_scale=loss_scale,
+        ipo_mask_low=float(KL_ONLY.ipo_mask_low),
+        ipo_mask_high=float(KL_ONLY.ipo_mask_high),
+        adv_tau=float(KL_ONLY.adv_tau),
+        teacher_tau=float(KL_ONLY.teacher_tau),
+        kl_tau=float(KL_ONLY.kl_tau),
+        ratio_clip=float(KL_ONLY.ratio_clip),
+    )
+    actual = native_trainer.get_grpo_native_metrics()
+
+    assert expected, "the reference must produce metrics to compare against"
+    for key, expected_value in expected.items():
+        assert key in actual, f"the kernel reports no {key}"
+        # bf16 forward, so the logprobs feeding both sides carry real error;
+        # the tolerance is on the arithmetic agreeing, not on bit equality.
+        assert actual[key] == pytest.approx(expected_value, rel=1e-3, abs=1e-4), key

--- a/tests/grpo/test_turn_stats.py
+++ b/tests/grpo/test_turn_stats.py
@@ -337,11 +337,12 @@ class TestDiagnosticLayoutRoundTrip:
             if end - start > 1:
                 buf[start : end - 1] = logical_lp[start + 1 : end]
 
-        # The un-shift performed in GRPOTrainer._diagnostic_micro_step.
-        recovered = np.zeros(seq_len, dtype=np.float32)
-        for start, end in sample_ranges:
-            if end - start > 1:
-                recovered[start + 1 : end] = buf[start : end - 1]
+        # Call the un-shift the trainer actually uses, rather than a copy of it.
+        # This class exists to pin that transform, and a private re-implementation
+        # pins nothing: inverting the real one used to leave every test green.
+        from surogate.grpo.loss import unshift_to_logical
+
+        recovered = unshift_to_logical(buf, sample_ranges)
 
         from surogate.grpo.loss import compute_grpo_per_token_grads
 


### PR DESCRIPTION
Two latent defects in the GRPO loss path, and the parity tests that were
supposed to protect it but could not.

## The guards

**A falsy advantage config returned raw rewards as advantages**, with no
baseline subtracted — REINFORCE with all-positive advantages, every completion
reinforced including the bad ones, silently. It now raises.

To be precise about what this is: no config can reach it. The orchestrator
config always assigns a truthy advantage config, and neither config class
defines `__bool__` or `__len__`, so the branch can only ever see an explicit
`None` from a future caller. **This is an assertion on an unreachable path, not
a defect being closed** — worth having, worth not overstating.

**`_find_sample_boundaries` dropped the boundary of any one-token sample**, via a
`position_ids[i+1] == 1` lookahead, with no test coverage at all. Rather than
guard the ambiguity, it now uses the rule the engine already applies to the same
array — `curr - prev != 1` — so the loss's sample ranges and the attention mask
can no longer disagree about where a sample ends. Every producer writes a
sample's positions as `range(n)`, which makes that test exact rather than
heuristic.

## The parity tests could not establish parity

Their expected values came from the same `compute_grpo_per_token_grads` the code
under test calls, so the assertion was `f(x) == f(x)` — true whatever the
formula is. The trainer's own docstring cited them as proof that the decomposed
path and `step_grpo_native` agree.

They are renamed to say what they actually check, and `test_native_parity.py`
adds what was missing: the shift and `loss_scale` division checked against
values derived from the loss definition rather than from the code, plus a real
CUDA-vs-Python comparison.

## What the hardware run does and does not compare

Run on an RTX 5090 against the published image, **two cases, because one cannot
cover both**:

| Case | Compared | Mismatched | Non-zero | Covers |
|---|---|---|---|---|
| `ratio` | 9 | 0 | 5 | advantage / policy-gradient |
| `mask` | 9 | 0 | 8 | IPO masking |

They are mutually exclusive with this fixture. The model's per-token
probabilities are ~2e-6, so an importance ratio near 1 leaves `probs_diff` far
below the 0.2 mask threshold and nothing masks; clearing that threshold drives
the ratio to ~5e-5 and makes the advantage branch contribute ~5e-6 of
`policy_loss`, under the tolerance. An earlier single-case version of this test
would have passed with the policy gradient deleted from the kernel outright.

**Neither case alone compares the whole kernel.** Together they do.

The fixture also encodes two properties of a real pack that are easy to get
wrong: positions reset per sample (a continuous `arange` alongside two ranges
faults the kernel), and every sample begins with a masked prompt token. That
second one is an unvalidated invariant of the packed layout — the kernel emits
gradients only over `[start+1, end-1]` while the Python reference counts the
whole range, so breaking it diverges 7 of 9 metrics. Nothing enforces it at any
layer; worth closing separately.

## Also

- `shift_to_target` extracted beside `unshift_to_logical`. The forward transform
  was written out in three places while its inverse had just been shared, and
  the tests pinned the one copy no production path calls — a global shift in the
  diagnostic path left every test green.
- The attention arena guard warns when documents are so short the backward arena
  balloons. It triggers on the arena itself rather than on document length: the
  earlier threshold needed a mean document under two tokens and would have
  stayed silent at 17x and 44x oversized, both of which die with the same
  unexplained `bad_alloc` it exists to prevent.

## Not verified

- **The C++ warning has never run.** It is compile-checked only, and is inert
  until an image is rebuilt. There is no test for `compute_doc_masking`.
- **The parity test cannot run on H100 or B200** — both fault at this shape with
  `cudaErrorMisalignedAddress`, while a consumer Blackwell card runs it fine. A
  full-size run works on H100, so it is shape-specific. Pre-existing, unrelated
  to this change, but it means CI on datacenter hardware will not exercise it.

## Tests

64 across the GRPO suite. Each production hunk was reverted in turn to confirm
the tests fail without it; the boundary rule, the shared shift, the advantage
guard and the reference shift each have a mutation that breaks them.
