### PR TITLE
docs: CUDA 12.9 stops being a case of its own

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -39,9 +39,8 @@ jobs:
           #
           # Two wheels, not three. A binary built against 12.8 runs on any 12.x runtime -- CUDA
           # minor version compatibility -- and nothing here links torch, so there is no ABI
-          # tying a wheel to one toolkit. cu128 is what a CUDA 12.9 host installs. It also
-          # covers anyone whose driver predates CUDA 13, which is why it is not folded into
-          # cu130 as well.
+          # tying a wheel to one toolkit. cu128 covers the whole 12.x line, and anyone
+          # whose driver predates CUDA 13, which is why it is not folded into cu130 as well.
           - cuda_version: "12.8"
             cuda_build_image: "nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04"
             wheel_tag: "cu128"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ For per-family format support, conversion behavior, and hardware details, see th
 
 ### Install
 
-Use **Linux x86_64 and Python 3.12** with a supported NVIDIA GPU and CUDA 12.8, 12.9, or 13.x. See [hardware](#hardware) for the separate training and serving GPU targets.
+Use **Linux x86_64 and Python 3.12** with a supported NVIDIA GPU and CUDA 12.8+ or 13.x. See [hardware](#hardware) for the separate training and serving GPU targets.
 
 ```bash
 curl -LsSf https://github.com/invergent-ai/surogate/releases/latest/download/install.sh | bash
@@ -269,7 +269,7 @@ Training buffers remain reserved during generation, so choose a model and contex
 <details>
 <summary><strong>Docker and source builds</strong></summary>
 
-CUDA-specific containers are available as `ghcr.io/invergent-ai/surogate:latest-cu128` and `latest-cu130`. A CUDA 12.9 host uses the cu128 image.
+CUDA-specific containers are available as `ghcr.io/invergent-ai/surogate:latest-cu128` and `latest-cu130`.
 
 ```bash
 # From the directory containing train.yaml; output stays in ./output on the host.
@@ -305,7 +305,7 @@ Read [how training works](docs/about/how-it-works.md), the [DSL guide](docs/abou
 
 | Component | Current requirements / targets |
 |---|---|
-| **Platform** | Linux x86_64; published wheels target Python 3.12; CUDA 12.8, 12.9, or 13.x. |
+| **Platform** | Linux x86_64; published wheels target Python 3.12; CUDA 12.8+ or 13.x. |
 | **Training** | SM89+ in the current build: Ada (RTX 40 series, L4/L40), Hopper (H100/H200), and supported Blackwell targets. |
 | **FP8 / NVFP4 training** | FP8 requires SM89+; native NVFP4 requires a supported Blackwell GPU and matching build. |
 | **Generative serving** | Current default builds target **SM120a**: RTX 50 series and RTX PRO Blackwell. The SM89/Ada port compiles, with runtime validation pending. |

--- a/docs/appendix/compatibility.md
+++ b/docs/appendix/compatibility.md
@@ -10,13 +10,12 @@ The installer script creates a Python 3.12 virtual environment and the published
 
 The installer selects a CUDA-specific wheel build. It currently maps to:
 
-- `cu128` for CUDA 12.8 and 12.9
+- `cu128` for CUDA 12.8+
 - `cu130` for CUDA 13+
 
-A CUDA 12.9 host installs the `cu128` wheel. There is no `cu129` build: a binary compiled
-against 12.8 runs on any 12.x runtime, and nothing in the wheel links torch, so no ABI ties a
-wheel to one toolkit. On 12.9 the installer still fetches torch and the CUDA libraries built
-for 12.9 — only the surogate wheel is shared.
+Two builds cover every supported runtime. A binary compiled against 12.8 runs on any 12.x
+under CUDA minor version compatibility, and nothing in the wheel links torch, so no ABI ties
+a wheel to the toolkit that built it.
 
 If CUDA cannot be detected, installation fails.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,9 +9,8 @@
 
 Surogate requires a recent NVIDIA driver and CUDA libraries.
 
-Commonly used CUDA versions:
-- CUDA 12.8
-- CUDA 12.9
+Supported CUDA versions:
+- CUDA 12.8 or newer in the 12.x line
 - CUDA 13.x
 
 Multi-GPU training requires NCCL.
@@ -41,7 +40,7 @@ source .venv/bin/activate
 ## Option B: Build from source (developers)
 
 Prerequisites:
-- CUDA toolkit (12.8/12.9/13.x)
+- CUDA toolkit (12.8+ or 13.x)
 - NCCL development libraries
 
 From the repository root:

--- a/install.sh
+++ b/install.sh
@@ -80,27 +80,16 @@ fi
 
 install_cu128_deps() {
     local version="$1"
-    echo "Installing packages for CUDA 12.8..."
+    echo "Installing packages for CUDA 12.8+..."
     pip install "torch==2.11.0+cu128" "torchvision==0.26.0+cu128" "torchaudio==2.11.0+cu128" --index-url https://download.pytorch.org/whl/cu128
     pip install "vllm==0.25.1"
     install_surogate_wheel "$version" "cu128"
     pip install "nvidia-cuda-runtime-cu12==12.8.90" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.8.93" "nvidia-cudnn-cu12==9.19.0.56"
 }
 
-# CUDA 12.9 gets torch and the CUDA libraries built for 12.9, and the cu128 surogate wheel.
-# That is not a fallback: there is no cu129 wheel because there is nothing for one to do. A
-# binary built against 12.8 runs on any 12.x runtime, and nothing in the wheel links torch, so
-# no ABI ties it to a toolkit. The one thing 12.9 could compile that 12.8 could not was
-# sm_103a, which we do not target.
-install_cu129_deps() {
-    local version="$1"
-    echo "Installing packages for CUDA 12.9..."
-    pip install "torch==2.11.0+cu129" "torchvision==0.26.0+cu129" "torchaudio==2.11.0+cu129" --index-url https://download.pytorch.org/whl/cu129
-    pip install "vllm==0.25.1"
-    install_surogate_wheel "$version" "cu128"
-    pip install "nvidia-cuda-runtime-cu12==12.9.79" "nvidia-nccl-cu12==2.29.3" "nvidia-cufile-cu12==1.14.1.1" "nvidia-cuda-nvrtc-cu12==12.9.86" "nvidia-cudnn-cu12==9.19.0.56"
-}
-
+# One branch for the whole 12.x line. A binary built against 12.8 runs on any 12.x runtime
+# under CUDA minor version compatibility, and nothing in the wheel links torch, so no ABI ties
+# it to a toolkit.
 install_cu130_deps() {
     local version="$1"
     echo "Installing packages for CUDA 13+..."
@@ -205,8 +194,6 @@ fi
 
 if [[ "$CUDA_MAJOR" -ge 13 ]]; then
     install_cu130_deps "$VERSION"
-elif [[ "$CUDA_MAJOR" -eq 12 && "$CUDA_MINOR" -ge 9 ]]; then
-    install_cu129_deps "$VERSION"
 elif [[ "$CUDA_MAJOR" -eq 12 && "$CUDA_MINOR" -ge 8 ]]; then
     install_cu128_deps "$VERSION"
 else


### PR DESCRIPTION
Dropping the cu129 wheel left 12.9 named in places that now describe nothing.

## Changed

- **`install.sh`** — `install_cu129_deps` and its dispatch arm removed. A 12.9 host falls through to the 12.8+ branch and gets torch, the CUDA libraries and the wheel built for 12.8, which is what minor-version compatibility is for.
- **`README.md`** — `CUDA 12.8, 12.9, or 13.x` → `CUDA 12.8+ or 13.x` (twice), and the stale container-tag note.
- **`docs/getting-started/installation.md`** — the version list and the toolkit prerequisite.
- **`docs/appendix/compatibility.md`** — the wheel map.
- **`.github/workflows/wheel.yml`** — a comment that named 12.9 specifically.

## Routing verified after the change

```
CUDA 11.8  -> REFUSED      CUDA 12.9  -> cu128
CUDA 12.7  -> REFUSED      CUDA 12.10 -> cu128
CUDA 12.8  -> cu128        CUDA 13.0  -> cu130
                           CUDA 13.1  -> cu130
```

## Deliberately kept

- `docs/reference/benchmarks.md` heads two tables with the toolkit the numbers were **measured** on.
- `surogate/serve/BENCHMARKS.md` records `nvcc 12.9` among the things ruled out while chasing the CUTLASS spill.

Editing either would falsify a record of what was actually run.

- `docs/index.md` has two more, in a file being rewritten on a parallel branch that already drops both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)