### PR TITLE
build(serve): one engine binary for the RTX line, and the decode tiles stop being static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,16 @@ SERVE_BUILD_DIR ?= csrc/build-serve
 # the project dependency, and these tests need none of it.
 PYTEST ?= .venv/bin/python -m pytest
 
+# One engine binary for the RTX line: Ada (4090) and Blackwell (5090, PRO 6000). The kernels
+# that only Blackwell can run carry only its cubin -- csrc/CMakeLists.txt pins those targets --
+# so the second architecture costs what it actually uses rather than doubling the fatbin.
+SERVE_CUDA_ARCHS ?= 89;120a
+
 serve-configure:
 	cmake -S csrc -B $(SERVE_BUILD_DIR) -G Ninja \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_CUDA_ARCHITECTURES=120a \
+		-DCMAKE_CUDA_ARCHITECTURES="$(SERVE_CUDA_ARCHS)" \
+		-DSUROGATE_SERVE_CUDA_ARCHS="$(SERVE_CUDA_ARCHS)" \
 		-DPYTHON_BINDING=ON $(CCACHE_FLAGS)
 
 serve-build: serve-configure

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -99,8 +99,18 @@ option(ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer
 option(SUROGATE_BUILD_SERVE "Expose the serve engine targets" ON)
 option(SUROGATE_SERVE_TESTS "Expose the serve engine test targets" OFF)
 option(SUROGATE_SERVE_BENCH "Expose the serve engine bench targets" OFF)
-set(SUROGATE_SERVE_CUDA_ARCHS "120a" CACHE STRING
-    "CUDA architectures for the serve engine targets (RTX consumer set)")
+# One binary for the RTX line the engine is built for: Ada (RTX 4090) and consumer/workstation
+# Blackwell (RTX 5090, RTX PRO 6000). The driver picks the cubin; nothing chooses at build time.
+# Hopper and datacenter Blackwell are deliberately absent: this engine's shape -- experts banked
+# in host memory, pipeline stages and expert gathers over PCIe -- is a PCIe machine's, and on
+# NVLink hardware neither the design nor the competition is the same.
+#
+# A kernel family that only one of these architectures can run stays that architecture's alone
+# *inside* the one binary: `set_target_properties(<target> PROPERTIES CUDA_ARCHITECTURES 120a)`
+# below does that for the FP4 families, which keeps the fatbin from carrying an sm_89 copy of a
+# kernel sm_89 cannot execute.
+set(SUROGATE_SERVE_CUDA_ARCHS "89;120a" CACHE STRING
+    "CUDA architectures for the serve engine targets (the RTX line: Ada and Blackwell)")
 # A build machine missing FFmpeg or libcurl drops the serve targets with a status
 # line, which is right for a training-only tree and wrong for a wheel: it would
 # publish a package whose `surogate serve` exits 127 and say nothing. The wheel
@@ -921,6 +931,7 @@ target_link_libraries(sinfer_artifact PUBLIC sinfer_core)
 # sm_120-only hardware (TMA + cluster + block-scaled FP4 MMA). Port builds for
 # other architectures link a loud-failure stub instead.
 if("120a" IN_LIST SUROGATE_SERVE_CUDA_ARCHS OR SUROGATE_SERVE_CUDA_ARCHS STREQUAL "120a")
+  set(SINFER_NVFP4_TMA_REAL ON)
   add_library(sinfer_nvfp4_tma STATIC EXCLUDE_FROM_ALL
     ${SERVE_ROOT}/ops/linear/nvfp4/nvfp4_w4a4_tma.cu
     ${SERVE_ROOT}/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_w4a4_tma.cu)
@@ -932,6 +943,13 @@ sinfer_internal_includes(sinfer_nvfp4_tma)
 set_target_properties(sinfer_nvfp4_tma PROPERTIES
   CUDA_SEPARABLE_COMPILATION OFF
   CUDA_RESOLVE_DEVICE_SYMBOLS OFF)
+# TMA, cluster launch and block-scaled FP4 MMA are sm_120 hardware. In a multi-architecture
+# build the rest of the engine is compiled for every listed architecture and this is not:
+# an sm_89 cubin of a kernel sm_89 cannot run is fatbin weight and a compile that has to be
+# guarded instruction by instruction. `w4fp4_plane` admits these routes at CC 120 and above.
+if(SINFER_NVFP4_TMA_REAL)
+  set_target_properties(sinfer_nvfp4_tma PROPERTIES CUDA_ARCHITECTURES 120a)
+endif()
 target_compile_options(sinfer_nvfp4_tma PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>)
 target_link_libraries(sinfer_nvfp4_tma PRIVATE sinfer_core CUDA::cudart CUDA::cuda_driver)
 
@@ -960,6 +978,7 @@ target_link_libraries(sinfer_nvfp4_cutlass PRIVATE sinfer_core CUDA::cudart CUDA
 # loud-failure stub.
 set(TRTLLM_MOE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/trtllm_moe)
 if("120a" IN_LIST SUROGATE_SERVE_CUDA_ARCHS OR SUROGATE_SERVE_CUDA_ARCHS STREQUAL "120a")
+  set(SINFER_TRTLLM_MOE_REAL ON)
   file(GLOB TRTLLM_MOE_GENERATED ${TRTLLM_MOE_ROOT}/cutlass_instantiations/120/gemm_grouped/120/*.generated.cu)
   add_library(sinfer_trtllm_moe STATIC EXCLUDE_FROM_ALL
     ${TRTLLM_MOE_ROOT}/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_kernels_fp4_fp4.cu
@@ -1013,6 +1032,11 @@ set_target_properties(sinfer_trtllm_moe PROPERTIES
   CUDA_RESOLVE_DEVICE_SYMBOLS OFF
   CUDA_STANDARD 17
   CXX_STANDARD 17)
+# The instantiations vendored here are FlashInfer's for architecture 120, and the kernels are
+# NVFP4: sm_120 alone, like the TMA archive above, whatever else the binary is built for.
+if(SINFER_TRTLLM_MOE_REAL)
+  set_target_properties(sinfer_trtllm_moe PROPERTIES CUDA_ARCHITECTURES 120a)
+endif()
 target_link_libraries(sinfer_trtllm_moe PRIVATE sinfer_core CUDA::cudart CUDA::cuda_driver)
 
 # Shared mathematical Ops. The list is intentionally explicit: adding a
@@ -1546,8 +1570,11 @@ set_target_properties(sinfer_shared PROPERTIES
   # `gcc -c`, and the whole-archive block below reaches it as input files.
   CUDA_RESOLVE_DEVICE_SYMBOLS OFF
   POSITION_INDEPENDENT_CODE ON)
+# Comma-joined: the architecture list is a CMake list, and a `;` inside a compile definition
+# splits it into two definitions and an unterminated quote.
+string(REPLACE ";" "," SINFER_BUILD_CUDA_ARCHS_TEXT "${SUROGATE_SERVE_CUDA_ARCHS}")
 target_compile_definitions(sinfer_shared PRIVATE
-  SINFER_BUILD_CUDA_ARCHS="${SUROGATE_SERVE_CUDA_ARCHS}")
+  SINFER_BUILD_CUDA_ARCHS="${SINFER_BUILD_CUDA_ARCHS_TEXT}")
 target_include_directories(sinfer_shared PUBLIC ${SERVE_ROOT})
 # The products compile serve headers that reach for cuda_runtime.h, and call the
 # runtime themselves. They used to inherit that from whichever archive they linked

--- a/csrc/src/serve/ops/kernel/gqa_attention_decode_bf16.cuh
+++ b/csrc/src/serve/ops/kernel/gqa_attention_decode_bf16.cuh
@@ -40,6 +40,23 @@ __device__ __forceinline__ bool gqa_block_visible(const std::uint32_t* row_words
     }
 }
 
+/// The kernel's shared tiles, sized from the same constants the body derives.
+///
+/// They are *dynamic* shared memory, not static: a 512-wide head wants 68 KB and Ada caps a
+/// block's static allocation at 48 KB, while its dynamic cap with `cudaFuncSetAttribute` is
+/// 99 KB. The same kernel therefore compiles for sm_89 and sm_120 alike, and the launcher
+/// raises the limit once per device before the first launch.
+template <typename Geometry, int WarpsPerCta>
+struct GqaSmallTTcSmem {
+    static constexpr int kBc       = 32;
+    static constexpr int kQkvRows  = 2 * kBc;
+    static constexpr int kPageIds  = 64;
+    static constexpr int kQkvBytes = kQkvRows * Geometry::HeadDim * static_cast<int>(sizeof(__nv_bfloat16));
+    static constexpr int kPBytes   = WarpsPerCta * 16 * kBc * static_cast<int>(sizeof(__nv_bfloat16));
+    static constexpr int kPageBytes = kPageIds * static_cast<int>(sizeof(std::int32_t));
+    static constexpr int kBytes    = kQkvBytes + kPBytes + kPageBytes;
+};
+
 template <typename Geometry, int TokenTile, int WarpsPerCta, bool MultiBatch, bool Masked,
           typename CacheInput, typename CacheT = __nv_bfloat16, bool Sparse = false,
           int SparseBlock = 4>
@@ -93,9 +110,15 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
 
     static_assert(QkvRows >= Br);
 
-    __shared__ __align__(16) __nv_bfloat16 qkv_s[QkvRows * D];
-    __shared__ __align__(16) __nv_bfloat16 p_s[Wc * 16 * Bc];
-    __shared__ std::int32_t physical_pages_s[PageIds];
+    using Smem = GqaSmallTTcSmem<Geometry, WarpsPerCta>;
+    static_assert(Smem::kQkvBytes == QkvRows * D * static_cast<int>(sizeof(__nv_bfloat16)));
+    static_assert(Smem::kPBytes == Wc * 16 * Bc * static_cast<int>(sizeof(__nv_bfloat16)));
+    static_assert(Smem::kPageIds == PageIds);
+    extern __shared__ __align__(16) unsigned char gqa_small_t_smem[];
+    auto* qkv_s = reinterpret_cast<__nv_bfloat16*>(gqa_small_t_smem);
+    auto* p_s   = reinterpret_cast<__nv_bfloat16*>(gqa_small_t_smem + Smem::kQkvBytes);
+    auto* physical_pages_s =
+        reinterpret_cast<std::int32_t*>(gqa_small_t_smem + Smem::kQkvBytes + Smem::kPBytes);
     __nv_bfloat16* k_s = qkv_s;
     __nv_bfloat16* v_s = qkv_s + Bc * D;
 

--- a/csrc/src/serve/ops/launcher/gqa_attention_decode_launch.cuh
+++ b/csrc/src/serve/ops/launcher/gqa_attention_decode_launch.cuh
@@ -118,15 +118,24 @@ void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos
     const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
     Tensor& cache_k = cache.k_pages;
     Tensor& cache_v = cache.v_pages;
-    // bf16 kernel uses only static smem (no dynamic staging). A QSA selection instantiates the
-    // sparse specialization; without one the dense kernel is unchanged.
+    // The K/V/P tiles are dynamic shared memory: a 512-wide head asks for 68 KB, which is past
+    // the 48 KB a block may declare statically on sm_89 but inside the 99 KB it may opt into.
+    // The limit is raised once per device, per kernel -- the same call the prefill launchers make.
+    constexpr int kSmemBytes = GqaSmallTTcSmem<Geometry, WarpsPerCta>::kBytes;
+    // A QSA selection instantiates the sparse specialization; without one the dense kernel is
+    // unchanged.
     if (invocation.selection.words != nullptr) {
         if (invocation.selection.block != 4) {
             throw std::invalid_argument("gqa_attention: unregistered QSA block size");
         }
+        CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
+            gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta,
+                                                         MultiBatch, Masked, CacheInput, CacheT,
+                                                         true, 4>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));
         gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
                                                      Masked, CacheInput, CacheT, true, 4>
-            <<<grid, kBlock, 0, stream>>>(
+            <<<grid, kBlock, kSmemBytes, stream>>>(
                 static_cast<const __nv_bfloat16*>(q.data), input,
                 static_cast<const std::int32_t*>(pos.data), static_cast<CacheT*>(cache_k.data),
                 static_cast<CacheT*>(cache_v.data),
@@ -145,9 +154,13 @@ void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos
         CUDA_CHECK(cudaGetLastError());
         return;
     }
+    CUDA_CHECK(::sinfer::ops::set_func_attribute_per_device(
+        gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
+                                                     Masked, CacheInput, CacheT>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes));
     gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
                                                  Masked, CacheInput,
-                                                 CacheT><<<grid, kBlock, 0, stream>>>(
+                                                 CacheT><<<grid, kBlock, kSmemBytes, stream>>>(
         static_cast<const __nv_bfloat16*>(q.data), input,
         static_cast<const std::int32_t*>(pos.data), static_cast<CacheT*>(cache_k.data),
         static_cast<CacheT*>(cache_v.data),

--- a/csrc/src/serve/ops/sparse_moe/trtllm/trtllm_moe.cu
+++ b/csrc/src/serve/ops/sparse_moe/trtllm/trtllm_moe.cu
@@ -525,7 +525,30 @@ void require_geometry(const Geometry& geometry) {
 
 } // namespace
 
-bool available() noexcept { return true; }
+/// Whether this process can run the runner: the kernels are in the binary *and* the device is
+/// one they have a cubin for.
+///
+/// The build used to be the whole answer -- these translation units existed only in an sm_120a
+/// build, so their presence implied the hardware. One binary for the RTX line ends that: an
+/// Ada card loads the same library, and the FP4 instantiations carry no sm_89 cubin. Asking the
+/// device is what turns "no kernel image is available for execution" into the refusal in
+/// `sparse_moe.cpp`, which names the artifact and the architecture.
+bool available() noexcept {
+    static const bool supported = [] {
+        int device = 0;
+        if (cudaGetDevice(&device) != cudaSuccess) { return false; }
+        int major = 0;
+        int minor = 0;
+        if (cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device) !=
+                cudaSuccess ||
+            cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device) !=
+                cudaSuccess) {
+            return false;
+        }
+        return major * 10 + minor >= 120;
+    }();
+    return supported;
+}
 
 std::int32_t bucket_of(std::int32_t tokens) {
     if (tokens < 1 || tokens > kMaxTokens) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ CMAKE_CUDA_ARCHITECTURES = {env="CUDAARCHS"}
 # The wheel serves as well as trains, so a build host without FFmpeg or libcurl must fail
 # here rather than publish a package whose `surogate serve` exits 127. Note this governs
 # only the host libraries: the serve engine's device code is built for
-# SUROGATE_SERVE_CUDA_ARCHS (120a), independently of CUDAARCHS above.
+# SUROGATE_SERVE_CUDA_ARCHS -- the RTX line, Ada and Blackwell -- independently of CUDAARCHS
+# above, so one published wheel serves a 4090, a 5090 and an RTX PRO 6000.
 SUROGATE_REQUIRE_SERVE = "ON"
 
 [tool.uv]


### PR DESCRIPTION
One `surogate-engine` for the RTX line — **4090, 5090, RTX PRO 6000** — with the driver choosing
the cubin.

The engine served one architecture because the *build* said so, not because the kernels did.
`SUROGATE_SERVE_CUDA_ARCHS` was `120a`, and two archives (the NVFP4 W4A4 TMA kernels and the
vendored TRT-LLM cutlass MoE) were compiled-or-stubbed by that same switch. The list is now
`89;120a`.

Datacenter parts are deliberately absent: this engine's shape — experts banked in host memory,
pipeline stages and expert gathers crossing PCIe, a one-shot allreduce where there is no NVLink —
is a PCIe machine's.

## A single binary is not every kernel for every architecture

vLLM's CMake intersects each kernel family's own architecture list with the build's
(`cuda_archs_loose_intersection`); the same discipline here pins the FP4 families to `120a` where
they're defined:

| | cubins in `libsinfer.so` |
|---|---|
| sm_89 | 193 |
| sm_120a | 212 |

The nineteen extra are exactly the kernels Ada cannot run. Size goes **811 MB → 1.38 GB** rather
than doubling.

## What actually blocked Ada was shared memory, not a missing feature

Seven decode TUs declared **67.8–69.9 KB of *static* `__shared__`**; Ada caps a block's static
allocation at 48 KB. Its *dynamic* cap with `cudaFuncSetAttribute` is 99 KB — so the tiles are
dynamic now and the launcher raises the limit once per device. That call is what our own prefill
launchers already did, and what llama.cpp does through its per-device `smpbo`:

```cpp
if (nbytes_shared <= smpbo) {
    CUDA_SET_SHARED_MEMORY_LIMIT((kernel<true>), smpbo);
    kernel<true><<<grid, block, nbytes_shared, stream>>>(...);
}
```

`GqaSmallTTcSmem` derives the byte count from the same constants the kernel body does, with
`static_assert`s tying the two together.

## One gate the build had been standing in for

`trtllm_moe::available()` returned `true` unconditionally — those TUs existed only in an sm_120a
build, so their presence *implied* the hardware. In one binary an Ada card loads the same library,
so it asks the device now. Without it, an NVFP4 artifact on a 4090 reaches a kernel with no cubin
("no kernel image is available for execution") instead of the refusal in `sparse_moe.cpp` that
names the artifact and the architecture. The dense W4A4 plane was already gated this way.

## Verified

- `libsinfer_ops.a` compiles for both architectures, no errors.
- The built `libsinfer.so` carries both cubin sets (counts above).
- Serve suite **123/123 on a 5090** — the dynamic-shared-memory port costs Blackwell nothing.

## Not verified

**Nothing here has run on an Ada card.** Compiling for an architecture proves the kernels exist
for it, not that the engine serves on it. A 4090 pass is the next step — and since the `__trap()`
guards mean a route slipping past its gate crashes rather than explaining itself, the
per-capability admissions (`w8fp8_plane_enabled`, `w4fp4_plane_for`, `engine.cpp`, and now
`trtllm_moe::available()`) want gathering into one table before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
