### PR TITLE
fix(serve): the QSA selection rides on the cache dtype, so Flash-Next serves its own default again

### DIFF
--- a/csrc/src/serve/ops/launcher/gqa_attention_prefill.cu
+++ b/csrc/src/serve/ops/launcher/gqa_attention_prefill.cu
@@ -137,8 +137,9 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
                                                cudaStream_t stream,
                                                GqaBlockMask selection = {}) {
     if (q.ne[1] != Geometry::QHeads) {
-        if (selection.words && (selection.block != 4 || cache.dtype != DType::BF16)) {
-            throw std::invalid_argument("gqa_attention: selection requires block 4 and BF16 cache");
+        if (selection.words && cache.dtype == DType::I8) {
+            throw std::invalid_argument(
+                "gqa_attention: the QSA selection is not served over an int8 KV cache");
         }
         const auto launch = [&]<typename CacheT>() {
             gqa_attention_generic_kernel<CacheT, Metadata><<<dim3(q.ne[1], q.ne[2]), 32, 0, stream>>>(
@@ -159,9 +160,15 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
     }
     const Tensor& cache_k = cache.k_pages;
     const Tensor& cache_v = cache.v_pages;
-    if (selection.words != nullptr && cache.dtype != DType::BF16) {
+    // A selection rides on the cache dtype rather than replacing it: the BF16 and e4m3 prefill
+    // kernels are one template over the cache type, and the block mask is orthogonal to it. The
+    // int8 kernel is a different one and has no sparse specialization, so it says so by name.
+    if (selection.words != nullptr && cache.dtype == DType::I8) {
         throw std::invalid_argument(
-            "gqa_attention: the QSA selection needs a BF16 KV cache (the quantized kernels are dense)");
+            "gqa_attention: the QSA selection is not served over an int8 KV cache");
+    }
+    if (selection.words != nullptr && selection.block != 4) {
+        throw std::invalid_argument("gqa_attention: unregistered QSA block size");
     }
     // Both dtype-specialized kernels size their arena from the geometry's head
     // dimension; at 256 both exceed the default 48 KiB dynamic-smem ceiling, and
@@ -195,26 +202,35 @@ void gqa_attention_prompt_attention_launch_for(const Tensor& q, const Tensor& po
                 static_cast<const std::int32_t*>(positions.data), scale,
                 static_cast<__nv_bfloat16*>(out.data), tokens);
     } else if (cache.dtype == DType::FP8_E4M3FN) {
-        CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
-            gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));
         const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
                                   static_cast<unsigned>(Geometry::QHeads), 1u);
-        gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t>
-            <<<attention_grid, kGqaPrefillThreads, kSmemBytes, stream>>>(
-                static_cast<const __nv_bfloat16*>(q.data),
-                static_cast<const std::uint8_t*>(cache_k.data),
-                static_cast<const std::uint8_t*>(cache_v.data), metadata,
-                static_cast<const std::int32_t*>(positions.data), scale,
-                static_cast<__nv_bfloat16*>(out.data), tokens);
+        if (selection.words != nullptr) {
+            CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
+                gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t, true, 4>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));
+            gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t, true, 4>
+                <<<attention_grid, kGqaPrefillThreads, kSmemBytes, stream>>>(
+                    static_cast<const __nv_bfloat16*>(q.data),
+                    static_cast<const std::uint8_t*>(cache_k.data),
+                    static_cast<const std::uint8_t*>(cache_v.data), metadata,
+                    static_cast<const std::int32_t*>(positions.data), scale,
+                    static_cast<__nv_bfloat16*>(out.data), tokens, selection);
+        } else {
+            CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
+                gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));
+            gqa_attention_prefill_bf16_kernel<Geometry, Metadata, std::uint8_t>
+                <<<attention_grid, kGqaPrefillThreads, kSmemBytes, stream>>>(
+                    static_cast<const __nv_bfloat16*>(q.data),
+                    static_cast<const std::uint8_t*>(cache_k.data),
+                    static_cast<const std::uint8_t*>(cache_v.data), metadata,
+                    static_cast<const std::int32_t*>(positions.data), scale,
+                    static_cast<__nv_bfloat16*>(out.data), tokens);
+        }
     } else {
         const dim3 attention_grid(static_cast<unsigned>(div_up(tokens, kGqaPrefillBr)),
                                   static_cast<unsigned>(Geometry::QHeads), 1u);
         if (selection.words != nullptr) {
-            // QSA selection: only the 4-cell block is registered.
-            if (selection.block != 4) {
-                throw std::invalid_argument("gqa_attention: unregistered QSA block size");
-            }
             CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
                 gqa_attention_prefill_bf16_kernel<Geometry, Metadata, __nv_bfloat16, true, 4>,
                 cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));


### PR DESCRIPTION
**Qwen3.8-Flash-Next could not be served at all** on `main`. Found while re-measuring its board
rows: the engine dies during warm-up.

```
gqa_attention: the QSA selection needs a BF16 KV cache (the quantized kernels are dense)
```

Three things have to be true at once, and today they are:

- warm-up prefills the full 4,096-token context, which is past the indexer's **2,048-key**
  budget, so the QSA selection engages;
- the KV cache under the engine's own `auto` policy is **e4m3**, because linear-attention layers
  carry this stack;
- the prefill dispatch refused that pair.

## The refusal described the dispatch, not the kernels

`gqa_attention_prefill_bf16_kernel` is one template over the cache type —
`gqa_prefill_stage_kv<Geometry, CacheT>` stages a BF16 tile out of a BF16 *or* an e4m3 page — and
`Sparse`/`SparseBlock` are orthogonal parameters deciding only which keys get visited. The e4m3
branch just never instantiated the sparse specialization, and the guard above it turned that
omission into a hard refusal. It instantiates it now; the refusal stays where it is true: **int8**,
whose prefill is a different kernel with no sparse form.

Same reasoning for the query-count fallback added in `3fca7ba5`: its generic kernel dequantizes
per value and tests the mask per key, so it is general over both, and its entry check was
refusing what its own body supports.

## Why this was invisible

The selection stays off while the whole context fits the indexer's budget — *"a deployment whose
whole KV cache is shorter than the budget can never reach a selection"* — which is **every shape on
the board**: 512-token prompts never engage it. It takes a long prompt *and* a quantized cache in
the same run, and `3fca7ba5` (deriving the indexer from checkpoint metadata) is what finally put
them together.

## Verification

One 5090, engine defaults plus `--kv-cache-dtype fp8`:

- loads, warms up at 4,096, serves — where it previously died during warm-up;
- a **2,581-token needle prompt** (above the 2,051-key dense budget, so the sparse e4m3 path is
  the one running) returns the needle, with zero selection errors in the log;
- serve suite **122/122**.

## Gap left open

No unit test covers a selection over a quantized cache: `test_qsa_indexer` checks the folding and
the block choice, `test_gqa_attention`'s harness has no selection at all. That gap is why this
shipped broken and is worth closing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
