### PR TITLE
fix(docker): the cu130 image carries what the engine loads

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -123,18 +123,40 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.wheel_tag }}
 
       # The image is the last place the packaging can go wrong, and the first place a user
-      # meets it: `surogate serve` execs a binary it has to find under the installed package.
-      # This asks the installed CLI the same question it asks itself, without a GPU.
-      - name: "`surogate serve` finds its engine in the image"
+      # meets it. Two questions, and neither answers the other.
+      #
+      # `_resolve_binary` is how `surogate serve` decides what to exec, but it only asks whether
+      # a file is there -- so it passes on a binary that cannot start, which is exactly what this
+      # image shipped: the engine links FFmpeg and libnuma, and nothing installed them. `ldd`
+      # asks the other half, whether the image carries what the binary loads, and it needs no GPU.
+      #
+      # libcuda.so.1 is the driver. The container runtime injects it under `--gpus`, so it is
+      # absent here by design and is the one permitted miss. Everything else that resolves here
+      # -- libcudart and libcublasLt out of the pip CUDA wheels included -- is a live check on
+      # the ld.so.conf.d paths written above, which is the other thing that has no test.
+      - name: The engine is whole in the image
         if: steps.should_build.outputs.build == 'true' && matrix.serve
         run: |
           set -euo pipefail
           image="ghcr.io/invergent-ai/surogate:${{ steps.version.outputs.version }}-${{ matrix.wheel_tag }}"
-          docker run --rm --entrypoint python3 "$image" -c '
-          import sys
+          docker run --rm -i --entrypoint python3 "$image" - <<'PY'
+          import subprocess, sys
           from surogate.cli.serve import _resolve_binary
-          missing = [m for m in ("server", "generate", "embed") if _resolve_binary(m) is None]
-          if missing:
-              sys.exit("surogate serve cannot find its binary for: " + ", ".join(missing))
-          print("engine resolved:", _resolve_binary("server"))
-          '
+
+          DRIVER = "libcuda.so.1"
+          problems = []
+          for mode in ("server", "generate", "embed"):
+              path = _resolve_binary(mode)
+              if path is None:
+                  problems.append(f"{mode}: surogate serve cannot find a binary to exec")
+                  continue
+              ldd = subprocess.run(["ldd", path], capture_output=True, text=True).stdout
+              missing = [ln.split("=>")[0].strip() for ln in ldd.splitlines()
+                         if "not found" in ln and DRIVER not in ln]
+              if missing:
+                  problems.append(f"{mode}: {path} cannot load " + ", ".join(missing))
+              else:
+                  print(f"ok: {mode} -> {path}")
+          if problems:
+              sys.exit("::error::" + "; ".join(problems))
+          PY

--- a/Dockerfile.cu130
+++ b/Dockerfile.cu130
@@ -30,8 +30,14 @@ ENV UV_NO_CACHE=1
 # uv's 30s default request timeout loses that race on a slow link.
 ENV UV_HTTP_TIMEOUT=600
 
+# The engine in this wheel is a compiled binary, and it loads more than the trainer does:
+# FFmpeg for the multimodal decode path (serve/media/decode) and libnuma for the host-offload
+# path (expert_cache, host_bank). Neither arrives with the wheel, so without them `surogate
+# serve` finds its binary and the binary refuses to start. Only this image needs them: the
+# engine requires CUDA 13.1, so the cu128 and cu129 wheels are built without one.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --allow-change-held-packages ca-certificates curl libdw-dev python3-dev build-essential rsync wget netcat-openbsd gcc patch pciutils fuse3 openssh-server sudo openssh-server git \
+       libavformat60 libavcodec60 libavutil58 libswscale7 libnuma1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo "${CUDA_LIB_ROOT}/cu13/lib" >> /etc/ld.so.conf.d/cuda-13-1.conf \


### PR DESCRIPTION
The Dockerfiles date from July. The serve engine landed in the wheel in September and nothing since asked the image whether it could run one — it cannot.

## The defect

`surogate-engine` links FFmpeg (`serve/media/decode`) and libnuma (`expert_cache`, `host_bank`). The image installs neither, so `surogate serve` finds its binary and the binary refuses to start.

Measured in `ubuntu:noble-20260210.1` with the image’s own apt list — `ldd surogate-engine` reports 8 missing, of which 5 are real:

```
libavformat.so.60   libavcodec.so.60   libavutil.so.58   libswscale.so.7   libnuma.so.1
libcudart.so.13     libcublasLt.so.13     <- the pip CUDA wheels; the real image has these
libcuda.so.1                              <- the driver; injected under --gpus
```

Only cu130 gets the packages: the engine needs CUDA 13.1, so cu128/cu129 are trainer-only and would carry an FFmpeg tree for nothing.

## The check is replaced, not extended

The old one could not have caught this. `_resolve_binary` asks whether a *file exists*, so it passes on a binary that cannot load — it tests CLI wiring, not the image. `ldd` answers the other half and needs no GPU, which matters because the engine links `libcuda.so.1` and a hosted runner has no driver. So libcuda is the one permitted miss and everything else must resolve, which makes it a live check on the `ld.so.conf.d` paths too — the other thing with no test.

## Verified against a real image, both directions

The cu130 image was built locally and the real engine binaries checked inside it:

```
ok   surogate-engine / -cli / -embed
libcudart.so.13   -> nvidia/cu13/lib/libcudart.so.13     (via ld.so.conf.d)
libcublasLt.so.13 -> nvidia/cu13/lib/libcublasLt.so.13
only miss: libcuda.so.1
```

With the five packages removed, the gate fails and names each one:

```
::error::server: cannot load libnuma.so.1, libavformat.so.60, libavcodec.so.60, libavutil.so.58, libswscale.so.7; generate: ...; embed: ...
```

## Separately found, not fixed here

The install RPATH lists only the CUDA 12 split layout (`nvidia/cuda_runtime/lib`, `nvidia/cublas/lib`). CUDA 13 wheels use the consolidated `nvidia/cu13/lib`, which is in neither list, so a plain `pip install surogate…+cu130` outside Docker gives an engine that cannot find `libcudart.so.13` — and since the engine is exec’d as a separate process, torch having loaded its own copy does not help. The image is unaffected because `ld.so.conf.d` covers it. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)