### PR TITLE
ci: the Build gate runs on release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,22 @@ on:
     branches:
       - main
       - release-*
+    # A release tag runs this too. The wheel builds its own engine and checks the wheel it
+    # produced, but two of the checks here have no equivalent there: that llama-quantize
+    # reports the revision we pinned, and that the products start at all.
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
+
+# One self-hosted runner takes one job at a time, so runs queue rather than pile onto the
+# machine -- but they still queue, and a full CUDA build is not quick. Superseding a branch or
+# pull request run is the right call; superseding a tag is not, because that run is the record
+# for a release, so tags are exempt from the cancellation.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   engine:


### PR DESCRIPTION
Build ran on pushes to `main` and on pull requests, but not on the one push that ships something. A tag fired the wheel and, after it, the images — the gate that compiles the engine and checks the quantiser was not part of a release at all.

## Why the wheel job is not a substitute

It builds its own engine and inspects the wheel it produced, including both cubin sets. Two checks live only in Build:

- `llama-quantize` reports the revision pinned in `llama_cpp_quantizer.cmake`
- the three products actually start

## Concurrency comes with it

There is **one** self-hosted runner (`densemax2`) and it takes one job at a time, so runs queue rather than crowd the machine — but a full CUDA build is not quick, and three pushes to `main` should not mean three of them back to back.

```yaml
group: build-${{ github.ref }}
cancel-in-progress: ${{ !startsWith(github.ref, "refs/tags/") }}
```

Superseded branch and PR runs are cancelled. Tags are exempt: that run is the record for a release.

## Note

The workflow is `disabled_manually`, so this is inert until it is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)