### PR TITLE
build(serve): the tests link the shared library too, and 60 GB of build directory goes away

### DIFF
--- a/csrc/src/testing/serve/CMakeLists.txt
+++ b/csrc/src/testing/serve/CMakeLists.txt
@@ -5,6 +5,11 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 add_executable(sinfer_public_api_test test_public_api.cpp)
 target_include_directories(sinfer_public_api_test PRIVATE ${SERVE_ROOT})
 add_test(NAME sinfer_public_api_test COMMAND sinfer_public_api_test)
+# It joins the aggregate like every test built by the helper below. It is excluded
+# from `all` and was not on the list, so `make serve-test-build` never compiled it
+# and ctest reported it Not Run -- the exact failure the helper's comment describes,
+# in the one test that predates the helper.
+set_property(GLOBAL APPEND PROPERTY SINFER_SERVE_TEST_TARGETS sinfer_public_api_test)
 
 function(sinfer_add_test name)
   cmake_parse_arguments(arg "NEEDS_SOURCE_DIR" "" "SOURCES;LIBRARIES" ${ARGN})
@@ -21,11 +26,25 @@ function(sinfer_add_test name)
     # links sinfer_engine rather than sinfer_core does not inherit the toolkit's
     # include path, so give every test target its own.
     ${CUDAToolkit_INCLUDE_DIRS})
-  if(arg_LIBRARIES)
-    target_link_libraries(${name} PRIVATE ${arg_LIBRARIES})
-  else()
-    target_link_libraries(${name} PRIVATE sinfer_core)
+  # Every sinfer archive a test names resolves to the one shared library. libsinfer.so
+  # holds all of them, and a test that links the archives statically embeds the device
+  # code the way the products used to: 132 test binaries at ~450 MB each was 60 GB of
+  # build directory, and every link paid for writing it. The LIBRARIES argument is kept
+  # as the record of what a test actually uses; anything that is not a sinfer archive
+  # (CUDA::cudart, and whatever a test adds later) still links as itself.
+  set(test_libraries "")
+  foreach(requested IN LISTS arg_LIBRARIES)
+    if(requested MATCHES "^sinfer_")
+      list(APPEND test_libraries sinfer_shared)
+    else()
+      list(APPEND test_libraries ${requested})
+    endif()
+  endforeach()
+  if(NOT test_libraries MATCHES "sinfer_shared")
+    list(APPEND test_libraries sinfer_shared)
   endif()
+  list(REMOVE_DUPLICATES test_libraries)
+  target_link_libraries(${name} PRIVATE ${test_libraries})
   if(arg_NEEDS_SOURCE_DIR)
     target_compile_definitions(${name} PRIVATE
       SINFER_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
@@ -244,7 +263,7 @@ target_include_directories(sinfer_bench_support_test PRIVATE ${CMAKE_CURRENT_SOU
 # artifact — but built beside the tests so it stays compiling.
 add_executable(sinfer_embed_cli encoder/embed_cli.cpp)
 target_include_directories(sinfer_embed_cli PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${SERVE_ROOT})
-target_link_libraries(sinfer_embed_cli PRIVATE sinfer_encoder)
+target_link_libraries(sinfer_embed_cli PRIVATE sinfer_shared)
 
 # The host kernels: no GPU and no artifact, so this one is a real ctest.
 sinfer_add_op_test(sinfer_cpu_ops_test
@@ -253,7 +272,7 @@ sinfer_add_op_test(sinfer_cpu_ops_test
 
 add_executable(sinfer_cpu_embed_cli encoder/cpu_embed_cli.cpp)
 target_include_directories(sinfer_cpu_embed_cli PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${SERVE_ROOT})
-target_link_libraries(sinfer_cpu_embed_cli PRIVATE sinfer_encoder)
+target_link_libraries(sinfer_cpu_embed_cli PRIVATE sinfer_shared)
 
 # The /v1/embeddings server moved to the product build as `surogate-embed`
 # (csrc/CMakeLists.txt): `surogate serve --embed` execs it, so it is not a test

--- a/csrc/src/testing/serve/bench/CMakeLists.txt
+++ b/csrc/src/testing/serve/bench/CMakeLists.txt
@@ -6,7 +6,7 @@ function(sinfer_add_op_bench name)
     ${CMAKE_CURRENT_SOURCE_DIR}/ops
     ${SERVE_ROOT}
     ${SERVE_ROOT})
-  target_link_libraries(${name} PRIVATE sinfer_ops)
+  target_link_libraries(${name} PRIVATE sinfer_shared)
   target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>)
 endfunction()
 
@@ -80,7 +80,7 @@ target_include_directories(sinfer_bench PRIVATE
   ${SERVE_ROOT}
   ${SUROGATE_VENDOR_DIR})
 target_compile_definitions(sinfer_bench PRIVATE SINFER_SOURCE_DIR="${SERVE_ROOT}")
-target_link_libraries(sinfer_bench PRIVATE sinfer_engine CUDA::cudart)
+target_link_libraries(sinfer_bench PRIVATE sinfer_shared CUDA::cudart)
 
 # Native target-private MTP proposal/verification microbenchmark. It enters through the target
 # Program facade and executes the production round schedule over a real .sinfer artifact.
@@ -92,8 +92,7 @@ target_include_directories(sinfer_qwen3_5_mtp_round_bench PRIVATE
   ${SUROGATE_VENDOR_DIR}
   ${SERVE_ROOT}/targets/qwen3_5/export
   ${SERVE_ROOT}/targets/qwen3_5/export)
-target_link_libraries(sinfer_qwen3_5_mtp_round_bench PRIVATE
-  sinfer_engine sinfer_core)
+target_link_libraries(sinfer_qwen3_5_mtp_round_bench PRIVATE sinfer_shared)
 
 # Complete production DFlash steady round: confirmed-context append, next proposal, target
 # verification/acceptance, and host publication over a real 35B artifact.
@@ -105,5 +104,4 @@ target_include_directories(sinfer_qwen3_5_moe_dflash_round_bench PRIVATE
   ${SUROGATE_VENDOR_DIR}
   ${SERVE_ROOT}/targets/qwen3_5_moe/export
   ${SERVE_ROOT}/targets/qwen3_5/export)
-target_link_libraries(sinfer_qwen3_5_moe_dflash_round_bench PRIVATE
-  sinfer_engine sinfer_core)
+target_link_libraries(sinfer_qwen3_5_moe_dflash_round_bench PRIVATE sinfer_shared)


### PR DESCRIPTION
Follow-on to #85. The products stopped duplicating the device code; the tests had not.

Every test linked the archives it named, so every test binary embedded its own copy of the
fatbin — ~450 MB each, 132 of them:

| | before | after |
|---|---|---|
| `csrc/build-serve/serve_tests/` | 60 GB | 27 MB |
| `csrc/build-serve` (whole) | 86 GB | 17 GB |

The `LIBRARIES` argument stays as the record of what a test uses; any `sinfer_*` archive it
names resolves to `sinfer_shared`, and anything else (`CUDA::cudart`, and whatever a test adds
later) links as itself. The benches go the same way.

`sinfer_public_api_test` predates the `sinfer_add_test` helper and so never joined the
aggregate the helper appends to. It is excluded from `all`, nothing built it, and ctest had
been reporting it **Not Run** — the exact failure the helper's own comment describes, in the
one test that came before the helper. It is on the list now, and passes.

## Verification

118 tests on one card: **110 passed, 7 skipped** for absent fixtures. `sinfer_mean_pool_test`
failed once under `--parallel 8` (chunked reduction, index 581) and passes 6/6 standalone — a
pre-existing flake under contention, not a link change.

An earlier run put every test on GPU 0 while another process had it at 32061/32607 MiB, and
84 died on `cudaMalloc: out of memory`. That is the machine, not the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
